### PR TITLE
fix: job-level concurrency control to prevent container name conflicts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,11 +7,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Enforce only 1 pipeline run at a time to prevent container name conflicts
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: write  # For GitHub Pages deployment
   pages: write
@@ -463,6 +458,10 @@ jobs:
     runs-on: self-hosted
     needs: [prepare-workspace, security-analysis]
     timeout-minutes: 4
+    # Prevent multiple unit test jobs from running concurrently (queue instead)
+    concurrency:
+      group: unit-tests
+      cancel-in-progress: false
     outputs:
       tests-passed: ${{ steps.test-results.outputs.passed }}
       coverage-percent: ${{ steps.test-results.outputs.coverage }}
@@ -813,6 +812,10 @@ jobs:
     runs-on: self-hosted
     needs: [unit-tests]  # Sequential: runs after unit tests pass
     timeout-minutes: 5
+    # Prevent multiple integration test jobs from running concurrently (queue instead)
+    concurrency:
+      group: integration-tests
+      cancel-in-progress: false
     outputs:
       tests-passed: ${{ steps.test-results.outputs.passed }}
 


### PR DESCRIPTION
## Problem
Container name conflicts causing test failures:
```
Error: The container name "/loyalty_postgres_unit" is already in use
```

## Root Cause
Multiple concurrent workflow runs were creating containers with identical names, causing conflicts.

## Solution
Implemented job-level concurrency control with queueing:

### Changes Made
1. **Removed workflow-level concurrency** (was too restrictive - cancelled entire runs)
2. **Added job-level concurrency control**:
   - `unit-tests`: `group: unit-tests, cancel-in-progress: false`
   - `integration-tests`: `group: integration-tests, cancel-in-progress: false`
   - `e2e-tests`: Already had job-level concurrency

### Behavior
✅ Multiple pipeline runs can execute in parallel  
✅ Different jobs run in parallel (lint, typecheck, etc.)  
✅ Same job type queues instead of running concurrently  
✅ No container name conflicts  
✅ No port allocation conflicts  

## Testing
- Verified concurrency control syntax is correct
- Checked that test jobs have proper concurrency groups
- Confirmed `cancel-in-progress: false` ensures queueing

## Related Issues
- Fixes container name conflicts in CI/CD pipeline
- Resolves port allocation issues during concurrent test runs
- Maintains parallel execution of different job types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>