### PR TITLE
fix: race condition protections for parallel pipeline runs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,12 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Workflow-level concurrency: prevent parallel runs on same branch
+# This prevents race conditions when multiple commits push in quick succession
+concurrency:
+  group: "ci-${{ github.ref }}"
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: write  # For GitHub Pages deployment
   pages: write
@@ -101,9 +107,12 @@ jobs:
           LOCK_HASH=$(sha256sum package-lock.json | cut -d' ' -f1)
 
           echo "💾 Saving backend node_modules to cache..."
-          rm -rf "$CACHE_DIR/node_modules"
-          cp -r node_modules "$CACHE_DIR/"
-          echo "$LOCK_HASH" > "$CACHE_DIR/.lock-hash"
+          # Use flock to prevent race conditions with parallel runs from other branches
+          flock -w 60 "$CACHE_DIR/.flock" bash -c "
+            rm -rf '$CACHE_DIR/node_modules'
+            cp -r node_modules '$CACHE_DIR/'
+            echo '$LOCK_HASH' > '$CACHE_DIR/.lock-hash'
+          "
           echo "✅ Cache saved with hash: ${LOCK_HASH:0:12}..."
 
       - name: "📦 Restore frontend dependencies with hash validation"
@@ -141,9 +150,12 @@ jobs:
           LOCK_HASH=$(sha256sum package-lock.json | cut -d' ' -f1)
 
           echo "💾 Saving frontend node_modules to cache..."
-          rm -rf "$CACHE_DIR/node_modules"
-          cp -r node_modules "$CACHE_DIR/"
-          echo "$LOCK_HASH" > "$CACHE_DIR/.lock-hash"
+          # Use flock to prevent race conditions with parallel runs from other branches
+          flock -w 60 "$CACHE_DIR/.flock" bash -c "
+            rm -rf '$CACHE_DIR/node_modules'
+            cp -r node_modules '$CACHE_DIR/'
+            echo '$LOCK_HASH' > '$CACHE_DIR/.lock-hash'
+          "
           echo "✅ Cache saved with hash: ${LOCK_HASH:0:12}..."
 
       - name: "📦 Restore root dependencies with hash validation"
@@ -181,9 +193,12 @@ jobs:
 
           echo "✅ Root dependencies installed (includes @playwright/test)"
           echo "💾 Saving root node_modules to cache..."
-          rm -rf "$CACHE_DIR/node_modules"
-          cp -r node_modules "$CACHE_DIR/"
-          echo "$LOCK_HASH" > "$CACHE_DIR/.lock-hash"
+          # Use flock to prevent race conditions with parallel runs from other branches
+          flock -w 60 "$CACHE_DIR/.flock" bash -c "
+            rm -rf '$CACHE_DIR/node_modules'
+            cp -r node_modules '$CACHE_DIR/'
+            echo '$LOCK_HASH' > '$CACHE_DIR/.lock-hash'
+          "
           echo "✅ Cache saved with hash: ${LOCK_HASH:0:12}..."
 
       - name: "🔧 Generate Prisma client (shared)"
@@ -1707,8 +1722,12 @@ jobs:
           echo "📦 Installing backend dependencies with local npm cache..."
           npm ci --cache /tmp/runner-cache/${{ env.CACHE_VERSION }}/npm --prefer-offline --include=dev
           echo "💾 Saving backend node_modules to local cache..."
-          rm -rf /tmp/runner-cache/${{ env.CACHE_VERSION }}/backend-node_modules/node_modules
-          cp -r node_modules /tmp/runner-cache/${{ env.CACHE_VERSION }}/backend-node_modules/
+          CACHE_DIR="/tmp/runner-cache/${{ env.CACHE_VERSION }}/backend-node_modules"
+          # Use flock to prevent race conditions with parallel runs from other branches
+          flock -w 60 "$CACHE_DIR/.flock" bash -c "
+            rm -rf '$CACHE_DIR/node_modules'
+            cp -r node_modules '$CACHE_DIR/'
+          "
 
       - name: "📦 Restore frontend node_modules from local cache"
         id: frontend-cache
@@ -1729,9 +1748,13 @@ jobs:
           echo "📦 Installing frontend dependencies with local npm cache..."
           npm ci --cache /tmp/runner-cache/${{ env.CACHE_VERSION }}/npm --prefer-offline
           echo "💾 Saving frontend node_modules to local cache..."
-          rm -rf /tmp/runner-cache/${{ env.CACHE_VERSION }}/frontend-node_modules/node_modules
-          cp -r node_modules /tmp/runner-cache/${{ env.CACHE_VERSION }}/frontend-node_modules/
-      
+          CACHE_DIR="/tmp/runner-cache/${{ env.CACHE_VERSION }}/frontend-node_modules"
+          # Use flock to prevent race conditions with parallel runs from other branches
+          flock -w 60 "$CACHE_DIR/.flock" bash -c "
+            rm -rf '$CACHE_DIR/node_modules'
+            cp -r node_modules '$CACHE_DIR/'
+          "
+
       - name: "🔧 Generate Prisma client (build phase)"
         run: |
           echo "🔧 Generating Prisma client for TypeScript compilation..."
@@ -1895,7 +1918,7 @@ jobs:
     timeout-minutes: 10
     concurrency:
       group: dev-deployment
-      cancel-in-progress: true
+      cancel-in-progress: false  # Queue deployments - never cancel mid-deployment
     env:
       DEPLOY_PATH: /home/nut/loyalty-app-develop
 
@@ -2186,7 +2209,7 @@ jobs:
     timeout-minutes: 15
     concurrency:
       group: prod-deployment
-      cancel-in-progress: true
+      cancel-in-progress: false  # Queue deployments - never cancel mid-deployment
     env:
       DEPLOY_PATH: /home/nut/loyalty-app-production
 


### PR DESCRIPTION
## Summary

This PR adds protections against race conditions when multiple pipeline runs execute in parallel on shared infrastructure.

### Changes

1. **Workflow-level concurrency** - prevents parallel runs on same branch
   - Same branch: Only one workflow runs at a time (queued)
   - Main branch: Never cancelled mid-run
   - Other branches: Can be cancelled if newer commit arrives

2. **Deployment jobs now queue instead of cancel**
   - dev-deployment and prod-deployment use cancel-in-progress: false
   - Deployments wait in queue, never cancelled mid-deployment

3. **File locking for cache writes** using flock
   - Backend, frontend, and root cache writes protected
   - 60 second timeout for lock acquisition

### Why This Matters

On a single machine running both dev and prod with multiple GitHub Actions runners:
- Parallel workflow runs could corrupt shared cache
- Cancelling a deployment mid-way could leave containers in bad state
- File locks ensure atomic cache updates even with parallel branch builds

## Test plan

- [x] Pipeline passed on develop branch
- [ ] Verify queuing behavior works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)