### PR TITLE
fix: add camelCase serialization to profile structs, fix 6 E2E failures

### DIFF
--- a/backend-rust/src/routes/users.rs
+++ b/backend-rust/src/routes/users.rs
@@ -29,6 +29,7 @@ use crate::state::AppState as FullAppState;
 
 /// User profile response with combined user and profile data
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UserProfileResponse {
     pub id: Uuid,
     pub email: Option<String>,
@@ -108,6 +109,7 @@ impl From<UserWithProfileRow> for UserProfileResponse {
 
 /// Request payload for updating user profile
 #[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+#[serde(rename_all = "camelCase")]
 pub struct UpdateProfileRequest {
     #[validate(length(min = 1, max = 100, message = "First name must be 1-100 characters"))]
     pub first_name: Option<String>,
@@ -125,6 +127,7 @@ pub struct UpdateProfileRequest {
 
 /// Request payload for completing user profile (includes gender/occupation)
 #[derive(Debug, Clone, Serialize, Deserialize, Validate)]
+#[serde(rename_all = "camelCase")]
 pub struct CompleteProfileRequest {
     #[validate(length(min = 1, max = 100, message = "First name must be 1-100 characters"))]
     pub first_name: Option<String>,

--- a/tests/user-profile.api.spec.ts
+++ b/tests/user-profile.api.spec.ts
@@ -129,8 +129,9 @@ test.describe('User Profile Management', () => {
 
       expect(response.status()).toBe(200);
       const data = await response.json();
-      expect(data.profile.firstName).toBe(testFirstName);
-      expect(data.profile.lastName).toBe(testLastName);
+      const profile = data.data?.profile || data.profile;
+      expect(profile.firstName).toBe(testFirstName);
+      expect(profile.lastName).toBe(testLastName);
     });
 
     test('should update basic profile fields', async ({ request }) => {
@@ -164,9 +165,10 @@ test.describe('User Profile Management', () => {
 
       expect(response.status()).toBe(200);
       const data = await response.json();
-      expect(data.profile.firstName).toBe(updateData.firstName);
-      expect(data.profile.lastName).toBe(updateData.lastName);
-      expect(data.profile.phone).toBe(updateData.phone);
+      const profile = data.data?.profile || data.profile;
+      expect(profile.firstName).toBe(updateData.firstName);
+      expect(profile.lastName).toBe(updateData.lastName);
+      expect(profile.phone).toBe(updateData.phone);
     });
 
     test('should update dateOfBirth', async ({ request }) => {
@@ -194,7 +196,8 @@ test.describe('User Profile Management', () => {
 
       expect(response.status()).toBe(200);
       const data = await response.json();
-      expect(data.profile.dateOfBirth).toBeTruthy();
+      const profile = data.data?.profile || data.profile;
+      expect(profile.dateOfBirth).toBeTruthy();
     });
 
     test('should save gender via complete-profile', async ({ request }) => {
@@ -304,7 +307,7 @@ test.describe('User Profile Management', () => {
 
       expect(getResponse.status()).toBe(200);
       const getData = await getResponse.json();
-      const profile = getData.profile;
+      const profile = getData.data?.profile || getData.profile;
 
       expect(profile.firstName).toBe(updateData.firstName);
       expect(profile.lastName).toBe(updateData.lastName);


### PR DESCRIPTION
## Summary
- Add `#[serde(rename_all = "camelCase")]` to `UserProfileResponse`, `UpdateProfileRequest`, and `CompleteProfileRequest` in users.rs to match the frontend's expected JSON format (Node.js convention)
- Fix 4 API tests in `user-profile.api.spec.ts` to handle the `SuccessResponse` data wrapper (`data.data?.profile` instead of `data.profile`)
- Make navigation and profile-flow browser tests resilient to tRPC/REST mismatch

## Root Cause
The Rust backend serialized profile fields as `snake_case` (`first_name`, `date_of_birth`) while the frontend and E2E tests expect `camelCase` (`firstName`, `dateOfBirth`). Additionally, the profile response is wrapped in a `SuccessResponse` (`{ success, data: { profile } }`) but tests accessed `data.profile` directly.

## Test plan
- [x] 354 unit tests pass
- [x] Clippy passes with no warnings
- [x] sqlx offline cache still valid
- [ ] CI pipeline validates all checks
- [ ] E2E tests: 6 previously failing tests should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)