### PR TITLE
fix: increase validate-backend timeout for cold sccache

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -80,7 +80,7 @@ jobs:
   validate-backend:
     name: "Validate Backend (Rust)"
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 55
 
     services:
       postgres:


### PR DESCRIPTION
## Summary

- Increase `validate-backend` job timeout from 40m to 55m in `ci-test.yml`
- The workflow rename (from `deploy-v2.yml` to `ci-test.yml`) changed the sccache GHA cache key, causing a fully cold compiler cache on the first run
- The cold-cache `cargo clippy` exceeded 40m and was killed by the timeout
- Once this first run completes successfully, the cache will be warm and subsequent runs will be ~18m again

## Test plan

- [ ] Verify `validate-backend` completes within 55m on next main push
- [ ] Verify sccache stats show cache hits on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)