### PR TITLE
fix(backend): HEALTHCHECK hits /api/health (was 404 on /health)

### DIFF
--- a/backend-rust/Dockerfile
+++ b/backend-rust/Dockerfile
@@ -109,7 +109,7 @@ EXPOSE 4001
 
 # Health check using curl to hit the health endpoint
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:4001/health || exit 1
+    CMD curl -f http://localhost:4001/api/health || exit 1
 
 # Run the binary
 CMD ["/app/loyalty-backend"]

--- a/backend-rust/Dockerfile.ci
+++ b/backend-rust/Dockerfile.ci
@@ -39,7 +39,7 @@ EXPOSE 4001
 
 # Health check using curl to hit the health endpoint
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:4001/health || exit 1
+    CMD curl -f http://localhost:4001/api/health || exit 1
 
 # Run the binary
 CMD ["/app/loyalty-backend"]


### PR DESCRIPTION
## Summary

Both backend Dockerfile HEALTHCHECK directives were probing `http://localhost:4001/health` which 404s. The Rust backend mounts the health endpoint under `/api/health` (`backend-rust/src/routes/mod.rs:73`).

Production was masked by `docker-compose.prod.yml`'s healthcheck override (which uses `/api/health`). Staging had no override — the new SSH-based deploy shim's `wait_healthy loyalty_backend_dev` (correctly) refused to consider the deploy healthy in the first post-migration run: https://github.com/thehfhotel/loyalty-app/actions/runs/25603127695

Fixing the Dockerfiles makes both stacks pass without depending on the prod-only compose override (now redundant but left in place — belt and suspenders).

## Test plan

- [ ] CI rebuilds both backend images with the fixed HEALTHCHECK
- [ ] Deploy workflow's `deploy-staging` → `deploy-production` complete green
- [ ] `docker inspect loyalty_backend_dev | jq '.[0].State.Health.Status'` reports `healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)