### PR TITLE
chore: drop unused VITE_* decls, hide dev console.log, fix stale docs

### DIFF
--- a/backend-rust/Dockerfile.ci
+++ b/backend-rust/Dockerfile.ci
@@ -1,7 +1,18 @@
 # ==============================================================================
 # CI Dockerfile - Uses pre-built binary from GitHub Actions
 # This avoids recompiling Rust inside Docker, saving ~15 minutes per build.
-# The full Dockerfile (with cargo-chef) is still used for local development.
+#
+# IMPORTANT - Single-stage runtime image only:
+#   - Used by the build-and-push CI workflow, which compiles the Rust binary
+#     on the runner and copies the artifact (./loyalty-backend) into this image.
+#   - Defines ONLY the `runner` stage - no `development` or `planner` stages.
+#   - INCOMPATIBLE with `target:` selection in compose files. Running e.g.
+#     `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`
+#     against a server that points at this Dockerfile WILL FAIL because the
+#     base compose specifies `target: development`, which does not exist here.
+#   - The canonical multi-stage Dockerfile is `backend-rust/Dockerfile`; that
+#     one is used by `docker-compose.yml`'s default build path and supports
+#     all `target:` overrides (development, planner, runner).
 # ==============================================================================
 FROM debian:bookworm-slim AS runner
 

--- a/frontend/src/utils/apiConfig.ts
+++ b/frontend/src/utils/apiConfig.ts
@@ -62,9 +62,12 @@ export const getApiUrl = (): string => {
 export const API_BASE_URL = getApiUrl();
 
 // Log API configuration on module load (helpful for E2E debugging)
-console.log('[apiConfig] API_BASE_URL:', API_BASE_URL);
-console.log('[apiConfig] VITE_API_URL:', import.meta.env.VITE_API_URL);
-console.log('[apiConfig] isBrowser:', typeof window !== 'undefined');
+// Dev-only: avoid polluting end-user consoles in production builds.
+if (import.meta.env.DEV) {
+  console.log('[apiConfig] API_BASE_URL:', API_BASE_URL);
+  console.log('[apiConfig] VITE_API_URL:', import.meta.env.VITE_API_URL);
+  console.log('[apiConfig] isBrowser:', typeof window !== 'undefined');
+}
 
 /**
  * Check if the application is running in development mode

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,9 +2,6 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string
-  readonly VITE_GOOGLE_CLIENT_ID: string
-  readonly VITE_FACEBOOK_APP_ID: string
-  readonly VITE_LINE_CHANNEL_ID: string
   readonly VITE_TRANSLATION_ENABLED?: string
   readonly DEV: boolean
   readonly PROD: boolean


### PR DESCRIPTION
## Summary

Cleans up four LOW-priority audit findings to reduce noise and prevent silent footguns.

- **`frontend/src/vite-env.d.ts`** — Drop `VITE_GOOGLE_CLIENT_ID`, `VITE_FACEBOOK_APP_ID`, `VITE_LINE_CHANNEL_ID` type declarations. Verified zero references in `frontend/src` and zero references in any `.env*.example` file. These were holdovers from the client-side OAuth era; OAuth is now backend-handled.
- **`frontend/src/utils/apiConfig.ts`** — Wrap the three `[apiConfig]` startup `console.log` calls in `if (import.meta.env.DEV)` so end users no longer see internal config dumps in their production browser console. Logs still fire in dev for E2E debugging.
- **`backend-rust/Dockerfile.ci`** — Expand the header comment to make it explicit that this is a single-stage runtime image used by the build-and-push pipeline (operates on a pre-built `loyalty-backend` binary) and is INCOMPATIBLE with `target:` selection in compose files. Points readers at `backend-rust/Dockerfile` as the canonical multi-stage Dockerfile used by `docker-compose.yml`'s default build path.
- **`CLAUDE.md`** — No-op. Already on Rust 1.93 in this worktree with the obsolete "Key Dependency Pins" section removed; no further changes needed.

## Test plan

- [x] `cd frontend && npm run typecheck` (passes)
- [x] `cd frontend && npm run lint` (no errors; only pre-existing warnings)
- [x] `grep -rn 'VITE_GOOGLE_CLIENT_ID\|VITE_FACEBOOK_APP_ID\|VITE_LINE_CHANNEL_ID' frontend/src` returns nothing after the change
- [x] `grep` of all `.env*.example` files for the three unused VITE_* names returns nothing (so no example file needed editing)
- [x] `Dockerfile.ci` build steps untouched — only the header comment changed
- [ ] CI green on main checks
- [ ] Manual verification post-merge: open the production frontend, confirm `[apiConfig]` lines no longer appear in DevTools console

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>