### PR TITLE
chore(deploy): nginx security headers + bind data ports to localhost + remove dead env injection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,7 +131,9 @@ jobs:
           LINE_CALLBACK_URL:    ${{ vars.LINE_CALLBACK_URL }}
           FRONTEND_URL:         ${{ vars.FRONTEND_URL }}
           BACKEND_URL:          ${{ vars.BACKEND_URL }}
-          VITE_API_URL:         ${{ vars.VITE_API_URL }}
+          POSTGRES_USER:        ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD:    ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_DB:          ${{ secrets.POSTGRES_DB }}
         run: |
           set -euo pipefail
           tar -czf /tmp/deploy.tar.gz \
@@ -154,7 +156,9 @@ jobs:
             --arg LINE_CALLBACK_URL    "$LINE_CALLBACK_URL" \
             --arg FRONTEND_URL         "$FRONTEND_URL" \
             --arg BACKEND_URL          "$BACKEND_URL" \
-            --arg VITE_API_URL         "$VITE_API_URL" \
+            --arg POSTGRES_USER        "$POSTGRES_USER" \
+            --arg POSTGRES_PASSWORD    "$POSTGRES_PASSWORD" \
+            --arg POSTGRES_DB          "$POSTGRES_DB" \
             '{
               commit_sha: $commit_sha,
               deploy_payload_b64: $deploy_payload_b64,
@@ -167,11 +171,13 @@ jobs:
                 JWT_SECRET:           $JWT_SECRET,
                 JWT_REFRESH_SECRET:   $JWT_REFRESH_SECRET,
                 SESSION_SECRET:       $SESSION_SECRET,
-                DATABASE_URL:         "postgresql://loyalty_dev:loyalty_dev_pass@postgres:5432/loyalty_dev_db",
+                POSTGRES_USER:        $POSTGRES_USER,
+                POSTGRES_PASSWORD:    $POSTGRES_PASSWORD,
+                POSTGRES_DB:          $POSTGRES_DB,
+                DATABASE_URL:         ("postgresql://" + $POSTGRES_USER + ":" + $POSTGRES_PASSWORD + "@postgres:5432/" + $POSTGRES_DB),
                 REDIS_URL:            "redis://redis:6379",
                 FRONTEND_URL:         $FRONTEND_URL,
                 BACKEND_URL:          $BACKEND_URL,
-                VITE_API_URL:         $VITE_API_URL,
                 GOOGLE_CLIENT_ID:     $GOOGLE_CLIENT_ID,
                 GOOGLE_CLIENT_SECRET: $GOOGLE_CLIENT_SECRET,
                 GOOGLE_CALLBACK_URL:  $GOOGLE_CALLBACK_URL,
@@ -237,6 +243,9 @@ jobs:
           JWT_REFRESH_SECRET:   ${{ secrets.JWT_REFRESH_SECRET }}
           SESSION_SECRET:       ${{ secrets.SESSION_SECRET }}
           DATABASE_URL:         ${{ secrets.DATABASE_URL }}
+          POSTGRES_USER:        ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD:    ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_DB:          ${{ secrets.POSTGRES_DB }}
           GOOGLE_CLIENT_ID:     ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
           GOOGLE_CALLBACK_URL:  ${{ vars.GOOGLE_CALLBACK_URL }}
@@ -245,7 +254,6 @@ jobs:
           LINE_CALLBACK_URL:    ${{ vars.LINE_CALLBACK_URL }}
           FRONTEND_URL:         ${{ vars.FRONTEND_URL }}
           BACKEND_URL:          ${{ vars.BACKEND_URL }}
-          VITE_API_URL:         ${{ vars.VITE_API_URL }}
           SMTP_HOST:            ${{ secrets.SMTP_HOST }}
           SMTP_PORT:            ${{ secrets.SMTP_PORT }}
           SMTP_USER:            ${{ secrets.SMTP_USER }}
@@ -269,6 +277,9 @@ jobs:
             --arg JWT_REFRESH_SECRET   "$JWT_REFRESH_SECRET" \
             --arg SESSION_SECRET       "$SESSION_SECRET" \
             --arg DATABASE_URL         "$DATABASE_URL" \
+            --arg POSTGRES_USER        "$POSTGRES_USER" \
+            --arg POSTGRES_PASSWORD    "$POSTGRES_PASSWORD" \
+            --arg POSTGRES_DB          "$POSTGRES_DB" \
             --arg GOOGLE_CLIENT_ID     "$GOOGLE_CLIENT_ID" \
             --arg GOOGLE_CLIENT_SECRET "$GOOGLE_CLIENT_SECRET" \
             --arg GOOGLE_CALLBACK_URL  "$GOOGLE_CALLBACK_URL" \
@@ -277,7 +288,6 @@ jobs:
             --arg LINE_CALLBACK_URL    "$LINE_CALLBACK_URL" \
             --arg FRONTEND_URL         "$FRONTEND_URL" \
             --arg BACKEND_URL          "$BACKEND_URL" \
-            --arg VITE_API_URL         "$VITE_API_URL" \
             --arg SMTP_HOST            "${SMTP_HOST:-}" \
             --arg SMTP_PORT            "${SMTP_PORT:-587}" \
             --arg SMTP_USER            "${SMTP_USER:-}" \
@@ -298,11 +308,13 @@ jobs:
                 JWT_SECRET:           $JWT_SECRET,
                 JWT_REFRESH_SECRET:   $JWT_REFRESH_SECRET,
                 SESSION_SECRET:       $SESSION_SECRET,
+                POSTGRES_USER:        $POSTGRES_USER,
+                POSTGRES_PASSWORD:    $POSTGRES_PASSWORD,
+                POSTGRES_DB:          $POSTGRES_DB,
                 DATABASE_URL:         $DATABASE_URL,
                 REDIS_URL:            "redis://redis:6379",
                 FRONTEND_URL:         $FRONTEND_URL,
                 BACKEND_URL:          $BACKEND_URL,
-                VITE_API_URL:         $VITE_API_URL,
                 GOOGLE_CLIENT_ID:     $GOOGLE_CLIENT_ID,
                 GOOGLE_CLIENT_SECRET: $GOOGLE_CLIENT_SECRET,
                 GOOGLE_CALLBACK_URL:  $GOOGLE_CALLBACK_URL,

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,13 +11,16 @@ services:
     container_name: loyalty_postgres_production
     restart: unless-stopped
     ports:
-      - "5434:5432"  # Production PostgreSQL port
+      # Bind to localhost only — backend reaches postgres via the docker network.
+      # Host port mapping exists for ad-hoc DBA access from the host (via SSH tunnel).
+      - "127.0.0.1:5434:5432"  # Production PostgreSQL port
 
   redis:
     container_name: loyalty_redis_production
     restart: unless-stopped
     ports:
-      - "6379:6379"  # Production Redis port
+      # Bind to localhost only — backend reaches redis via the docker network.
+      - "127.0.0.1:6379:6379"  # Production Redis port
 
   backend:
     container_name: loyalty_backend_production
@@ -79,9 +82,9 @@ services:
 
   frontend:
     container_name: loyalty_frontend_production
-    environment:
-      NODE_ENV: ${NODE_ENV:-production}
-      VITE_API_URL: ${VITE_API_URL}
+    # NOTE: VITE_API_URL is build-time only (baked into the image during docker build).
+    # NODE_ENV is not consumed by the alpine nginx serving the built SPA.
+    # Neither belongs in runtime env for the GHCR frontend image.
     volumes:
       # GHCR frontend uses nginx:alpine with logs at /var/log/nginx
       - frontend_logs:/var/log/nginx

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -12,13 +12,15 @@ services:
   postgres:
     container_name: loyalty_postgres_dev
     ports:
-      - "5435:5432"  # Dev port 5435 (prod uses 5434)
+      # Bind to localhost only — backend reaches postgres via the docker network.
+      # Host port mapping exists for ad-hoc DBA access from the host (via SSH tunnel).
+      - "127.0.0.1:5435:5432"  # Dev port 5435 (prod uses 5434)
     environment:
-      POSTGRES_USER: loyalty_dev
-      POSTGRES_PASSWORD: loyalty_dev_pass
-      POSTGRES_DB: loyalty_dev_db
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB required}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U loyalty_dev -d loyalty_dev_db"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -28,7 +30,8 @@ services:
   redis:
     container_name: loyalty_redis_dev
     ports:
-      - "6380:6379"  # Dev port 6380 (prod uses 6379)
+      # Bind to localhost only — backend reaches redis via the docker network.
+      - "127.0.0.1:6380:6379"  # Dev port 6380 (prod uses 6379)
 
   backend:
     container_name: loyalty_backend_dev
@@ -67,9 +70,9 @@ services:
 
   frontend:
     container_name: loyalty_frontend_dev
-    environment:
-      NODE_ENV: staging
-      VITE_API_URL: ${VITE_API_URL}
+    # NOTE: VITE_API_URL is build-time only (baked into the image during docker build).
+    # NODE_ENV is not consumed by the alpine nginx serving the built SPA.
+    # Neither belongs in runtime env for the GHCR frontend image.
     # No source code bind mounts - uses GHCR image with built code
     # GHCR frontend uses nginx:alpine with logs at /var/log/nginx
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,13 @@ services:
     image: postgres:15-alpine
     container_name: loyalty_postgres
     environment:
-      POSTGRES_USER: loyalty
-      POSTGRES_PASSWORD: loyalty_pass
-      POSTGRES_DB: loyalty_db
+      # Credentials are required via env vars (no insecure defaults).
+      # Local dev loads them from .env.development; CI/staging/prod inject via the deploy workflow.
+      # NOTE: POSTGRES_USER/PASSWORD only initialize the role on a fresh data volume.
+      # Existing volumes keep their original credentials — the env vars must match.
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD required}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB required}
     volumes:
       - postgres_data:/var/lib/postgresql/data
       # Removed old SQL migrations - Prisma handles schema migrations now
@@ -15,7 +19,7 @@ services:
     # PORTS: Defined in environment-specific override files (dev/prod)
     # to prevent port conflicts when both environments run on same machine
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U loyalty -d loyalty_db"]
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -33,6 +33,14 @@ http {
         listen 80;
         server_name localhost;
 
+        # Security headers (applied to all responses, including errors, via `always`)
+        # CSP starts permissive enough for the SPA to render — tune if console errors fire.
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header Content-Security-Policy "default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https:; font-src 'self' data:; frame-ancestors 'none';" always;
+
         # Favicon specific handling
         location = /favicon.ico {
             proxy_pass http://frontend;
@@ -46,20 +54,16 @@ http {
         }
 
         # Static assets optimization for PWA icons and other assets
+        # No CORS headers — the SPA serves itself, no legitimate cross-origin use case.
         location ~* \.(png|jpg|jpeg|gif|svg|woff|woff2|ttf|eot)$ {
             proxy_pass http://frontend;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
-            
+
             # Cache static assets for better performance
             proxy_cache_valid 200 1d;
             proxy_cache_bypass $http_cache_control;
             add_header Cache-Control "public, max-age=86400";
-            
-            # Add CORS headers for web fonts and icons
-            add_header Access-Control-Allow-Origin "*";
-            add_header Access-Control-Allow-Methods "GET, OPTIONS";
-            add_header Access-Control-Allow-Headers "DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range";
         }
 
         # Manifest and service worker


### PR DESCRIPTION
## Summary

Hardens deployment configuration based on a recent audit. Four findings, one commit:

1. **HIGH — nginx security headers + drop wildcard CORS** (`nginx/nginx.conf`). Add `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Strict-Transport-Security`, and a permissive CSP at the `server {}` level via `always`. Drop the wildcard `Access-Control-Allow-Origin: *` and friends from the static asset location — the SPA serves itself, no legitimate cross-origin web-font use case.
2. **MEDIUM — Bind postgres + redis host port mappings to `127.0.0.1`** (`docker-compose.prod.yml`, `docker-compose.staging.yml`). Backend reaches them via the docker network so this is unaffected; host ports remain reachable for ad-hoc DBA access via SSH tunnel only. Closes a direct-internet route into the database.
3. **MEDIUM — Remove default `loyalty:loyalty_pass` postgres credentials baked into base compose** (`docker-compose.yml`). `POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB` are now required env vars (`:?required`) so deploys fail loud if missing. The deploy workflow now injects them from per-environment GitHub secrets, and `DATABASE_URL` is constructed from the same values for staging to keep them in lockstep. Production still passes `DATABASE_URL` from its own secret (must match `POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB`).
4. **MEDIUM — Remove dead `VITE_API_URL` runtime env injection** (`.github/workflows/deploy.yml`, `docker-compose.prod.yml`, `docker-compose.staging.yml`). `VITE_API_URL` is build-time only — baked into the frontend image during `docker build`. Same for `NODE_ENV` on the alpine-nginx frontend image (not consumed at runtime). Removed from both runtime env-injection blobs and both override compose files.

## REQUIRED BEFORE MERGING — populate new GitHub secrets

This PR turns existing implicit defaults into hard requirements. Until the secrets below exist in the right environment, the matching deploy will fail loud at `docker compose up` with a `POSTGRES_USER required` error (intentional — the alternative is silent regression to the old default credentials).

### `development` (staging) environment secrets — required
- `POSTGRES_USER` = `loyalty_dev`
- `POSTGRES_PASSWORD` = `loyalty_dev_pass`
- `POSTGRES_DB` = `loyalty_dev_db`

These MUST match the credentials the existing `postgres_dev_data` volume was initialized with — the staging compose previously hardcoded these exact values via `DATABASE_URL`, so they ARE the existing credentials. The `DATABASE_URL` for staging is now reconstructed in the workflow from these three secrets (no longer a hardcoded literal).

### `production` environment secrets — required
- `POSTGRES_USER` = `loyalty` (the existing role on the prod postgres volume)
- `POSTGRES_PASSWORD` = `loyalty_pass` (the existing password on the prod postgres volume — see note below)
- `POSTGRES_DB` = `loyalty_db` (the existing database on the prod postgres volume)

**Critical note on the existing prod postgres volume:** Postgres only honors `POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB` env vars on **fresh-volume init**. The existing `postgres_data` volume was initialized with `loyalty:loyalty_pass`, and you cannot change an existing role's password by changing the env var on subsequent boots — the env vars are silently ignored when the data dir already exists. So:
- The new prod secrets MUST be set to the existing role's exact values, otherwise `DATABASE_URL` (which the prod workflow still pulls from the `DATABASE_URL` secret) will be inconsistent with the postgres role and the backend will fail to connect.
- If you want to actually rotate the prod password, do it as a separate operation (`ALTER USER loyalty WITH PASSWORD '...'` via psql) AND update the `DATABASE_URL` and `POSTGRES_PASSWORD` secrets together in the same maintenance window.

## Server-side shim update — required if shims validate env

The audit notes the deploy shims live at `/srv/run-deploy-loyalty-app-staging.sh` and `/srv/run-deploy-loyalty-app-production.sh` on evergreen, and that I should provide updated contents if I needed to add `POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB` to their required-env validation list.

I do not have read access to the current shims, so I cannot diff them. **Please check the existing shims** for any `required_vars` / `must-be-set` allowlist. If such a list exists, append `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`. If the shim simply writes whatever JSON `env` keys arrive into `.env` and runs `docker compose up`, no change is needed — the `:?required` interpolation in the compose file will fail loud if any of the three is missing, which is the desired behavior.

## Things I did NOT touch (out of scope per audit)

- `.env.example` — adding the three new required vars there would be a developer-experience improvement for `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`, but it's outside the file allowlist for this PR. Local devs running base+dev will need to either `export` the vars or add them to a top-level `.env`.
- Backend `DATABASE_URL` literal in base `docker-compose.yml` (still references `loyalty:loyalty_pass`) — overridden by every override file (dev, staging, prod) so harmless in practice; rewriting it to use the new env vars would be a wider refactor and was not in the audit.

## nginx CSP caveat — verify on staging

Per the audit's own verification step: confirm the SPA still renders on staging after the new CSP. The CSP starts permissive (`default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https:; font-src 'self' data:; frame-ancestors 'none';`) but if the frontend uses any inline scripts, eval, or external CDNs, the browser console will report violations and the CSP will need tuning.

One nginx behavior to be aware of: `add_header` declared at the `server {}` level is overridden (NOT merged) by any `add_header` in a `location {}` block. The audit explicitly placed the security headers at server level, so locations that set their own `add_header` (favicon, static assets, manifest, storage) will lose the security headers on those responses specifically. The HTML responses (the only place HSTS / CSP truly matter) come through the catch-all `location /` which has no `add_header`, so they will receive the full set. Worth flagging during review in case stricter coverage is desired.

## Verification I ran locally

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yml'))"` — passes
- YAML parse of all four compose files — passes
- `jq -n` test of the new `DATABASE_URL` construction expression — produces correct `postgresql://user:pass@postgres:5432/db`
- `docker compose ... config -q` — could not run; docker is uninstalled on this workstation. Please verify on a docker-equipped machine before merging if desired.

## Test plan

- [ ] Populate `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` secrets in the `development` GitHub environment with `loyalty_dev` / `loyalty_dev_pass` / `loyalty_dev_db`
- [ ] Populate `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` secrets in the `production` GitHub environment with the existing prod role values (must match what the existing `postgres_data` volume expects)
- [ ] Update server-side shims at `/srv/run-deploy-loyalty-app-{staging,production}.sh` if they have an explicit env-var allowlist
- [ ] Merge → confirm staging deploy succeeds; check `/api/health` is 200 and the SPA loads with no CSP console violations
- [ ] Approve production deploy → confirm `/api/health` is 200 and the SPA loads
- [ ] Verify `ss -tlnp | grep -E ':(5434|5435|6379|6380)'` on evergreen shows the four ports bound to `127.0.0.1` only, not `0.0.0.0`
- [ ] Verify response headers on https://loyalty.saichon.com include `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Strict-Transport-Security`, `Content-Security-Policy` (and that `Access-Control-Allow-Origin: *` is GONE from static asset responses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)