### PR TITLE
fix(backend): close 5 security gaps (storage auth, rate limit, body cap, JWT fallback)

### DIFF
--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -6,6 +6,7 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
+use axum::extract::DefaultBodyLimit;
 use axum::Router;
 use tokio::net::TcpListener;
 use tower_http::compression::CompressionLayer;
@@ -13,6 +14,11 @@ use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::{self, TraceLayer};
 use tracing::{error, info, Level};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Global request body limit. 16 MiB matches `client_max_body_size 15M` in
+/// nginx/nginx.conf with a small headroom for multipart framing overhead;
+/// per-route handlers (e.g. JSON endpoints) can tighten this further.
+const DEFAULT_BODY_LIMIT_BYTES: usize = 16 * 1024 * 1024;
 
 use loyalty_backend::{
     config::{Environment, Settings},
@@ -141,7 +147,7 @@ fn init_tracing() {
         .with(
             tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
                 // Default log levels for different modules
-                "loyalty_backend=debug,tower_http=debug,axum=trace,sqlx=warn".into()
+                "loyalty_backend=info,tower_http=info,axum=info,sqlx=warn".into()
             }),
         )
         .with(
@@ -215,6 +221,11 @@ fn create_app(state: AppState, config: &Settings) -> Router {
     app
         // Compression (gzip, deflate, br)
         .layer(CompressionLayer::new())
+        // Cap incoming request bodies. axum's default is 2 MiB which would
+        // reject every legitimate file upload; nginx's 15 MiB limit only
+        // protects requests that pass through the reverse proxy, so we
+        // enforce an equivalent (with a touch of headroom) here too.
+        .layer(DefaultBodyLimit::max(DEFAULT_BODY_LIMIT_BYTES))
         // Request timeout (30 seconds default)
         .layer(TimeoutLayer::new(Duration::from_secs(30)))
         // Request tracing/logging

--- a/backend-rust/src/middleware/auth.rs
+++ b/backend-rust/src/middleware/auth.rs
@@ -159,16 +159,20 @@ fn validate_token(token: &str, jwt_secret: &str) -> Result<Claims, AuthError> {
 ///     .layer(middleware::from_fn_with_state(state, auth_middleware));
 /// ```
 pub async fn auth_middleware(mut request: Request, next: Next) -> Result<Response, AuthError> {
-    // Get JWT secret from Extension (injected by create_router from AppState config),
-    // falling back to env var for backwards compatibility
+    // The JwtSecret extension is injected at the top of the router tree by
+    // `create_router`. A missing extension means the auth middleware is being
+    // used outside that router (a routing/test bug). We refuse to validate
+    // tokens in that case rather than silently fall back to an env var or a
+    // hard-coded development secret — both of which previously masked exactly
+    // this kind of misconfiguration in production.
     let jwt_secret = request
         .extensions()
         .get::<JwtSecret>()
         .map(|s| s.0.clone())
-        .unwrap_or_else(|| {
-            std::env::var("JWT_SECRET")
-                .unwrap_or_else(|_| "development-secret-change-in-production".to_string())
-        });
+        .ok_or_else(|| {
+            tracing::error!("auth_middleware reached without JwtSecret extension — routing bug");
+            AuthError::InvalidToken
+        })?;
 
     // Extract Authorization header
     let auth_header = request
@@ -195,14 +199,16 @@ pub async fn auth_middleware(mut request: Request, next: Next) -> Result<Respons
 /// Instead, it simply doesn't add AuthUser to extensions if authentication fails.
 /// Useful for routes that work differently for authenticated vs unauthenticated users.
 pub async fn optional_auth_middleware(mut request: Request, next: Next) -> Response {
-    let jwt_secret = request
-        .extensions()
-        .get::<JwtSecret>()
-        .map(|s| s.0.clone())
-        .unwrap_or_else(|| {
-            std::env::var("JWT_SECRET")
-                .unwrap_or_else(|_| "development-secret-change-in-production".to_string())
-        });
+    // No JwtSecret extension means we cannot validate tokens; treat the
+    // request as anonymous (the same outcome a missing/invalid token would
+    // produce). Falling back to env vars or hard-coded secrets here is
+    // dangerous — see auth_middleware.
+    let Some(jwt_secret) = request.extensions().get::<JwtSecret>().map(|s| s.0.clone()) else {
+        tracing::warn!(
+            "optional_auth_middleware reached without JwtSecret extension — treating request as anonymous"
+        );
+        return next.run(request).await;
+    };
 
     // Try to extract and validate token, but don't fail if not present
     if let Some(auth_header) = request

--- a/backend-rust/src/routes/mod.rs
+++ b/backend-rust/src/routes/mod.rs
@@ -20,11 +20,12 @@ pub mod surveys;
 pub mod translation;
 pub mod users;
 
-use axum::{Extension, Router};
+use axum::{middleware, Extension, Router};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::middleware::auth::JwtSecret;
+use crate::middleware::rate_limit::{redis_rate_limit_middleware, RedisRateLimiter};
 use crate::openapi::ApiDoc;
 use crate::state::AppState;
 
@@ -63,14 +64,40 @@ pub fn create_router(state: AppState) -> Router {
     // Extract JWT secret from config to inject as Extension for auth middleware
     let jwt_secret = JwtSecret(state.config().auth.jwt_secret.clone());
 
+    // Rate limiters are only attached in production. In development and test
+    // we disable them so iterative testing (login retries, integration suites
+    // hitting the same endpoints from 127.0.0.1) doesn't trip the strict
+    // 5/min threshold. The limiter itself fails open if Redis is unavailable,
+    // so leaving it on in dev would still mostly work — but disabling is
+    // simpler and avoids flaky tests.
+    let rate_limiters = if state.is_production() {
+        Some((
+            RedisRateLimiter::with_defaults(state.redis(), "api"),
+            RedisRateLimiter::strict(state.redis(), "auth"),
+        ))
+    } else {
+        None
+    };
+
     // Storage routes use a different state type, so mount separately
     let storage_state = storage::StorageState::new(crate::services::storage::StorageService::new());
     let storage_router =
         Router::new().nest("/api/storage", storage::routes().with_state(storage_state));
 
-    Router::new()
+    // Auth routes get a tighter (strict) rate limit on top of the global one
+    // when running in production. The strict layer is applied per-router so
+    // it stacks under the global limiter in main.rs.
+    let auth_routes = match &rate_limiters {
+        Some((_default, strict)) => auth::routes().layer(middleware::from_fn_with_state(
+            strict.clone(),
+            redis_rate_limit_middleware,
+        )),
+        None => auth::routes(),
+    };
+
+    let app = Router::new()
         .nest("/api/health", health::routes())
-        .nest("/api/auth", auth::routes())
+        .nest("/api/auth", auth_routes)
         .nest("/api/users", users::routes())
         .nest("/api/oauth", oauth::routes())
         .nest("/api/loyalty", loyalty::routes())
@@ -88,9 +115,19 @@ pub fn create_router(state: AppState) -> Router {
         .merge(SwaggerUi::new("/api/docs").url("/api/openapi.json", ApiDoc::openapi()))
         .with_state(state)
         // Merge storage routes (separate state type)
-        .merge(storage_router)
-        // Inject JWT secret for auth middleware (must be after with_state so it wraps everything)
-        .layer(Extension(jwt_secret))
+        .merge(storage_router);
+
+    // Apply the global default rate limiter (production only) on top of
+    // everything, then inject the JWT secret so auth_middleware can read it.
+    let app = match rate_limiters {
+        Some((default_limiter, _strict)) => app.layer(middleware::from_fn_with_state(
+            default_limiter,
+            redis_rate_limit_middleware,
+        )),
+        None => app,
+    };
+
+    app.layer(Extension(jwt_secret))
 }
 
 #[cfg(test)]

--- a/backend-rust/src/routes/storage.rs
+++ b/backend-rust/src/routes/storage.rs
@@ -3,15 +3,15 @@
 //! Provides endpoints for file upload, avatar management, and file serving.
 //!
 //! Routes (all nested under /api/storage):
-//! - POST /api/storage/upload - General file upload
-//! - POST /api/storage/avatar - Avatar upload (requires authentication)
-//! - POST /api/storage/slip - Slip upload (requires authentication)
-//! - GET /api/storage/files/:filename - Serve uploaded files
-//! - GET /api/storage/avatars/:filename - Serve avatar images
-//! - GET /api/storage/slips/:filename - Serve slip images
+//! - POST /api/storage/upload - General file upload (authenticated)
+//! - POST /api/storage/avatar - Avatar upload (authenticated; user derived from JWT)
+//! - POST /api/storage/slip - Slip upload (authenticated)
+//! - GET /api/storage/files/:filename - Serve uploaded files (public)
+//! - GET /api/storage/avatars/:filename - Serve avatar images (public)
+//! - GET /api/storage/slips/:filename - Serve slip images (public)
 //! - GET /api/storage/stats - Get storage statistics (admin only)
 //! - POST /api/storage/backup - Trigger manual backup (admin only)
-//! - DELETE /api/storage/files/:filename - Delete a file
+//! - DELETE /api/storage/files/:filename - Delete a file (admin only)
 
 use axum::{
     body::Body,
@@ -20,17 +20,17 @@ use axum::{
     middleware,
     response::Response,
     routing::{get, post},
-    Json, Router,
+    Extension, Json, Router,
 };
 use bytes::Bytes;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::sync::Arc;
 use tokio::fs::File;
 use tokio_util::io::ReaderStream;
 use tracing::{debug, error, info};
 
 use crate::error::{AppError, AppResult};
-use crate::middleware::auth::{auth_middleware, require_role};
+use crate::middleware::auth::{auth_middleware, require_role, AuthUser};
 use crate::services::storage::{StorageReport, StorageService};
 
 /// State for storage routes
@@ -83,23 +83,20 @@ pub struct BackupResponse {
     pub files_backed_up: Option<u64>,
 }
 
-/// Request body for avatar upload with user context
-#[derive(Debug, Deserialize)]
-pub struct AvatarUploadRequest {
-    pub user_id: String,
-}
-
 /// General file upload handler
 ///
 /// POST /storage/upload
 /// Content-Type: multipart/form-data
+/// Authentication: required (Bearer token)
 ///
 /// Form fields:
 /// - file: The file to upload
 async fn upload_file(
     State(state): State<StorageState>,
+    Extension(auth_user): Extension<AuthUser>,
     mut multipart: Multipart,
 ) -> AppResult<Json<UploadResponse>> {
+    debug!(user_id = %auth_user.id, "upload_file invoked");
     let mut file_data: Option<Bytes> = None;
     let mut filename: Option<String> = None;
     let mut content_type: Option<String> = None;
@@ -147,17 +144,20 @@ async fn upload_file(
 ///
 /// POST /storage/avatar
 /// Content-Type: multipart/form-data
+/// Authentication: required (Bearer token). The avatar is always saved
+/// against the authenticated user's ID — clients cannot specify a target
+/// user. (Previously the endpoint trusted a `user_id` form field, which
+/// allowed unauthenticated overwrite of any user's avatar.)
 ///
 /// Form fields:
-/// - avatar: The avatar image file
-/// - user_id: The user's ID (should come from auth middleware in production)
+/// - avatar (or file): The avatar image file
 async fn upload_avatar(
     State(state): State<StorageState>,
+    Extension(auth_user): Extension<AuthUser>,
     mut multipart: Multipart,
 ) -> AppResult<Json<AvatarUploadResponse>> {
     let mut file_data: Option<Bytes> = None;
     let mut content_type: Option<String> = None;
-    let mut user_id: Option<String> = None;
 
     while let Some(field) = multipart.next_field().await.map_err(|e| {
         error!("Failed to read multipart field: {}", e);
@@ -176,13 +176,6 @@ async fn upload_avatar(
 
                 file_data = Some(data);
             },
-            "user_id" => {
-                let value = field.text().await.map_err(|e| {
-                    error!("Failed to read user_id: {}", e);
-                    AppError::BadRequest(format!("Failed to read user_id: {}", e))
-                })?;
-                user_id = Some(value);
-            },
             _ => {
                 debug!("Ignoring unknown field: {}", field_name);
             },
@@ -190,9 +183,7 @@ async fn upload_avatar(
     }
 
     let data = file_data.ok_or_else(|| AppError::BadRequest("No file uploaded".to_string()))?;
-
-    let uid = user_id.ok_or_else(|| AppError::MissingField("user_id".to_string()))?;
-
+    let uid = auth_user.id.clone();
     let mime_type =
         content_type.ok_or_else(|| AppError::BadRequest("Content type is required".to_string()))?;
 
@@ -218,13 +209,16 @@ async fn upload_avatar(
 ///
 /// POST /storage/slip
 /// Content-Type: multipart/form-data
+/// Authentication: required (Bearer token)
 ///
 /// Form fields:
-/// - slip: The slip image file
+/// - slip (or file): The slip image file
 async fn upload_slip(
     State(state): State<StorageState>,
+    Extension(auth_user): Extension<AuthUser>,
     mut multipart: Multipart,
 ) -> AppResult<Json<SlipUploadResponse>> {
+    debug!(user_id = %auth_user.id, "upload_slip invoked");
     let mut file_data: Option<Bytes> = None;
     let mut content_type: Option<String> = None;
 
@@ -403,14 +397,23 @@ async fn delete_file(
 ///
 /// These routes are nested under /api/storage in the main router
 pub fn routes() -> Router<StorageState> {
-    // Public routes - file serving and uploads
-    let public_routes = Router::new()
-        .route("/upload", post(upload_file))
-        .route("/avatar", post(upload_avatar))
-        .route("/slip", post(upload_slip))
+    // File-serving routes are intentionally public (any client can fetch a
+    // saved avatar/slip/file by URL — the URLs themselves are unguessable
+    // because they include UUIDs).
+    let public_get_routes = Router::new()
         .route("/files/:filename", get(serve_file))
         .route("/avatars/:filename", get(serve_avatar))
         .route("/slips/:filename", get(serve_slip));
+
+    // POST upload routes require authentication. The avatar route always
+    // saves to the authenticated user's slot — clients CANNOT specify a
+    // target user via the multipart body. Without this gate, any caller
+    // could overwrite any user's avatar (or fill the disk).
+    let authenticated_upload_routes = Router::new()
+        .route("/upload", post(upload_file))
+        .route("/avatar", post(upload_avatar))
+        .route("/slip", post(upload_slip))
+        .layer(middleware::from_fn(auth_middleware));
 
     // Admin routes - require authentication + admin role
     let admin_routes = Router::new()
@@ -422,7 +425,9 @@ pub fn routes() -> Router<StorageState> {
         }))
         .layer(middleware::from_fn(auth_middleware));
 
-    public_routes.merge(admin_routes)
+    public_get_routes
+        .merge(authenticated_upload_routes)
+        .merge(admin_routes)
 }
 
 /// Create storage routes with state

--- a/backend-rust/tests/integration/storage_test.rs
+++ b/backend-rust/tests/integration/storage_test.rs
@@ -10,14 +10,16 @@
 use axum::{
     body::Body,
     http::{header, Request, StatusCode},
-    Router,
+    Extension, Router,
 };
 use bytes::Bytes;
+use jsonwebtoken::{encode, EncodingKey, Header};
 use serde_json::Value;
 use std::sync::Arc;
 use tempfile::tempdir;
 use tower::ServiceExt;
 
+use loyalty_backend::middleware::auth::{Claims, JwtSecret};
 use loyalty_backend::routes::storage::{routes_with_state, StorageState};
 use loyalty_backend::services::storage::{StorageConfig, StorageService};
 
@@ -25,16 +27,49 @@ use loyalty_backend::services::storage::{StorageConfig, StorageService};
 // Test Setup
 // ============================================================================
 
-/// Create a test storage router with a temporary directory
+/// JWT secret used by the test storage router. The auth middleware refuses
+/// to validate when the JwtSecret extension is missing (no env-var fallback
+/// in production code), so tests must inject it explicitly.
+const TEST_JWT_SECRET: &str = "test-jwt-secret-for-integration-tests-minimum-64-characters-long";
+
+/// Create a test storage router with a temporary directory and a JWT secret
+/// extension so the auth middleware on the upload routes can validate Bearer
+/// tokens minted by `mint_test_token`.
 fn create_test_storage_router() -> (Router, tempfile::TempDir) {
     let temp_dir = tempdir().expect("Failed to create temp directory");
     let config = StorageConfig::new(temp_dir.path());
     let service = StorageService::with_config(config);
     let state = StorageState::new(service);
 
-    let router = Router::new().nest("/api/storage", routes_with_state(state));
+    let router = Router::new()
+        .nest("/api/storage", routes_with_state(state))
+        .layer(Extension(JwtSecret(TEST_JWT_SECRET.to_string())));
 
     (router, temp_dir)
+}
+
+/// Mint a JWT for tests, signed with `TEST_JWT_SECRET` and a 1-hour lifetime.
+fn mint_test_token(user_id: &str, role: &str) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let claims = Claims {
+        id: user_id.to_string(),
+        email: Some(format!("{}@test.local", user_id)),
+        role: role.to_string(),
+        iat: Some(now),
+        exp: now + 3600,
+    };
+    encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(TEST_JWT_SECRET.as_bytes()),
+    )
+    .expect("Failed to encode test JWT")
+}
+
+/// Convenience: build the `Authorization: Bearer <token>` header value for a
+/// freshly-minted test token.
+fn bearer_header(user_id: &str, role: &str) -> String {
+    format!("Bearer {}", mint_test_token(user_id, role))
 }
 
 /// Helper struct for test responses
@@ -174,6 +209,7 @@ async fn test_upload_file() {
     let request = Request::builder()
         .method("POST")
         .uri("/api/storage/upload")
+        .header(header::AUTHORIZATION, bearer_header("12345", "customer"))
         .header(
             header::CONTENT_TYPE,
             format!("multipart/form-data; boundary={}", boundary),
@@ -239,18 +275,16 @@ async fn test_upload_avatar() {
         0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
     ];
 
+    // user_id is no longer accepted from the multipart body — it's derived
+    // from the authenticated JWT. The test mints a token for "12345" and
+    // expects the saved avatar URL to embed that user ID.
     let user_id = "12345";
-    let (boundary, body) = create_multipart_body_with_fields(
-        "avatar",
-        "my-avatar.png",
-        "image/png",
-        png_data,
-        &[("user_id", user_id)],
-    );
+    let (boundary, body) = create_multipart_body("avatar", "my-avatar.png", "image/png", png_data);
 
     let request = Request::builder()
         .method("POST")
         .uri("/api/storage/avatar")
+        .header(header::AUTHORIZATION, bearer_header(user_id, "customer"))
         .header(
             header::CONTENT_TYPE,
             format!("multipart/form-data; boundary={}", boundary),
@@ -420,6 +454,7 @@ async fn test_upload_invalid_file_type() {
     let request = Request::builder()
         .method("POST")
         .uri("/api/storage/upload")
+        .header(header::AUTHORIZATION, bearer_header("12345", "customer"))
         .header(
             header::CONTENT_TYPE,
             format!("multipart/form-data; boundary={}", boundary),
@@ -478,6 +513,7 @@ async fn test_upload_executable_file_type() {
     let request = Request::builder()
         .method("POST")
         .uri("/api/storage/upload")
+        .header(header::AUTHORIZATION, bearer_header("12345", "customer"))
         .header(
             header::CONTENT_TYPE,
             format!("multipart/form-data; boundary={}", boundary),
@@ -584,6 +620,7 @@ async fn test_upload_missing_file_field() {
     let request = Request::builder()
         .method("POST")
         .uri("/api/storage/upload")
+        .header(header::AUTHORIZATION, bearer_header("12345", "customer"))
         .header(
             header::CONTENT_TYPE,
             format!("multipart/form-data; boundary={}", boundary),
@@ -599,20 +636,21 @@ async fn test_upload_missing_file_field() {
     test_response.assert_status(StatusCode::BAD_REQUEST);
 }
 
-/// Test uploading avatar without user_id
+/// Avatar upload requires a Bearer token. Without one, the route must reject
+/// the request before any multipart parsing happens. (Previously this
+/// endpoint was unauthenticated and trusted a user_id from the form body —
+/// any caller could overwrite any user's avatar.)
 #[tokio::test]
-async fn test_upload_avatar_missing_user_id() {
-    // Arrange
+async fn test_upload_avatar_unauthenticated_returns_401() {
     let (router, _temp_dir) = create_test_storage_router();
 
     let jpeg_data: &[u8] = &[0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10];
-
-    // Create multipart without user_id field
     let (boundary, body) = create_multipart_body("avatar", "test.jpg", "image/jpeg", jpeg_data);
 
     let request = Request::builder()
         .method("POST")
         .uri("/api/storage/avatar")
+        // No Authorization header.
         .header(
             header::CONTENT_TYPE,
             format!("multipart/form-data; boundary={}", boundary),
@@ -620,29 +658,100 @@ async fn test_upload_avatar_missing_user_id() {
         .body(Body::from(body))
         .unwrap();
 
-    // Act
     let response = router.oneshot(request).await.unwrap();
     let test_response = TestResponse::from_response(response).await;
 
-    // Assert - Should return 400 Bad Request
-    test_response.assert_status(StatusCode::BAD_REQUEST);
+    test_response.assert_status(StatusCode::UNAUTHORIZED);
+}
 
-    // Verify error message indicates missing user_id
-    let json_result = test_response.json();
-    if let Ok(json) = json_result {
-        let error_message = json
-            .get("error")
-            .or_else(|| json.get("message"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("");
+/// Same as above but for the general /upload endpoint — also auth-gated.
+#[tokio::test]
+async fn test_upload_file_unauthenticated_returns_401() {
+    let (router, _temp_dir) = create_test_storage_router();
 
-        assert!(
-            error_message.to_lowercase().contains("user_id")
-                || error_message.to_lowercase().contains("missing"),
-            "Error message should indicate missing user_id: {}",
-            error_message
-        );
-    }
+    let png_data: &[u8] = &[0x89, 0x50, 0x4E, 0x47];
+    let (boundary, body) = create_multipart_body("file", "x.png", "image/png", png_data);
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/storage/upload")
+        .header(
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={}", boundary),
+        )
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    let test_response = TestResponse::from_response(response).await;
+
+    test_response.assert_status(StatusCode::UNAUTHORIZED);
+}
+
+/// Avatar upload uses the JWT subject as the storage key — clients cannot
+/// pass a different user_id via the multipart body. Even if a `user_id`
+/// field is present, it must be ignored and the authenticated user's ID
+/// used instead.
+#[tokio::test]
+async fn test_upload_avatar_ignores_body_user_id() {
+    let (router, _temp_dir) = create_test_storage_router();
+
+    // Valid 1x1 PNG (the image processor will accept it and convert to JPEG).
+    let png_data: &[u8] = &[
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F,
+        0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x63, 0x00,
+        0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49,
+        0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+    ];
+
+    let authenticated_user = "alice";
+    let attempted_victim = "bob";
+
+    let (boundary, body) = create_multipart_body_with_fields(
+        "avatar",
+        "x.png",
+        "image/png",
+        png_data,
+        &[("user_id", attempted_victim)],
+    );
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/storage/avatar")
+        .header(
+            header::AUTHORIZATION,
+            bearer_header(authenticated_user, "customer"),
+        )
+        .header(
+            header::CONTENT_TYPE,
+            format!("multipart/form-data; boundary={}", boundary),
+        )
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    let test_response = TestResponse::from_response(response).await;
+
+    test_response.assert_status(StatusCode::OK);
+
+    let json: Value = test_response.json().expect("Response should be valid JSON");
+    let avatar_url = json
+        .get("data")
+        .and_then(|d| d.get("avatarUrl"))
+        .and_then(|v| v.as_str())
+        .expect("Response should contain avatarUrl");
+
+    assert!(
+        avatar_url.contains(authenticated_user),
+        "Avatar URL must embed the authenticated user's ID, not the body's: {}",
+        avatar_url
+    );
+    assert!(
+        !avatar_url.contains(attempted_victim),
+        "Avatar URL must NOT embed the spoofed body user_id: {}",
+        avatar_url
+    );
 }
 
 /// Test uploading PDF file (should be allowed for general upload)
@@ -660,6 +769,7 @@ async fn test_upload_pdf_file() {
     let request = Request::builder()
         .method("POST")
         .uri("/api/storage/upload")
+        .header(header::AUTHORIZATION, bearer_header("12345", "customer"))
         .header(
             header::CONTENT_TYPE,
             format!("multipart/form-data; boundary={}", boundary),
@@ -698,17 +808,13 @@ async fn test_upload_avatar_invalid_content_type() {
     // Try to upload non-image data as avatar (image decoder will reject it)
     let fake_data = b"This is not an image file at all";
 
-    let (boundary, body) = create_multipart_body_with_fields(
-        "avatar",
-        "fake-avatar.jpg",
-        "image/jpeg",
-        fake_data,
-        &[("user_id", "123")],
-    );
+    let (boundary, body) =
+        create_multipart_body("avatar", "fake-avatar.jpg", "image/jpeg", fake_data);
 
     let request = Request::builder()
         .method("POST")
         .uri("/api/storage/avatar")
+        .header(header::AUTHORIZATION, bearer_header("123", "customer"))
         .header(
             header::CONTENT_TYPE,
             format!("multipart/form-data; boundary={}", boundary),


### PR DESCRIPTION
## Summary

Five backend security findings from the post-deploy audit, in one PR. Four files in `backend-rust/src/`, one test file updated.

### CRITICAL — auth on `/api/storage/*` POST routes
`upload_avatar`, `upload_file`, `upload_slip` were mounted in `public_routes` with no auth middleware. `upload_avatar` additionally read `user_id` from the multipart body — any anonymous caller could overwrite any user's avatar (or fill the disk).

POST routes now require a Bearer token; the avatar handler always saves to `auth_user.id` and silently ignores any `user_id` field in the body. Three new tests cover:
- 401 on missing token (avatar route)
- 401 on missing token (file-upload route)
- spoofed `user_id` body field is ignored in favor of the JWT subject

### HIGH — Redis-backed rate limiter wired up
`RedisRateLimiter` and `redis_rate_limit_middleware` were defined and re-exported but no router ever attached them. `routes::create_router` now instantiates:
- a default limiter (`api` prefix, 100 req/min) layered globally
- a strict limiter (`auth` prefix, 5 req/min) layered onto `auth::routes()`

Limiters only attach in production. Dev/test would otherwise trip the strict threshold with the integration suite hammering `/api/auth/login` from `127.0.0.1`.

### HIGH — Global request body limit (16 MiB)
axum's default body limit is 2 MiB (rejects every legitimate file upload), and `tower-http`'s `limit` feature was enabled but unused. Added `DefaultBodyLimit::max(16 * 1024 * 1024)` in `create_app` — matches `nginx/nginx.conf`'s `client_max_body_size 15M` with a touch of headroom for multipart framing.

### HIGH — JWT middleware no longer falls back to a hard-coded secret
Both `auth_middleware` and `optional_auth_middleware` previously contained:
```rust
.unwrap_or_else(|| std::env::var("JWT_SECRET")
    .unwrap_or_else(|_| "development-secret-change-in-production".to_string()))
```
A routing bug or test misconfig that prevented the `JwtSecret` extension from being injected silently turned production into a deployment that validated tokens signed with that literal string. Both middlewares now refuse to validate without the extension (auth returns 401; optional treats the request as anonymous).

### LOW — Quieter default `RUST_LOG`
Default fallback was `loyalty_backend=debug,tower_http=debug,axum=trace,sqlx=warn`. `axum=trace` logs request bodies and `Authorization` headers if `RUST_LOG` was unset in production. Lowered to `info` across the board; explicit `RUST_LOG=debug` still works for dev.

## Verification
- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo build --release` — clean
- `cargo test --lib --bins` — 358 passed
- `cargo test --test lib storage` — 13 passed (10 existing + 3 new)

## Test plan
- [ ] CI green (CI Tests + CI Build & E2E)
- [ ] Deploy to staging green; verify backend container reports `healthy`
- [ ] Smoke: `curl -X POST https://loyalty-dev.saichon.com/api/storage/avatar -F avatar=@x.png` returns 401 without Authorization header
- [ ] Smoke: same with valid Bearer token returns 200 and avatar URL contains the JWT subject

🤖 Generated with [Claude Code](https://claude.com/claude-code)