### PR TITLE
fix(deploy): drop VITE_API_URL from base compose (build-time only)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,11 @@ services:
     container_name: loyalty_frontend
     environment:
       NODE_ENV: ${NODE_ENV:-development}
-      VITE_API_URL: ${VITE_API_URL:?VITE_API_URL is required}
+      # VITE_API_URL is build-time only (baked into the frontend image during
+      # `docker build` via build-args). It is NOT a runtime env var — the
+      # served bundle already has it resolved. The dev override
+      # (docker-compose.dev.yml) sets VITE_API_URL for the Vite dev server,
+      # which is the only place that reads it at runtime.
     # VOLUMES: Source mounts (./frontend:/app) are in docker-compose.dev.yml ONLY
     # Production uses Docker image contents - no source mount needed
     depends_on:


### PR DESCRIPTION
## Summary

Hotfix for PR #186. The deploy after #186 merged (run [25629799982](https://github.com/thehfhotel/loyalty-app/actions/runs/25629799982)) failed all 5 `docker compose pull` retries with:

```
error while interpolating services.frontend.environment.VITE_API_URL:
required variable VITE_API_URL is missing a value
```

PR #186 correctly dropped \`VITE_API_URL\` from \`docker-compose.{staging,prod}.yml\` (it's build-time only — baked into the frontend image via \`--build-arg\`, not read by the served bundle). It missed \`docker-compose.yml\` (the BASE compose used by every environment), which still had:

\`\`\`yaml
VITE_API_URL: \${VITE_API_URL:?VITE_API_URL is required}
\`\`\`

The \`:?\` syntax fires at compose parse time, so the override emptying the line did NOT save it.

## Fix
Replace the line with a comment explaining VITE_API_URL is build-time only. Local dev still gets the var from \`docker-compose.dev.yml\` (Vite dev server, the only runtime consumer).

## Test plan
- [ ] CI green
- [ ] Post-merge deploy: \`docker compose pull backend frontend\` succeeds
- [ ] staging + production stacks both `healthy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)