### PR TITLE
chore: scrub public-repo credential surface (compose + env + workflow)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,10 +51,6 @@ GOOGLE_CLIENT_ID=your_google_client_id
 GOOGLE_CLIENT_SECRET=your_google_client_secret
 GOOGLE_CALLBACK_URL=http://localhost:5001/api/oauth/google/callback
 
-FACEBOOK_APP_ID=your_facebook_app_id
-FACEBOOK_APP_SECRET=your_facebook_app_secret
-FACEBOOK_CALLBACK_URL=http://localhost:5001/api/oauth/facebook/callback
-
 LINE_CHANNEL_ID=your_line_channel_id
 LINE_CHANNEL_SECRET=your_line_channel_secret
 LINE_CALLBACK_URL=http://localhost:5001/api/oauth/line/callback

--- a/.env.production.example
+++ b/.env.production.example
@@ -20,38 +20,37 @@ TRANSLATION_FEATURE_ENABLED=false
 # DATABASE CONFIGURATION
 # ===========================================
 # These remain as container names for internal Docker communication
-DATABASE_URL=postgresql://loyalty:loyalty_pass@postgres:5432/loyalty_db
+POSTGRES_USER=CHANGE_ME_USER
+POSTGRES_PASSWORD=CHANGE_ME_PASSWORD
+POSTGRES_DB=CHANGE_ME_DB
+DATABASE_URL=postgresql://CHANGE_ME_USER:CHANGE_ME_PASSWORD@postgres:5432/CHANGE_ME_DB
 REDIS_URL=redis://redis:6379
 
 # ===========================================
 # SECURITY SECRETS (PRODUCTION)
 # ===========================================
-# Generate strong random values for production using: openssl rand -base64 32
-JWT_SECRET=production_jwt_secret_here
-JWT_REFRESH_SECRET=production_refresh_secret_here
-SESSION_SECRET=production_session_secret_here
+# Generate strong random values for production using: openssl rand -base64 64
+JWT_SECRET=CHANGE_ME_JWT_SECRET_64_CHAR_MIN_GENERATE_WITH_OPENSSL_RAND_BASE64_64
+JWT_REFRESH_SECRET=CHANGE_ME_JWT_REFRESH_SECRET_64_CHAR_MIN_GENERATE_WITH_OPENSSL
+SESSION_SECRET=CHANGE_ME_SESSION_SECRET_64_CHAR_MIN_GENERATE_WITH_OPENSSL_RAND
 
 # ===========================================
 # OAUTH CONFIGURATION (PRODUCTION)
 # ===========================================
 # Update these in your OAuth provider consoles with production domain
-GOOGLE_CLIENT_ID=your_production_google_client_id
-GOOGLE_CLIENT_SECRET=your_production_google_client_secret
+GOOGLE_CLIENT_ID=CHANGE_ME_GOOGLE_CLIENT_ID
+GOOGLE_CLIENT_SECRET=CHANGE_ME_GOOGLE_CLIENT_SECRET
 GOOGLE_CALLBACK_URL=https://your-domain.com/api/oauth/google/callback
 
-FACEBOOK_APP_ID=your_production_facebook_app_id
-FACEBOOK_APP_SECRET=your_production_facebook_app_secret
-FACEBOOK_CALLBACK_URL=https://your-domain.com/api/oauth/facebook/callback
-
-LINE_CHANNEL_ID=your_production_line_channel_id
-LINE_CHANNEL_SECRET=your_production_line_channel_secret
+LINE_CHANNEL_ID=CHANGE_ME_LINE_CHANNEL_ID
+LINE_CHANNEL_SECRET=CHANGE_ME_LINE_CHANNEL_SECRET
 LINE_CALLBACK_URL=https://your-domain.com/api/oauth/line/callback
 
 # ===========================================
 # ADMIN USER CONFIGURATION
 # ===========================================
-LOYALTY_USERNAME=your_admin_email@domain.com
-LOYALTY_PASSWORD=your_secure_admin_password
+LOYALTY_USERNAME=CHANGE_ME_admin@your-domain.com
+LOYALTY_PASSWORD=CHANGE_ME_ADMIN_PASSWORD
 
 # ===========================================
 # PRODUCTION SETTINGS

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,16 +67,6 @@ jobs:
   # DEPLOY TO STAGING (no approval needed)
   # =============================================================================
 
-  # ---------------------------------------------------------------------------
-  # Phase-1 deploy pattern (mirrors new-hotel / payroll / host-metrics-pusher):
-  # GH-hosted ubuntu-latest installs cloudflared + the per-env SSH key, then
-  # SSHes to deploy@evergreen.thehfhotel.org through the asgard cloudflared
-  # tunnel. The SSH key in /home/deploy/.ssh/authorized_keys is forced-command
-  # pinned to /srv/run-deploy-loyalty-app-{staging,production}.sh — no other
-  # commands are reachable. The shim takes a JSON payload on stdin (commit_sha,
-  # base64 tarball of compose + nginx.conf, ghcr token, env), writes a 0600
-  # .env, runs `docker compose pull && up -d`, and verifies /api/health.
-  # ---------------------------------------------------------------------------
   deploy-staging:
     name: "Deploy to Staging"
     runs-on: ubuntu-latest

--- a/backend-rust/.env.example
+++ b/backend-rust/.env.example
@@ -24,14 +24,14 @@ LINE_CLIENT_SECRET=your_line_client_secret
 LINE_REDIRECT_URI=http://localhost:4000/api/auth/line/callback
 
 # Email Service (SMTP)
-SMTP_HOST=smtp.privateemail.com
+SMTP_HOST=smtp.your-email-provider.com
 SMTP_PORT=465
 SMTP_USER=noreply@yourdomain.com
 SMTP_PASS=your_password
 SMTP_FROM="Loyalty App <noreply@yourdomain.com>"
 
 # Email Service (IMAP)
-IMAP_HOST=mail.privateemail.com
+IMAP_HOST=mail.your-email-provider.com
 IMAP_PORT=993
 IMAP_USER=noreply@yourdomain.com
 IMAP_PASS=your_password

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -12,7 +12,7 @@ use tokio::net::TcpListener;
 use tower_http::compression::CompressionLayer;
 use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::{self, TraceLayer};
-use tracing::{error, info, Level};
+use tracing::{error, info, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 /// Global request body limit. 16 MiB matches `client_max_body_size 15M` in
@@ -60,6 +60,13 @@ async fn main() -> anyhow::Result<()> {
         log_level = %config.server.log_level,
         "Configuration loaded"
     );
+
+    // Refuse to boot in production with well-known development credentials.
+    // In dev/staging this only emits a warning so iteration is unblocked.
+    if let Err(e) = enforce_safe_database_url(&config.database.url, &config.environment) {
+        error!("Refusing to start: {}", e);
+        return Err(e);
+    }
 
     // Connect to database with configured connection pool settings
     info!("Connecting to PostgreSQL...");
@@ -249,5 +256,175 @@ fn build_cors_layer(config: &Settings) -> tower_http::cors::CorsLayer {
     } else {
         // In production/staging, use the configured CORS layer
         cors_layer()
+    }
+}
+
+/// Well-known development/example credentials that must never reach production.
+///
+/// Each entry is a substring search against `DATABASE_URL`. Centralized so the
+/// guard and its unit tests share a single source of truth.
+const FORBIDDEN_DB_CREDENTIAL_PATTERNS: &[&str] = &[
+    "loyalty:loyalty_pass",
+    "loyalty_dev:loyalty_dev_pass",
+    "CHANGE_ME_PASSWORD",
+    "CHANGE_ME_USER",
+    "password@",
+    ":password:",
+];
+
+/// Reject boot when `DATABASE_URL` matches a well-known dev/example credential
+/// pattern in production. In non-production environments this only warns.
+///
+/// Catches:
+/// - The legacy `loyalty:loyalty_pass` literal that the base compose file used
+///   to bake into the backend container.
+/// - The dev compose's `loyalty_dev:loyalty_dev_pass` placeholder.
+/// - The `CHANGE_ME_*` placeholders shipped in `.env.production.example`.
+/// - Trivial `password` user/secret choices (`password@` and `:password:`).
+/// - An empty password segment (e.g. `postgres://user:@host/db`).
+fn enforce_safe_database_url(
+    database_url: &str,
+    environment: &Environment,
+) -> anyhow::Result<()> {
+    let matched_pattern = forbidden_pattern_match(database_url);
+
+    let Some(pattern) = matched_pattern else {
+        return Ok(());
+    };
+
+    if matches!(environment, Environment::Production) {
+        return Err(anyhow::anyhow!(
+            "DATABASE_URL contains a forbidden development credential pattern \
+             ({pattern:?}); refusing to start in production. Rotate the database \
+             password and update the deploy secret before retrying."
+        ));
+    }
+
+    warn!(
+        pattern = pattern,
+        environment = %environment,
+        "DATABASE_URL contains a development credential pattern. \
+         This will refuse-to-boot in production."
+    );
+    Ok(())
+}
+
+/// Returns the first forbidden pattern matched by `database_url`, if any.
+fn forbidden_pattern_match(database_url: &str) -> Option<&'static str> {
+    for pattern in FORBIDDEN_DB_CREDENTIAL_PATTERNS {
+        if database_url.contains(pattern) {
+            return Some(pattern);
+        }
+    }
+    if has_empty_password_segment(database_url) {
+        return Some("<empty-password>");
+    }
+    None
+}
+
+/// Detects URLs of the form `scheme://user:@host/...` (empty password segment).
+fn has_empty_password_segment(database_url: &str) -> bool {
+    let Some(after_scheme) = database_url.split_once("://").map(|(_, rest)| rest) else {
+        return false;
+    };
+    let Some(authority) = after_scheme.split('@').next() else {
+        return false;
+    };
+    // Authority is `user:password` if creds are present. Skip URLs without creds.
+    let Some((_user, password)) = authority.split_once(':') else {
+        return false;
+    };
+    // True empty password is `user:` with nothing between `:` and `@`.
+    password.is_empty() && after_scheme.contains('@')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enforce_safe_database_url_rejects_legacy_loyalty_pass_in_production() {
+        let url = "postgresql://loyalty:loyalty_pass@postgres:5432/loyalty_db";
+        let err = enforce_safe_database_url(url, &Environment::Production)
+            .expect_err("should refuse legacy loyalty_pass in production");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("loyalty:loyalty_pass"),
+            "error should mention the matched pattern: {msg}"
+        );
+    }
+
+    #[test]
+    fn enforce_safe_database_url_rejects_dev_creds_in_production() {
+        let url = "postgresql://loyalty_dev:loyalty_dev_pass@postgres:5432/loyalty_dev_db";
+        assert!(enforce_safe_database_url(url, &Environment::Production).is_err());
+    }
+
+    #[test]
+    fn enforce_safe_database_url_rejects_change_me_password_in_production() {
+        let url = "postgresql://prod_user:CHANGE_ME_PASSWORD@postgres:5432/prod_db";
+        assert!(enforce_safe_database_url(url, &Environment::Production).is_err());
+    }
+
+    #[test]
+    fn enforce_safe_database_url_rejects_literal_password_creds_in_production() {
+        let url = "postgresql://admin:password@postgres:5432/prod_db";
+        // matches `password@`
+        assert!(enforce_safe_database_url(url, &Environment::Production).is_err());
+    }
+
+    #[test]
+    fn enforce_safe_database_url_rejects_password_in_path_in_production() {
+        let url = "postgresql://admin:password:extra@postgres:5432/db";
+        // matches `:password:`
+        assert!(enforce_safe_database_url(url, &Environment::Production).is_err());
+    }
+
+    #[test]
+    fn enforce_safe_database_url_rejects_empty_password_segment_in_production() {
+        let url = "postgresql://admin:@postgres:5432/db";
+        let err = enforce_safe_database_url(url, &Environment::Production)
+            .expect_err("should refuse empty password in production");
+        assert!(err.to_string().contains("empty-password"));
+    }
+
+    #[test]
+    fn enforce_safe_database_url_warns_in_development() {
+        let url = "postgresql://loyalty_dev:loyalty_dev_pass@postgres:5432/loyalty_dev_db";
+        // Dev should warn, not refuse.
+        assert!(enforce_safe_database_url(url, &Environment::Development).is_ok());
+    }
+
+    #[test]
+    fn enforce_safe_database_url_warns_in_staging() {
+        let url = "postgresql://loyalty_dev:loyalty_dev_pass@postgres:5432/loyalty_dev_db";
+        // Staging is treated as non-production (per task spec) — warn only.
+        assert!(enforce_safe_database_url(url, &Environment::Staging).is_ok());
+    }
+
+    #[test]
+    fn enforce_safe_database_url_accepts_strong_creds_in_production() {
+        let url =
+            "postgresql://prod_user_28a:F8q!7vXr2sH9pZdL3kN@db.internal:5432/loyalty_prod_db";
+        assert!(enforce_safe_database_url(url, &Environment::Production).is_ok());
+    }
+
+    #[test]
+    fn has_empty_password_segment_detects_empty_password() {
+        assert!(has_empty_password_segment(
+            "postgresql://user:@host:5432/db"
+        ));
+    }
+
+    #[test]
+    fn has_empty_password_segment_ignores_filled_password() {
+        assert!(!has_empty_password_segment(
+            "postgresql://user:strongpw@host:5432/db"
+        ));
+    }
+
+    #[test]
+    fn has_empty_password_segment_ignores_url_without_creds() {
+        assert!(!has_empty_password_segment("postgresql://host:5432/db"));
     }
 }

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -282,10 +282,7 @@ const FORBIDDEN_DB_CREDENTIAL_PATTERNS: &[&str] = &[
 /// - The `CHANGE_ME_*` placeholders shipped in `.env.production.example`.
 /// - Trivial `password` user/secret choices (`password@` and `:password:`).
 /// - An empty password segment (e.g. `postgres://user:@host/db`).
-fn enforce_safe_database_url(
-    database_url: &str,
-    environment: &Environment,
-) -> anyhow::Result<()> {
+fn enforce_safe_database_url(database_url: &str, environment: &Environment) -> anyhow::Result<()> {
     let matched_pattern = forbidden_pattern_match(database_url);
 
     let Some(pattern) = matched_pattern else {
@@ -404,8 +401,7 @@ mod tests {
 
     #[test]
     fn enforce_safe_database_url_accepts_strong_creds_in_production() {
-        let url =
-            "postgresql://prod_user_28a:F8q!7vXr2sH9pZdL3kN@db.internal:5432/loyalty_prod_db";
+        let url = "postgresql://prod_user_28a:F8q!7vXr2sH9pZdL3kN@db.internal:5432/loyalty_prod_db";
         assert!(enforce_safe_database_url(url, &Environment::Production).is_ok());
     }
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,8 @@ services:
       - .env.development
     ports:
       - "5435:5432"  # Dev port 5435 (prod uses 5434)
+    # Dev-only credentials. NOT used in staging or production
+    # (those are env-driven from GitHub Actions secrets).
     environment:
       POSTGRES_USER: loyalty_dev
       POSTGRES_PASSWORD: loyalty_dev_pass
@@ -42,6 +44,8 @@ services:
       RUST_ENV: development
       NODE_ENV: development
       PORT: ${BACKEND_PORT:-4001}
+      # Dev-only credentials. NOT used in staging or production
+      # (those are env-driven from GitHub Actions secrets).
       DATABASE_URL: postgresql://loyalty_dev:loyalty_dev_pass@postgres:5432/loyalty_dev_db
       REDIS_URL: redis://redis:6379
       JWT_SECRET: ${JWT_SECRET}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -39,7 +39,7 @@ services:
       RUST_ENV: staging
       NODE_ENV: staging
       PORT: ${BACKEND_PORT:-4001}
-      DATABASE_URL: postgresql://loyalty_dev:loyalty_dev_pass@postgres:5432/loyalty_dev_db
+      DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required}
       REDIS_URL: redis://redis:6379
       JWT_SECRET: ${JWT_SECRET}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       RUST_ENV: ${RUST_ENV:-development}
       NODE_ENV: ${NODE_ENV:-development}
       PORT: ${BACKEND_PORT:-4001}
-      DATABASE_URL: postgresql://loyalty:loyalty_pass@postgres:5432/loyalty_db
+      DATABASE_URL: ${DATABASE_URL:?DATABASE_URL is required}
       REDIS_URL: redis://redis:6379
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET:?JWT_REFRESH_SECRET is required}


### PR DESCRIPTION
## Summary

The repo just went public; this PR scrubs the operational-secret surface across compose files, env templates, and the deploy workflow, and adds a Rust startup guard that refuses to boot production with well-known development credentials.

## Changes by file

| File | Change |
|---|---|
| `docker-compose.yml` | Replace literal `DATABASE_URL=postgresql://loyalty:loyalty_pass@...` with `${DATABASE_URL:?DATABASE_URL is required}`. Prevents a fresh prod volume from initializing with the demo credential pair. |
| `docker-compose.staging.yml` | Replace literal `loyalty_dev:loyalty_dev_pass@...` with `${DATABASE_URL:?DATABASE_URL is required}`. The deploy workflow already composes `DATABASE_URL` from `POSTGRES_USER + POSTGRES_PASSWORD + POSTGRES_DB` via `jq`. |
| `docker-compose.dev.yml` | Keep `loyalty_dev:loyalty_dev_pass` literals (local dev only) but add comment blocks marking them dev-only and clarifying that staging/prod use Actions secrets. |
| `.env.production.example` | Replace every functional-looking secret value (DB url, Postgres user/pass/db, JWT/refresh/session secrets, OAuth client_id/secret, admin user/pass) with `CHANGE_ME_*` placeholders. Drop Facebook OAuth lines (provider was already removed). |
| `.env.example` | Drop `FACEBOOK_APP_ID/SECRET/CALLBACK_URL`. |
| `backend-rust/.env.example` | Replace `smtp.privateemail.com` / `mail.privateemail.com` (Namecheap-specific hostnames) with provider-neutral `smtp.your-email-provider.com` / `mail.your-email-provider.com`. |
| `.github/workflows/deploy.yml` | Delete the multi-line comment block (lines 70-79) that documented the SSH/cloudflared deploy contract: login user, shim path, forced-command pinning, JSON payload schema, .env file mode, post-deploy verification path, and named the three sibling internal services. |
| `backend-rust/src/main.rs` | New `enforce_safe_database_url()` boot guard. In production, refuses to start if `DATABASE_URL` matches `loyalty:loyalty_pass`, `loyalty_dev:loyalty_dev_pass`, `CHANGE_ME_PASSWORD`, `CHANGE_ME_USER`, `password@`, `:password:`, or has an empty password segment. In dev/staging, only emits a `tracing::warn`. Includes 11 unit tests. |

## Workflow comment block: before / after

**Before** (lines 66-80):

\`\`\`yaml
  # =============================================================================
  # DEPLOY TO STAGING (no approval needed)
  # =============================================================================

  # ---------------------------------------------------------------------------
  # Phase-1 deploy pattern (mirrors new-hotel / payroll / host-metrics-pusher):
  # GH-hosted ubuntu-latest installs cloudflared + the per-env SSH key, then
  # SSHes to deploy@evergreen.thehfhotel.org through the asgard cloudflared
  # tunnel. The SSH key in /home/deploy/.ssh/authorized_keys is forced-command
  # pinned to /srv/run-deploy-loyalty-app-{staging,production}.sh — no other
  # commands are reachable. The shim takes a JSON payload on stdin (commit_sha,
  # base64 tarball of compose + nginx.conf, ghcr token, env), writes a 0600
  # .env, runs \`docker compose pull && up -d\`, and verifies /api/health.
  # ---------------------------------------------------------------------------
  deploy-staging:
\`\`\`

**After**:

\`\`\`yaml
  # =============================================================================
  # DEPLOY TO STAGING (no approval needed)
  # =============================================================================

  deploy-staging:
\`\`\`

The actual workflow steps below the deleted block are unchanged and still execute identically.

## Operational risk: production may refuse to boot after merge

The `enforce_safe_database_url` guard is intentionally aggressive. **If the live production `DATABASE_URL` happens to match any of these patterns, the next deploy will refuse to start.** That is by design — the guard is meant to surface accidental dev creds before they reach a public-facing service.

**Action before merge:** confirm prod `DATABASE_URL` does NOT contain `loyalty:loyalty_pass`, `loyalty_dev:loyalty_dev_pass`, `CHANGE_ME_PASSWORD`, `CHANGE_ME_USER`, `password@`, or `:password:`, and is not of the form `postgres://user:@host/db`. If any match, rotate the DB password and update the GitHub Actions secret BEFORE merging.

## Test plan

- [ ] CI Tests workflow runs `cargo test` and exercises the 11 new unit tests in `backend-rust/src/main.rs::tests`
- [ ] CI Build workflow validates Rust compilation
- [ ] Manual: confirm `docker compose -f docker-compose.yml up` errors with `DATABASE_URL is required` when `.env` is missing the value
- [ ] Manual: confirm `docker compose -f docker-compose.yml -f docker-compose.dev.yml up` still works (dev compose injects creds inline)
- [ ] Manual (pre-merge): verify production `DATABASE_URL` secret won't trigger the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)