### PR TITLE
fix(security): use GitHub private advisories + real email contact

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,10 @@
 
 ## Reporting a vulnerability
 
-If you discover a vulnerability, please email **security@thehfhotel.com**.
-<!-- TODO: confirm this is the correct disclosure address; replace if a dedicated security@ inbox does not yet exist. -->
+If you discover a vulnerability, please use one of the following private channels:
+
+- **GitHub Security Advisories** (preferred): open a private report at <https://github.com/thehfhotel/loyalty-app/security/advisories/new>. This requires a GitHub account but is the most reliable channel — reports are visible only to maintainers and you can collaborate on the fix in a private fork.
+- **Email**: <winut.hf@gmail.com>. Slower, but works without a GitHub account.
 
 Do **not** file a public issue, pull request, or discussion thread.
 


### PR DESCRIPTION
## Summary

The `security@thehfhotel.com` placeholder address in SECURITY.md (added by PR #196) doesn't actually exist as an inbox. Replace with two real private channels:

1. **GitHub Security Advisories** (preferred) — built-in private reporting, no email infrastructure needed
2. **Email** (fallback) — `winut.hf@gmail.com` (already public via git commit metadata)

Also enabled GitHub's private vulnerability reporting feature on the repo via the API so the advisory link actually works.

## Test plan

- [ ] CI green
- [ ] Visit https://github.com/thehfhotel/loyalty-app/security/advisories/new — should show the report-a-vulnerability form (proves private reporting is enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)