### PR TITLE
feat(admin): implement top 5 endpoints from gaps doc

### DIFF
--- a/backend-rust/src/routes/admin.rs
+++ b/backend-rust/src/routes/admin.rs
@@ -1260,6 +1260,10 @@ pub fn router() -> Router<AppState> {
         .route("/new-member-coupon-settings", get(get_new_member_coupon_settings))
         .route("/new-member-coupon-settings", put(update_new_member_coupon_settings))
         .route("/coupon-status/:couponId", get(get_coupon_status))
+        // Room/room-type/blocked-dates admin endpoints live in a sibling
+        // module to keep this file from growing further. Merge before the
+        // auth layer so `auth_middleware` covers the merged routes too.
+        .merge(crate::routes::admin_rooms::router())
         // Apply auth middleware to all routes
         .layer(middleware::from_fn(auth_middleware))
 }

--- a/backend-rust/src/routes/admin_rooms.rs
+++ b/backend-rust/src/routes/admin_rooms.rs
@@ -1,0 +1,608 @@
+//! Admin room/room-type/blocked-dates routes
+//!
+//! Provides admin-only endpoints for room inventory and calendar availability:
+//! - `GET    /api/admin/room-types`            — list room types
+//! - `GET    /api/admin/rooms`                 — list physical rooms (filterable by room type)
+//! - `GET    /api/admin/blocked-dates`         — list blocked dates in a date range
+//! - `POST   /api/admin/blocked-dates`         — block one or more dates for a room
+//! - `DELETE /api/admin/blocked-dates`         — unblock one or more dates for a room
+//!
+//! All routes require admin authentication. The router returned by
+//! [`router`] is intended to be `.merge(...)`d into the parent admin router
+//! defined in [`crate::routes::admin`], which applies `auth_middleware` once
+//! to the merged result.
+//!
+//! ## Schema notes
+//!
+//! These handlers operate on the existing `room_types`, `rooms`, and
+//! `room_blocked_dates` tables. The frontend's TypeScript interfaces include
+//! a few fields that are not present in the current schema (e.g.
+//! `room_types.bedType / amenities / images / sortOrder`,
+//! `rooms.notes`, `room_blocked_dates.created_by`). We omit those from the
+//! response rather than adding columns; the frontend already treats them as
+//! optional and renders gracefully when they are absent. Adding those
+//! columns is a separate, schema-bearing change tracked in
+//! `docs/admin-backend-gaps.md`.
+//!
+//! ## sqlx note
+//!
+//! These handlers use **runtime** `sqlx::query()` / `sqlx::query_as()` rather
+//! than the compile-time `query!()` macros. The macros require regenerating
+//! `.sqlx/` against a live database (`cargo sqlx prepare`), which is not
+//! available in this worktree. Runtime queries are still parameterised, so
+//! injection-safe. CI's `cargo sqlx prepare --check` only validates entries
+//! that already exist in the cache — it does not require new ones.
+
+use axum::{
+    extract::{Extension, Path, Query, State},
+    routing::{delete, get, post},
+    Json, Router,
+};
+use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::error::{AppError, AppResult};
+use crate::middleware::auth::{has_role, AuthUser};
+use crate::state::AppState;
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/// Reject the request unless the caller has the `admin` role (or higher).
+///
+/// Mirrors `routes::admin::require_admin`; duplicated here so this module is
+/// independent and the parent file does not need to re-export private helpers.
+fn require_admin(user: &AuthUser) -> AppResult<()> {
+    if !has_role(user, "admin") {
+        return Err(AppError::Forbidden("Admin access required".to_string()));
+    }
+    Ok(())
+}
+
+// ============================================================================
+// DTOs — Room Types
+// ============================================================================
+
+/// Query params for `GET /room-types`. The frontend always wants every row
+/// (active and inactive) for the management page but only active ones for
+/// dropdowns. Default: include inactive (matches the management page's
+/// query key `{ includeInactive: true }`); set `?include_inactive=false`
+/// to filter to active rows only.
+#[derive(Debug, Deserialize)]
+pub struct ListRoomTypesQuery {
+    #[serde(default = "default_true")]
+    pub include_inactive: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomTypeResponse {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    /// Stored as `DECIMAL(10,2)` — serialised as a JSON number with two
+    /// decimal places by `rust_decimal`'s serde impl.
+    #[serde(rename = "pricePerNight")]
+    pub price_per_night: Decimal,
+    #[serde(rename = "maxGuests")]
+    pub max_guests: i32,
+    #[serde(rename = "isActive")]
+    pub is_active: bool,
+    #[serde(rename = "createdAt")]
+    pub created_at: DateTime<Utc>,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Row representation matching the `room_types` schema.
+#[derive(Debug, sqlx::FromRow)]
+struct RoomTypeRow {
+    id: Uuid,
+    name: String,
+    description: Option<String>,
+    price_per_night: Decimal,
+    max_guests: i32,
+    is_active: bool,
+    // The schema defines these with `DEFAULT NOW()` but no `NOT NULL`, so
+    // sqlx infers them as nullable. Fall back to `Utc::now()` in the
+    // response if a row somehow has NULLs.
+    created_at: Option<DateTime<Utc>>,
+    updated_at: Option<DateTime<Utc>>,
+}
+
+impl From<RoomTypeRow> for RoomTypeResponse {
+    fn from(row: RoomTypeRow) -> Self {
+        Self {
+            id: row.id,
+            name: row.name,
+            description: row.description,
+            price_per_night: row.price_per_night,
+            max_guests: row.max_guests,
+            is_active: row.is_active,
+            created_at: row.created_at.unwrap_or_else(Utc::now),
+            updated_at: row.updated_at.unwrap_or_else(Utc::now),
+        }
+    }
+}
+
+// ============================================================================
+// DTOs — Rooms
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct ListRoomsQuery {
+    /// Filter by room type. Frontend sends this from the RoomAvailability
+    /// page when an admin selects a specific room type.
+    #[serde(rename = "roomTypeId")]
+    pub room_type_id: Option<Uuid>,
+    /// Whether to include `is_active = false` rows. Default true (matches
+    /// the management page).
+    #[serde(default = "default_true", rename = "includeInactive")]
+    pub include_inactive: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomResponse {
+    pub id: Uuid,
+    #[serde(rename = "roomTypeId")]
+    pub room_type_id: Uuid,
+    #[serde(rename = "roomNumber")]
+    pub room_number: String,
+    pub floor: Option<i32>,
+    #[serde(rename = "isActive")]
+    pub is_active: bool,
+    #[serde(rename = "createdAt")]
+    pub created_at: DateTime<Utc>,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: DateTime<Utc>,
+    /// Embedded room-type summary so the management table can show the type
+    /// name without a second roundtrip. The frontend already treats this as
+    /// optional (`room.roomType?.name`).
+    #[serde(rename = "roomType", skip_serializing_if = "Option::is_none")]
+    pub room_type: Option<RoomTypeSummary>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RoomTypeSummary {
+    pub id: Uuid,
+    pub name: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct RoomRow {
+    id: Uuid,
+    room_type_id: Uuid,
+    room_number: String,
+    floor: Option<i32>,
+    is_active: bool,
+    created_at: Option<DateTime<Utc>>,
+    updated_at: Option<DateTime<Utc>>,
+    rt_name: Option<String>,
+}
+
+impl From<RoomRow> for RoomResponse {
+    fn from(row: RoomRow) -> Self {
+        let room_type = row.rt_name.map(|name| RoomTypeSummary {
+            id: row.room_type_id,
+            name,
+        });
+        Self {
+            id: row.id,
+            room_type_id: row.room_type_id,
+            room_number: row.room_number,
+            floor: row.floor,
+            is_active: row.is_active,
+            created_at: row.created_at.unwrap_or_else(Utc::now),
+            updated_at: row.updated_at.unwrap_or_else(Utc::now),
+            room_type,
+        }
+    }
+}
+
+// ============================================================================
+// DTOs — Blocked Dates
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub struct ListBlockedDatesQuery {
+    /// Inclusive start of the date range. Defaults to "today" when omitted.
+    #[serde(rename = "startDate")]
+    pub start_date: Option<NaiveDate>,
+    /// Inclusive end of the date range. Defaults to start + 31 days when
+    /// omitted.
+    #[serde(rename = "endDate")]
+    pub end_date: Option<NaiveDate>,
+    /// Restrict to rooms of a particular room type — useful when the
+    /// availability calendar is filtered.
+    #[serde(rename = "roomTypeId")]
+    pub room_type_id: Option<Uuid>,
+}
+
+/// One blocked date entry returned to the frontend. Shape mirrors the
+/// `BlockedDateItem` interface in `RoomAvailability.tsx`.
+#[derive(Debug, Serialize)]
+pub struct BlockedDateItem {
+    pub id: Uuid,
+    #[serde(rename = "roomId")]
+    pub room_id: Uuid,
+    #[serde(rename = "blockedDate")]
+    pub blocked_date: NaiveDate,
+    pub reason: Option<String>,
+    #[serde(rename = "createdAt")]
+    pub created_at: DateTime<Utc>,
+    /// Schema does not currently track who created the block; always
+    /// `null`. Frontend already handles this as optional.
+    #[serde(rename = "createdBy")]
+    pub created_by: Option<Uuid>,
+}
+
+/// Grouped-by-room response shape — matches `RoomBlockedDates` in the
+/// frontend (`{ roomId, roomNumber, dates: [...] }`).
+#[derive(Debug, Serialize)]
+pub struct RoomBlockedDatesGroup {
+    #[serde(rename = "roomId")]
+    pub room_id: Uuid,
+    #[serde(rename = "roomNumber")]
+    pub room_number: String,
+    pub dates: Vec<BlockedDateItem>,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct BlockedDateRow {
+    id: Uuid,
+    room_id: Uuid,
+    room_number: String,
+    blocked_date: NaiveDate,
+    reason: Option<String>,
+    created_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BlockDatesRequest {
+    #[serde(rename = "roomId")]
+    pub room_id: Uuid,
+    /// One or more dates to block. The frontend sends the dates the admin
+    /// dragged-selected on the calendar.
+    pub dates: Vec<NaiveDate>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UnblockDatesRequest {
+    #[serde(rename = "roomId")]
+    pub room_id: Uuid,
+    pub dates: Vec<NaiveDate>,
+}
+
+// ============================================================================
+// Handlers — Room Types
+// ============================================================================
+
+/// `GET /api/admin/room-types`
+///
+/// Returns all room types ordered by name. When `include_inactive=false`
+/// only `is_active=true` rows are returned.
+async fn list_room_types(
+    Extension(user): Extension<AuthUser>,
+    State(state): State<AppState>,
+    Query(query): Query<ListRoomTypesQuery>,
+) -> AppResult<Json<Vec<RoomTypeResponse>>> {
+    require_admin(&user)?;
+
+    let sql = if query.include_inactive {
+        r#"
+        SELECT id, name, description, price_per_night, max_guests, is_active,
+               created_at, updated_at
+          FROM room_types
+         ORDER BY LOWER(name) ASC
+        "#
+    } else {
+        r#"
+        SELECT id, name, description, price_per_night, max_guests, is_active,
+               created_at, updated_at
+          FROM room_types
+         WHERE is_active = TRUE
+         ORDER BY LOWER(name) ASC
+        "#
+    };
+
+    let rows: Vec<RoomTypeRow> = sqlx::query_as(sql).fetch_all(state.db()).await?;
+
+    Ok(Json(rows.into_iter().map(RoomTypeResponse::from).collect()))
+}
+
+// ============================================================================
+// Handlers — Rooms
+// ============================================================================
+
+/// `GET /api/admin/rooms`
+///
+/// Returns all rooms (joined with their room type for the `roomType.name`
+/// field the frontend wants), optionally filtered by `roomTypeId` and
+/// active flag. Ordered by room number for stable display.
+async fn list_rooms(
+    Extension(user): Extension<AuthUser>,
+    State(state): State<AppState>,
+    Query(query): Query<ListRoomsQuery>,
+) -> AppResult<Json<Vec<RoomResponse>>> {
+    require_admin(&user)?;
+
+    // We build the SQL once with two optional WHERE clauses. Using runtime
+    // `query_as` lets us conditionally bind only the args that are present.
+    let mut sql = String::from(
+        r#"
+        SELECT r.id, r.room_type_id, r.room_number, r.floor, r.is_active,
+               r.created_at, r.updated_at,
+               rt.name AS rt_name
+          FROM rooms r
+          JOIN room_types rt ON rt.id = r.room_type_id
+         WHERE 1 = 1
+        "#,
+    );
+
+    let mut next_param: usize = 1;
+    if query.room_type_id.is_some() {
+        sql.push_str(&format!(" AND r.room_type_id = ${}", next_param));
+        next_param += 1;
+    }
+    if !query.include_inactive {
+        sql.push_str(&format!(" AND r.is_active = ${}", next_param));
+        next_param += 1;
+    }
+    // Order by numeric prefix when possible (so "10" sorts after "9"), then
+    // the raw string. Postgres' natural string sort would put "10" before
+    // "2"; using a substring cast handles common pure-numeric room numbers.
+    sql.push_str(" ORDER BY LENGTH(r.room_number), r.room_number ASC");
+    // Silence the "value assigned but never read" lint on the final
+    // increment — the counter is structural so future filter additions are
+    // a one-line change.
+    let _ = next_param;
+
+    let mut q = sqlx::query_as::<_, RoomRow>(&sql);
+    if let Some(rt_id) = query.room_type_id {
+        q = q.bind(rt_id);
+    }
+    if !query.include_inactive {
+        q = q.bind(true);
+    }
+
+    let rows: Vec<RoomRow> = q.fetch_all(state.db()).await?;
+    Ok(Json(rows.into_iter().map(RoomResponse::from).collect()))
+}
+
+// ============================================================================
+// Handlers — Blocked Dates
+// ============================================================================
+
+/// `GET /api/admin/blocked-dates`
+///
+/// Returns blocked dates for the requested range (default: today + 31
+/// days), grouped by room. The frontend's `RoomAvailability.tsx` consumes
+/// this exact shape (`Array<{ roomId, roomNumber, dates: [...] }>`).
+///
+/// When `roomTypeId` is supplied, only blocks for rooms of that type are
+/// returned.
+async fn list_blocked_dates(
+    Extension(user): Extension<AuthUser>,
+    State(state): State<AppState>,
+    Query(query): Query<ListBlockedDatesQuery>,
+) -> AppResult<Json<Vec<RoomBlockedDatesGroup>>> {
+    require_admin(&user)?;
+
+    let start = query.start_date.unwrap_or_else(|| Utc::now().date_naive());
+    let end = query
+        .end_date
+        .unwrap_or_else(|| start + chrono::Duration::days(31));
+
+    if end < start {
+        return Err(AppError::BadRequest(
+            "endDate must be on or after startDate".to_string(),
+        ));
+    }
+
+    let mut sql = String::from(
+        r#"
+        SELECT bd.id, bd.room_id, r.room_number, bd.blocked_date,
+               bd.reason, bd.created_at
+          FROM room_blocked_dates bd
+          JOIN rooms r ON r.id = bd.room_id
+         WHERE bd.blocked_date >= $1 AND bd.blocked_date <= $2
+        "#,
+    );
+
+    if query.room_type_id.is_some() {
+        sql.push_str(" AND r.room_type_id = $3");
+    }
+    sql.push_str(" ORDER BY r.room_number ASC, bd.blocked_date ASC");
+
+    let mut q = sqlx::query_as::<_, BlockedDateRow>(&sql)
+        .bind(start)
+        .bind(end);
+    if let Some(rt_id) = query.room_type_id {
+        q = q.bind(rt_id);
+    }
+
+    let rows: Vec<BlockedDateRow> = q.fetch_all(state.db()).await?;
+
+    // Group rows by room so the frontend can iterate roomId → dates[]
+    // directly. We use a Vec rather than a HashMap to preserve the
+    // ORDER BY room_number ordering.
+    let mut groups: Vec<RoomBlockedDatesGroup> = Vec::new();
+    for row in rows {
+        let item = BlockedDateItem {
+            id: row.id,
+            room_id: row.room_id,
+            blocked_date: row.blocked_date,
+            reason: row.reason,
+            created_at: row.created_at.unwrap_or_else(Utc::now),
+            created_by: None,
+        };
+        match groups.last_mut() {
+            Some(g) if g.room_id == row.room_id => g.dates.push(item),
+            _ => groups.push(RoomBlockedDatesGroup {
+                room_id: row.room_id,
+                room_number: row.room_number,
+                dates: vec![item],
+            }),
+        }
+    }
+
+    Ok(Json(groups))
+}
+
+/// `POST /api/admin/blocked-dates`
+///
+/// Block one or more dates for a room. Idempotent: re-blocking an already
+/// blocked date is a no-op (`ON CONFLICT DO NOTHING` against the
+/// `(room_id, blocked_date)` unique key).
+///
+/// Returns the rows that were actually inserted (existing blocks are
+/// excluded, mirroring INSERT...RETURNING semantics with ON CONFLICT).
+async fn block_dates(
+    Extension(user): Extension<AuthUser>,
+    State(state): State<AppState>,
+    Json(payload): Json<BlockDatesRequest>,
+) -> AppResult<Json<Vec<BlockedDateItem>>> {
+    require_admin(&user)?;
+
+    if payload.dates.is_empty() {
+        return Err(AppError::BadRequest(
+            "At least one date is required".to_string(),
+        ));
+    }
+
+    // Verify the room exists. A missing room would also fail the FK
+    // constraint, but explicit-then-friendly is nicer for the admin UI.
+    let room_exists: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM rooms WHERE id = $1")
+        .bind(payload.room_id)
+        .fetch_optional(state.db())
+        .await?;
+    if room_exists.is_none() {
+        return Err(AppError::NotFound("Room".to_string()));
+    }
+
+    // Bulk insert via UNNEST so a single round-trip handles N dates.
+    // ON CONFLICT collapses duplicates; RETURNING gives us back only the
+    // rows we actually created.
+    let inserted: Vec<(Uuid, NaiveDate, Option<DateTime<Utc>>)> = sqlx::query_as(
+        r#"
+        INSERT INTO room_blocked_dates (room_id, blocked_date, reason)
+        SELECT $1, d, $3
+          FROM UNNEST($2::date[]) AS d
+        ON CONFLICT (room_id, blocked_date) DO NOTHING
+        RETURNING id, blocked_date, created_at
+        "#,
+    )
+    .bind(payload.room_id)
+    .bind(&payload.dates)
+    .bind(&payload.reason)
+    .fetch_all(state.db())
+    .await?;
+
+    let response: Vec<BlockedDateItem> = inserted
+        .into_iter()
+        .map(|(id, blocked_date, created_at)| BlockedDateItem {
+            id,
+            room_id: payload.room_id,
+            blocked_date,
+            reason: payload.reason.clone(),
+            created_at: created_at.unwrap_or_else(Utc::now),
+            created_by: None,
+        })
+        .collect();
+
+    Ok(Json(response))
+}
+
+#[derive(Debug, Serialize)]
+pub struct UnblockDatesResponse {
+    pub success: bool,
+    pub deleted: u64,
+}
+
+/// `DELETE /api/admin/blocked-dates`
+///
+/// Unblock one or more dates for a room. The body shape matches
+/// `unblockMutation` in `RoomAvailability.tsx` (`{ roomId, dates: Date[] }`).
+/// Returns the count of rows actually removed (0 is fine — date was
+/// already unblocked).
+async fn unblock_dates(
+    Extension(user): Extension<AuthUser>,
+    State(state): State<AppState>,
+    Json(payload): Json<UnblockDatesRequest>,
+) -> AppResult<Json<UnblockDatesResponse>> {
+    require_admin(&user)?;
+
+    if payload.dates.is_empty() {
+        return Err(AppError::BadRequest(
+            "At least one date is required".to_string(),
+        ));
+    }
+
+    let result = sqlx::query(
+        r#"
+        DELETE FROM room_blocked_dates
+         WHERE room_id = $1
+           AND blocked_date = ANY($2::date[])
+        "#,
+    )
+    .bind(payload.room_id)
+    .bind(&payload.dates)
+    .execute(state.db())
+    .await?;
+
+    Ok(Json(UnblockDatesResponse {
+        success: true,
+        deleted: result.rows_affected(),
+    }))
+}
+
+// ============================================================================
+// Router
+// ============================================================================
+
+/// Build the room/room-type/blocked-dates sub-router.
+///
+/// Intended to be `.merge`d into the parent admin router so the existing
+/// `auth_middleware` layer covers these routes too. Mounted at
+/// `/api/admin/...` by the top-level router in `routes::mod`.
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/room-types", get(list_room_types))
+        .route("/rooms", get(list_rooms))
+        .route("/blocked-dates", get(list_blocked_dates))
+        .route("/blocked-dates", post(block_dates))
+        .route("/blocked-dates", delete(unblock_dates))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_room_types_query_default_includes_inactive() {
+        let q: ListRoomTypesQuery = serde_json::from_str("{}").unwrap();
+        assert!(q.include_inactive, "default should include inactive rows");
+    }
+
+    #[test]
+    fn list_rooms_query_default_includes_inactive_and_no_filter() {
+        let q: ListRoomsQuery = serde_json::from_str("{}").unwrap();
+        assert!(q.include_inactive);
+        assert!(q.room_type_id.is_none());
+    }
+
+    #[test]
+    fn block_dates_request_round_trips() {
+        let json = r#"{"roomId":"00000000-0000-0000-0000-000000000001","dates":["2026-06-01","2026-06-02"],"reason":"maintenance"}"#;
+        let req: BlockDatesRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.dates.len(), 2);
+        assert_eq!(req.reason.as_deref(), Some("maintenance"));
+    }
+}

--- a/backend-rust/src/routes/admin_rooms.rs
+++ b/backend-rust/src/routes/admin_rooms.rs
@@ -34,7 +34,7 @@
 //! that already exist in the cache — it does not require new ones.
 
 use axum::{
-    extract::{Extension, Path, Query, State},
+    extract::{Extension, Query, State},
     routing::{delete, get, post},
     Json, Router,
 };

--- a/backend-rust/src/routes/mod.rs
+++ b/backend-rust/src/routes/mod.rs
@@ -4,6 +4,7 @@
 //! All routes are nested under /api prefix via the create_router function.
 
 pub mod admin;
+pub mod admin_rooms;
 pub mod analytics;
 pub mod auth;
 pub mod bookings;

--- a/backend-rust/tests/common/mod.rs
+++ b/backend-rust/tests/common/mod.rs
@@ -1047,6 +1047,27 @@ impl TestClient {
 
         TestResponse::from_response(response).await
     }
+
+    /// Make a DELETE request with a JSON body.
+    ///
+    /// Most DELETEs are body-less, but a few admin endpoints
+    /// (e.g. unblock-dates) accept a JSON payload describing what to remove.
+    /// HTTP allows DELETE with a body; axum extracts the body via `Json<…>`
+    /// the same way it does for POST/PUT.
+    pub async fn delete_with_body<T: Serialize>(&self, uri: &str, body: &T) -> TestResponse {
+        let body_json = serde_json::to_string(body).unwrap();
+
+        let builder = Request::builder()
+            .method("DELETE")
+            .uri(uri)
+            .header("Content-Type", "application/json");
+        let builder = self.apply_common_headers(builder);
+
+        let request = builder.body(Body::from(body_json)).unwrap();
+        let response = self.router.clone().oneshot(request).await.unwrap();
+
+        TestResponse::from_response(response).await
+    }
 }
 
 /// Test response wrapper with helper methods

--- a/backend-rust/tests/integration/admin_test.rs
+++ b/backend-rust/tests/integration/admin_test.rs
@@ -726,9 +726,7 @@ async fn test_list_room_types_admin() {
     response.assert_status(200);
 
     let body: Value = response.json().expect("Response should be valid JSON");
-    let arr = body
-        .as_array()
-        .expect("response should be a JSON array");
+    let arr = body.as_array().expect("response should be a JSON array");
     assert!(arr.len() >= 2, "should return both inserted room types");
 
     // Verify each row has the camelCase shape the frontend expects.
@@ -779,8 +777,18 @@ async fn test_list_rooms_admin() {
 
     let suffix = Uuid::new_v4();
     let rt_id = insert_room_type(app.db(), &format!("StdRoom-{}", suffix), 1000.00).await;
-    insert_room(app.db(), rt_id, &format!("R-{}-101", &suffix.simple().to_string()[..6])).await;
-    insert_room(app.db(), rt_id, &format!("R-{}-102", &suffix.simple().to_string()[..6])).await;
+    insert_room(
+        app.db(),
+        rt_id,
+        &format!("R-{}-101", &suffix.simple().to_string()[..6]),
+    )
+    .await;
+    insert_room(
+        app.db(),
+        rt_id,
+        &format!("R-{}-102", &suffix.simple().to_string()[..6]),
+    )
+    .await;
 
     let client = app.authenticated_client_with_role(&admin.id, &admin.email, "admin");
     let response = client.get("/api/admin/rooms").await;
@@ -800,8 +808,14 @@ async fn test_list_rooms_admin() {
     let rt_summary = our
         .get("roomType")
         .expect("roomType summary should be embedded");
-    assert_eq!(rt_summary.get("id").and_then(|v| v.as_str()), Some(rt_id.to_string().as_str()));
-    assert!(rt_summary.get("name").is_some(), "embedded roomType missing name");
+    assert_eq!(
+        rt_summary.get("id").and_then(|v| v.as_str()),
+        Some(rt_id.to_string().as_str())
+    );
+    assert!(
+        rt_summary.get("name").is_some(),
+        "embedded roomType missing name"
+    );
 
     app.cleanup().await.ok();
 }
@@ -833,7 +847,9 @@ async fn test_blocked_dates_full_cycle() {
         "dates": ["2030-01-10", "2030-01-11"],
         "reason": "deep clean"
     });
-    let response = client.post("/api/admin/blocked-dates", &block_payload).await;
+    let response = client
+        .post("/api/admin/blocked-dates", &block_payload)
+        .await;
     response.assert_status(200);
 
     let body: Value = response.json().expect("response should be JSON");
@@ -843,7 +859,9 @@ async fn test_blocked_dates_full_cycle() {
     assert_eq!(inserted.len(), 2, "should insert exactly 2 dates");
 
     // Idempotency: blocking the same dates again returns 0 inserts.
-    let response = client.post("/api/admin/blocked-dates", &block_payload).await;
+    let response = client
+        .post("/api/admin/blocked-dates", &block_payload)
+        .await;
     response.assert_status(200);
     let body: Value = response.json().expect("response should be JSON");
     assert_eq!(
@@ -909,4 +927,3 @@ async fn test_blocked_dates_full_cycle() {
 
     app.cleanup().await.ok();
 }
-

--- a/backend-rust/tests/integration/admin_test.rs
+++ b/backend-rust/tests/integration/admin_test.rs
@@ -663,3 +663,250 @@ async fn test_list_users_search() {
 
     app.cleanup().await.ok();
 }
+
+// ============================================================================
+// Room / Room-Type / Blocked-Date Endpoints
+// ----------------------------------------------------------------------------
+// These cover the new admin endpoints in src/routes/admin_rooms.rs.
+// They use raw SQL to seed inventory so the tests stay self-contained — there
+// are no dedicated TestRoom / TestRoomType fixtures yet.
+// ============================================================================
+
+/// Insert a room type and return its id. Names must be unique
+/// (case-insensitively) so callers should append a uuid suffix.
+async fn insert_room_type(pool: &sqlx::PgPool, name: &str, price: f64) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO room_types (id, name, description, price_per_night, max_guests, is_active)
+        VALUES ($1, $2, 'integration-test fixture', $3::numeric, 2, TRUE)
+        "#,
+    )
+    .bind(id)
+    .bind(name)
+    .bind(price)
+    .execute(pool)
+    .await
+    .expect("Failed to insert room type");
+    id
+}
+
+/// Insert a room belonging to `room_type_id` and return its id.
+async fn insert_room(pool: &sqlx::PgPool, room_type_id: Uuid, room_number: &str) -> Uuid {
+    let id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO rooms (id, room_type_id, room_number, floor, is_active)
+        VALUES ($1, $2, $3, 1, TRUE)
+        "#,
+    )
+    .bind(id)
+    .bind(room_type_id)
+    .bind(room_number)
+    .execute(pool)
+    .await
+    .expect("Failed to insert room");
+    id
+}
+
+/// Test that admin can list room types (happy path).
+/// `GET /api/admin/room-types`
+#[tokio::test]
+async fn test_list_room_types_admin() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let admin = create_admin_user(app.db()).await;
+
+    let suffix = Uuid::new_v4();
+    insert_room_type(app.db(), &format!("Deluxe-{}", suffix), 1500.00).await;
+    insert_room_type(app.db(), &format!("Suite-{}", suffix), 3000.00).await;
+
+    let client = app.authenticated_client_with_role(&admin.id, &admin.email, "admin");
+    let response = client.get("/api/admin/room-types").await;
+
+    response.assert_status(200);
+
+    let body: Value = response.json().expect("Response should be valid JSON");
+    let arr = body
+        .as_array()
+        .expect("response should be a JSON array");
+    assert!(arr.len() >= 2, "should return both inserted room types");
+
+    // Verify each row has the camelCase shape the frontend expects.
+    for row in arr {
+        assert!(row.get("id").is_some(), "row missing id: {:?}", row);
+        assert!(row.get("name").is_some(), "row missing name: {:?}", row);
+        assert!(
+            row.get("pricePerNight").is_some(),
+            "row missing pricePerNight: {:?}",
+            row
+        );
+        assert!(
+            row.get("maxGuests").is_some(),
+            "row missing maxGuests: {:?}",
+            row
+        );
+        assert!(
+            row.get("isActive").is_some(),
+            "row missing isActive: {:?}",
+            row
+        );
+    }
+
+    app.cleanup().await.ok();
+}
+
+/// Test that a non-admin user is rejected from `GET /api/admin/room-types`.
+/// Confirms the auth_middleware + require_admin layers fire on the merged
+/// sub-router.
+#[tokio::test]
+async fn test_list_room_types_non_admin_fails() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let user = create_regular_user(app.db()).await;
+
+    let client = app.authenticated_client(&user.id, &user.email);
+    let response = client.get("/api/admin/room-types").await;
+
+    response.assert_status(403);
+    app.cleanup().await.ok();
+}
+
+/// Test that admin can list rooms with the embedded room-type summary.
+/// `GET /api/admin/rooms`
+#[tokio::test]
+async fn test_list_rooms_admin() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let admin = create_admin_user(app.db()).await;
+
+    let suffix = Uuid::new_v4();
+    let rt_id = insert_room_type(app.db(), &format!("StdRoom-{}", suffix), 1000.00).await;
+    insert_room(app.db(), rt_id, &format!("R-{}-101", &suffix.simple().to_string()[..6])).await;
+    insert_room(app.db(), rt_id, &format!("R-{}-102", &suffix.simple().to_string()[..6])).await;
+
+    let client = app.authenticated_client_with_role(&admin.id, &admin.email, "admin");
+    let response = client.get("/api/admin/rooms").await;
+
+    response.assert_status(200);
+
+    let body: Value = response.json().expect("Response should be valid JSON");
+    let arr = body.as_array().expect("response should be a JSON array");
+    assert!(arr.len() >= 2, "should include the two inserted rooms");
+
+    // Find one of our rooms and verify the embedded roomType payload is
+    // populated (proves the join landed correctly).
+    let our = arr
+        .iter()
+        .find(|row| row.get("roomTypeId").and_then(|v| v.as_str()) == Some(&rt_id.to_string()))
+        .expect("should find at least one row from our seeded room type");
+    let rt_summary = our
+        .get("roomType")
+        .expect("roomType summary should be embedded");
+    assert_eq!(rt_summary.get("id").and_then(|v| v.as_str()), Some(rt_id.to_string().as_str()));
+    assert!(rt_summary.get("name").is_some(), "embedded roomType missing name");
+
+    app.cleanup().await.ok();
+}
+
+/// Test the full block → list → unblock cycle for blocked-dates.
+/// Covers `POST`, `GET`, and `DELETE /api/admin/blocked-dates` in one
+/// realistic flow (the same flow the calendar page uses).
+#[tokio::test]
+async fn test_blocked_dates_full_cycle() {
+    use chrono::NaiveDate;
+
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let admin = create_admin_user(app.db()).await;
+
+    let suffix = Uuid::new_v4();
+    let rt_id = insert_room_type(app.db(), &format!("BlockRT-{}", suffix), 800.00).await;
+    let room_id = insert_room(
+        app.db(),
+        rt_id,
+        &format!("B-{}-201", &suffix.simple().to_string()[..6]),
+    )
+    .await;
+
+    let client = app.authenticated_client_with_role(&admin.id, &admin.email, "admin");
+
+    // Block two dates ----------------------------------------------------
+    let block_payload = json!({
+        "roomId": room_id,
+        "dates": ["2030-01-10", "2030-01-11"],
+        "reason": "deep clean"
+    });
+    let response = client.post("/api/admin/blocked-dates", &block_payload).await;
+    response.assert_status(200);
+
+    let body: Value = response.json().expect("response should be JSON");
+    let inserted = body
+        .as_array()
+        .expect("POST should return an array of inserted blocks");
+    assert_eq!(inserted.len(), 2, "should insert exactly 2 dates");
+
+    // Idempotency: blocking the same dates again returns 0 inserts.
+    let response = client.post("/api/admin/blocked-dates", &block_payload).await;
+    response.assert_status(200);
+    let body: Value = response.json().expect("response should be JSON");
+    assert_eq!(
+        body.as_array().map(|a| a.len()).unwrap_or(0),
+        0,
+        "re-blocking same dates should be a no-op"
+    );
+
+    // List the blocks, scoped to the date window we wrote into ----------
+    let response = client
+        .get("/api/admin/blocked-dates?startDate=2030-01-01&endDate=2030-01-31")
+        .await;
+    response.assert_status(200);
+
+    let body: Value = response.json().expect("response should be JSON");
+    let groups = body.as_array().expect("response should be a JSON array");
+    let our_group = groups
+        .iter()
+        .find(|g| g.get("roomId").and_then(|v| v.as_str()) == Some(&room_id.to_string()))
+        .expect("should find a group for our seeded room");
+    let dates = our_group
+        .get("dates")
+        .and_then(|v| v.as_array())
+        .expect("group missing dates array");
+    assert_eq!(dates.len(), 2, "should list both blocked dates");
+
+    // Unblock one of the two dates --------------------------------------
+    let unblock_payload = json!({
+        "roomId": room_id,
+        "dates": ["2030-01-10"]
+    });
+    let response = client
+        .delete_with_body("/api/admin/blocked-dates", &unblock_payload)
+        .await;
+    response.assert_status(200);
+    let body: Value = response.json().expect("response should be JSON");
+    assert_eq!(
+        body.get("deleted").and_then(|v| v.as_u64()),
+        Some(1),
+        "should report exactly 1 row deleted"
+    );
+
+    // Verify the second date is still blocked ---------------------------
+    let response = client
+        .get("/api/admin/blocked-dates?startDate=2030-01-01&endDate=2030-01-31")
+        .await;
+    response.assert_status(200);
+    let body: Value = response.json().expect("response should be JSON");
+    let groups = body.as_array().expect("array");
+    let our_group = groups
+        .iter()
+        .find(|g| g.get("roomId").and_then(|v| v.as_str()) == Some(&room_id.to_string()))
+        .expect("our room should still appear");
+    let dates = our_group.get("dates").and_then(|v| v.as_array()).unwrap();
+    assert_eq!(dates.len(), 1, "one date should remain blocked");
+    assert_eq!(
+        dates[0].get("blockedDate").and_then(|v| v.as_str()),
+        Some("2030-01-11")
+    );
+
+    // Sanity check: the silent extra constants did parse as real dates
+    let _: NaiveDate = "2030-01-11".parse().unwrap();
+
+    app.cleanup().await.ok();
+}
+

--- a/docs/admin-backend-gaps.md
+++ b/docs/admin-backend-gaps.md
@@ -19,6 +19,15 @@ PR, alongside the route handlers and integration tests.
 - **Missing** — no Rust handler exists; frontend renders a stub.
 - **Partial** — a related public/booking endpoint exists but no
   admin-scoped variant.
+- **Implemented** — handler shipped; frontend will pick it up the next
+  time the page mounts.
+
+## Progress
+
+- Batch 1 (`feat/admin-endpoints-batch-1`): 5 of 35 endpoints implemented
+  (room types list, rooms list, blocked-dates list/create/delete). All
+  five are pure reads/writes against tables that already exist in the
+  schema. Remaining: 30 endpoints.
 
 ---
 
@@ -55,10 +64,10 @@ Used by `RoomTypeManagement.tsx`. The current backend models room type as a
 hard-coded enum; implementing CRUD requires a `room_types` table and
 migrating bookings to reference a UUID rather than the enum.
 
-- `GET /api/admin/room-types` — list room types.
+- [x] `GET /api/admin/room-types` — list room types.
   Frontend: `frontend/src/pages/admin/RoomTypeManagement.tsx:82`,
   `frontend/src/pages/admin/RoomAvailability.tsx:68`,
-  `frontend/src/pages/admin/RoomManagement.tsx:61`. Status: Missing.
+  `frontend/src/pages/admin/RoomManagement.tsx:61`. Status: Implemented (batch 1).
 - `POST /api/admin/room-types` — create.
   Frontend: `frontend/src/pages/admin/RoomTypeManagement.tsx:90`. Status: Missing.
 - `PUT /api/admin/room-types/:id` — update.
@@ -74,9 +83,9 @@ migrating bookings to reference a UUID rather than the enum.
 
 Used by `RoomManagement.tsx`. Requires a `rooms` table.
 
-- `GET /api/admin/rooms` — list.
+- [x] `GET /api/admin/rooms` — list.
   Frontend: `frontend/src/pages/admin/RoomManagement.tsx:70`,
-  `frontend/src/pages/admin/RoomAvailability.tsx:80`. Status: Missing.
+  `frontend/src/pages/admin/RoomAvailability.tsx:80`. Status: Implemented (batch 1).
 - `POST /api/admin/rooms` — create.
   Frontend: `frontend/src/pages/admin/RoomManagement.tsx:78`. Status: Missing.
 - `PUT /api/admin/rooms/:id` — update.
@@ -94,14 +103,14 @@ Used by `RoomAvailability.tsx` to block specific room/date combinations.
 The booking module already reads from `room_blocked_dates`, but no
 admin-write endpoints exist.
 
-- `GET /api/admin/blocked-dates` — list blocks for a date range.
-  Frontend: `frontend/src/pages/admin/RoomAvailability.tsx:102`. Status: Missing.
+- [x] `GET /api/admin/blocked-dates` — list blocks for a date range.
+  Frontend: `frontend/src/pages/admin/RoomAvailability.tsx:102`. Status: Implemented (batch 1).
 - `GET /api/admin/bookings/calendar` — room-level booking grid.
   Frontend: `frontend/src/pages/admin/RoomAvailability.tsx:111`. Status: Missing.
-- `POST /api/admin/blocked-dates` — block dates.
-  Frontend: `frontend/src/pages/admin/RoomAvailability.tsx:119`. Status: Missing.
-- `DELETE /api/admin/blocked-dates` — unblock dates.
-  Frontend: `frontend/src/pages/admin/RoomAvailability.tsx:137`. Status: Missing.
+- [x] `POST /api/admin/blocked-dates` — block dates.
+  Frontend: `frontend/src/pages/admin/RoomAvailability.tsx:119`. Status: Implemented (batch 1).
+- [x] `DELETE /api/admin/blocked-dates` — unblock dates.
+  Frontend: `frontend/src/pages/admin/RoomAvailability.tsx:137`. Status: Implemented (batch 1).
 
 // shape TBD during implementation
 


### PR DESCRIPTION
## Summary

First batch of admin endpoints from `docs/admin-backend-gaps.md` (35 missing total).

All five endpoints in this PR operate on tables that **already exist** in the schema (`room_types`, `rooms`, `room_blocked_dates`), so no migrations are needed. They unblock the three room/availability admin pages without requiring frontend changes — those pages already call these URLs and currently 404.

## Endpoints implemented (5)

| Method | Path | One-liner |
| --- | --- | --- |
| `GET` | `/api/admin/room-types` | List all room types (filterable by `is_active`) |
| `GET` | `/api/admin/rooms` | List physical rooms joined with their room type (filterable by `roomTypeId`) |
| `GET` | `/api/admin/blocked-dates` | List blocked dates in a date range, grouped by room |
| `POST` | `/api/admin/blocked-dates` | Block one or more dates for a room (idempotent, bulk) |
| `DELETE` | `/api/admin/blocked-dates` | Unblock one or more dates for a room |

## Frontend pages unblocked (5 stubs become live)

- `frontend/src/pages/admin/RoomTypeManagement.tsx` — read-side now works (list)
- `frontend/src/pages/admin/RoomManagement.tsx` — read-side now works (list)
- `frontend/src/pages/admin/RoomAvailability.tsx` — full calendar block/unblock cycle
- `frontend/src/pages/admin/RoomTypeManagement.tsx` (the type dropdown read by other pages)
- `frontend/src/pages/admin/RoomManagement.tsx` (the rooms grid read by RoomAvailability)

(That's three distinct pages; two of them depend on multiple endpoints from the new five.)

## Why these 5 (not the others on the rollout list)

The "rollout order" in the gaps doc puts room-types/rooms **CRUD** first, but those mutating endpoints accept frontend fields the schema doesn't yet model:

- `room_types`: frontend posts `bedType`, `amenities`, `images`, `sortOrder` — none of those columns exist
- `rooms`: frontend posts `notes` — column doesn't exist
- `bookings` admin list: requires payment/slip/audit fields the bookings table doesn't track
- `email/status`, `email/test`: would need a real SMTP/IMAP probe (out of scope per task instructions)

So I shipped the **read** side of room-types/rooms (which work cleanly with the existing schema) plus the **full** blocked-dates trio (which is fully covered by the existing `room_blocked_dates` table). The mutating room/room-type endpoints are deferred to a follow-up that includes the schema migration in the same PR.

## Schema decisions

- **No new migrations.** All five endpoints use existing tables.
- **Fields the frontend expects but the schema lacks** (`room_types.bedType/amenities/images/sortOrder`, `rooms.notes`, `room_blocked_dates.created_by`) are simply omitted from responses. The frontend already treats these as optional and renders gracefully when absent (`?? null`, `?.name`, etc.).
- **Idempotent block-dates POST**: `INSERT … ON CONFLICT (room_id, blocked_date) DO NOTHING` so re-blocking the same date is a 0-insert no-op (returned in the array). Matches the calendar UX where dragging over already-blocked cells should not error.

## Implementation notes

- Handlers live in `backend-rust/src/routes/admin_rooms.rs` to keep `admin.rs` (already 1348 lines) from growing further. The sub-router is `.merge(...)`d into `admin::router()` so the existing `auth_middleware` + `require_admin` layers cover it identically.
- Queries use **runtime** `sqlx::query()` / `sqlx::query_as()` rather than the compile-time `query!()` macros. Regenerating `.sqlx/` requires a live database that is not reachable from this worktree, and CI's `cargo sqlx prepare --check` would otherwise fail. Runtime queries are still parameterised, so injection-safe. Documented in the module-level doc comment.
- Added `TestClient::delete_with_body(..)` since DELETE-with-body is not in the existing test client (axum supports it; HTTP allows it).

## Tests

Added to `backend-rust/tests/integration/admin_test.rs`:

- `test_list_room_types_admin` — happy path, asserts camelCase response shape
- `test_list_room_types_non_admin_fails` — confirms `auth_middleware` + `require_admin` fire on the merged sub-router (returns 403)
- `test_list_rooms_admin` — happy path, asserts the embedded `roomType` summary lands
- `test_blocked_dates_full_cycle` — POST → GET → DELETE → GET, including idempotency check on re-POST

Plus three unit tests in `admin_rooms.rs` for query-param defaults and request DTO round-trips.

## Estimate remaining

**30 of 35 endpoints still missing.** The next-easiest batch (assuming a one-PR schema migration is acceptable) would be room-types/rooms CRUD (`POST` / `PUT` / `DELETE` for both) — that's 6 more endpoints, plus a single migration adding the missing columns. After that, the booking-management endpoints (~9) need a much larger schema expansion (payment slips, audit history, discount tracking).

## Test plan

- [ ] CI: `cargo build` passes
- [ ] CI: `cargo sqlx prepare --check` still passes (no new `query!()` macros)
- [ ] CI: `cargo test --test '*'` passes including the four new admin tests
- [ ] Manual smoke (post-merge, on staging): admin hits `/api/admin/room-types`, sees seeded types
- [ ] Manual smoke (post-merge, on staging): admin POSTs `/api/admin/blocked-dates`, sees the row in `GET`, deletes it via `DELETE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)