### PR TITLE
fix(docker): set executable bit on binaries copied into Distroless image

### DIFF
--- a/backend-rust/Dockerfile.ci
+++ b/backend-rust/Dockerfile.ci
@@ -115,9 +115,11 @@ WORKDIR /app
 
 # Pre-built loyalty-backend binary from the GitHub Actions runner artifact
 # (placed in the build context at ./loyalty-backend by docker/build-push-action).
-COPY --chown=nonroot:nonroot loyalty-backend                  /app/loyalty-backend
+# --chmod=755 because actions/upload-artifact roundtrips lose the executable
+# bit, and Distroless has no shell to chmod after the fact.
+COPY --chown=nonroot:nonroot --chmod=755 loyalty-backend      /app/loyalty-backend
 # Tiny healthcheck binary compiled in stage 1.
-COPY --from=hc-builder --chown=nonroot:nonroot /hc/target/release/healthcheck /app/healthcheck
+COPY --from=hc-builder --chown=nonroot:nonroot --chmod=755 /hc/target/release/healthcheck /app/healthcheck
 
 # Drop privileges. cc-debian12 ships the `nonroot` user as uid/gid 65532.
 # (Previous image used a manually-created `appuser` at uid/gid 1000.


### PR DESCRIPTION
## Summary

The Distroless flip in #209 broke the e2e build (which then blocked the deploy of all 5 follow-up PRs from landing).

Failure: `runc create failed: ... exec: "/app/loyalty-backend": permission denied` ([failing job](https://github.com/thehfhotel/loyalty-app/actions/runs/25649174048))

Root cause: `actions/upload-artifact` strips the executable bit when round-tripping the binary between the `Build Backend Binary` job and the `Build & Push to GHCR` job. The pre-Distroless `debian:bookworm-slim` runner happened to mask this because Docker's default umask + the apt-installed userspace gave the binary the right perms anyway. Distroless has neither a shell nor `chmod`, so once the bit is gone, it stays gone.

## Fix

`COPY --chmod=755` on both binaries (works with BuildKit, which the workflow already uses). Also applied to the healthcheck binary copied from the in-Dockerfile stage 1 build, defensively.

## Test plan
- [ ] CI green (the same E2E tests that just failed should now pass)
- [ ] Deploy auto-promotes to staging then production
- [ ] `docker exec loyalty_backend_production /app/healthcheck && echo OK` works after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)