### PR TITLE
feat(bookings): implement POST /api/bookings/:id/slips

### DIFF
--- a/backend-rust/migrations/20260511000000_booking_slips.sql
+++ b/backend-rust/migrations/20260511000000_booking_slips.sql
@@ -1,0 +1,36 @@
+-- =====================================================
+-- Migration: booking_slips
+-- =====================================================
+-- Adds a table to record payment slips uploaded against a booking.
+--
+-- A single booking can accumulate multiple slips (e.g. a deposit slip and a
+-- balance slip), which is why each row has its own primary key rather than
+-- attaching a `slip_url` column to `bookings`.
+--
+-- The slip URL itself is produced by `POST /api/slips/upload`, which writes the
+-- file to `/storage/slips/<uuid>.<ext>` and returns the path. This table just
+-- links those URLs to the booking they were uploaded for, along with who
+-- uploaded them and when.
+-- =====================================================
+
+CREATE TABLE IF NOT EXISTS "public"."booking_slips" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "booking_id" UUID NOT NULL,
+    "slip_url" TEXT NOT NULL,
+    "uploaded_by" UUID NOT NULL,
+    "uploaded_at" TIMESTAMPTZ(6) NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT "booking_slips_pkey" PRIMARY KEY ("id")
+);
+
+ALTER TABLE "public"."booking_slips" ADD CONSTRAINT "booking_slips_booking_id_fkey"
+    FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+ALTER TABLE "public"."booking_slips" ADD CONSTRAINT "booking_slips_uploaded_by_fkey"
+    FOREIGN KEY ("uploaded_by") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+
+CREATE INDEX IF NOT EXISTS "idx_booking_slips_booking_id"
+    ON "public"."booking_slips" ("booking_id");
+
+CREATE INDEX IF NOT EXISTS "idx_booking_slips_uploaded_at"
+    ON "public"."booking_slips" ("uploaded_at" DESC);

--- a/backend-rust/src/routes/bookings.rs
+++ b/backend-rust/src/routes/bookings.rs
@@ -96,6 +96,39 @@ pub struct CompleteBookingRequest {
     pub notes: Option<String>,
 }
 
+/// Add slip request — attach a previously-uploaded payment slip URL to a booking.
+///
+/// The frontend uploads the file via `POST /api/slips/upload` first, then sends
+/// the returned URL here so it gets associated with the booking.
+#[derive(Debug, Deserialize, Validate)]
+#[serde(rename_all = "camelCase")]
+pub struct AddSlipRequest {
+    #[validate(length(
+        min = 1,
+        max = 1024,
+        message = "Slip URL must be between 1 and 1024 characters"
+    ))]
+    pub slip_url: String,
+}
+
+/// Response for an added slip.
+///
+/// Mirrors the `BookingSlip` shape the frontend's `bookingService` expects:
+/// `{ id, slipUrl, uploadedAt, slipokStatus, adminStatus }`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BookingSlipResponse {
+    pub id: Uuid,
+    pub booking_id: Uuid,
+    pub slip_url: String,
+    pub uploaded_by: Uuid,
+    pub uploaded_at: DateTime<Utc>,
+    /// Reserved for future SlipOK verification integration.
+    pub slipok_status: Option<String>,
+    /// Reserved for future admin review workflow.
+    pub admin_status: Option<String>,
+}
+
 /// Paginated booking list response
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -460,6 +493,60 @@ async fn complete_booking(
     );
 
     Ok(Json(completed))
+}
+
+/// POST /api/bookings/:id/slips - Attach a payment slip URL to a booking
+///
+/// Request body:
+/// - slipUrl: The URL returned by `POST /api/slips/upload`
+///
+/// Authentication is required (provided by the router layer). The caller must
+/// either own the booking or be an admin.
+///
+/// Returns 201 with the created `BookingSlipResponse` (camelCase JSON).
+async fn add_booking_slip(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Path(booking_id): Path<Uuid>,
+    Json(req): Json<AddSlipRequest>,
+) -> AppResult<(StatusCode, Json<BookingSlipResponse>)> {
+    // Validate the request body shape (length bounds on slip_url).
+    req.validate()?;
+
+    // Trim then re-check so payloads that are only whitespace are rejected.
+    let slip_url = req.slip_url.trim().to_string();
+    if slip_url.is_empty() {
+        return Err(AppError::Validation("slipUrl cannot be empty".to_string()));
+    }
+
+    // Look up the booking; surfaces a 404 when it doesn't exist.
+    let booking = query_booking_by_id(state.db(), booking_id).await?;
+
+    // Ownership / admin authorization. We do this AFTER the booking lookup so
+    // that a missing booking returns 404 (not 403), matching the pattern used
+    // by `get_booking`.
+    let auth_user_id = Uuid::parse_str(&auth_user.id)
+        .map_err(|_| AppError::InvalidToken("Invalid user ID in token".to_string()))?;
+
+    let is_admin = has_role(&auth_user, "admin");
+    if booking.user_id != auth_user_id && !is_admin {
+        return Err(AppError::Forbidden(
+            "You can only add slips to your own bookings".to_string(),
+        ));
+    }
+
+    // Insert the slip row. We let the database default the id / uploaded_at so
+    // the row matches what other reads will see.
+    let slip = insert_booking_slip(state.db(), booking_id, &slip_url, auth_user_id).await?;
+
+    tracing::info!(
+        user_id = %auth_user.id,
+        booking_id = %booking_id,
+        slip_id = %slip.id,
+        "Booking slip added"
+    );
+
+    Ok((StatusCode::CREATED, Json(slip)))
 }
 
 /// GET /api/bookings/availability - Check room availability
@@ -1154,6 +1241,55 @@ async fn award_loyalty_points(
     Ok(())
 }
 
+/// Row returned by `insert_booking_slip`.
+#[derive(Debug, FromRow)]
+struct BookingSlipRow {
+    pub id: Uuid,
+    pub booking_id: Uuid,
+    pub slip_url: String,
+    pub uploaded_by: Uuid,
+    pub uploaded_at: DateTime<Utc>,
+}
+
+impl From<BookingSlipRow> for BookingSlipResponse {
+    fn from(row: BookingSlipRow) -> Self {
+        Self {
+            id: row.id,
+            booking_id: row.booking_id,
+            slip_url: row.slip_url,
+            uploaded_by: row.uploaded_by,
+            uploaded_at: row.uploaded_at,
+            // These are nullable placeholders for the SlipOK / admin review
+            // workflows. They aren't wired up yet, so we always return None.
+            slipok_status: None,
+            admin_status: None,
+        }
+    }
+}
+
+/// Insert a slip row and return it as a response DTO.
+async fn insert_booking_slip(
+    db: &PgPool,
+    booking_id: Uuid,
+    slip_url: &str,
+    uploaded_by: Uuid,
+) -> AppResult<BookingSlipResponse> {
+    let row: BookingSlipRow = sqlx::query_as(
+        r#"
+        INSERT INTO booking_slips (booking_id, slip_url, uploaded_by)
+        VALUES ($1, $2, $3)
+        RETURNING id, booking_id, slip_url, uploaded_by, uploaded_at
+        "#,
+    )
+    .bind(booking_id)
+    .bind(slip_url)
+    .bind(uploaded_by)
+    .fetch_one(db)
+    .await?;
+
+    Ok(row.into())
+}
+
 // ==================== HELPER FUNCTIONS ====================
 
 /// Parse room type string to enum
@@ -1189,6 +1325,7 @@ pub fn routes() -> Router<AppState> {
 /// - POST /api/bookings - Create a new booking
 /// - PUT /api/bookings/:id - Update a booking
 /// - POST /api/bookings/:id/cancel - Cancel a booking
+/// - POST /api/bookings/:id/slips - Attach a payment slip URL to a booking
 /// - POST /api/bookings/:id/complete - Mark booking as completed (admin only)
 /// - GET /api/bookings/availability - Check room availability
 ///
@@ -1204,6 +1341,7 @@ pub fn router() -> Router<AppState> {
         .route("/:id", get(get_booking))
         .route("/:id", put(update_booking))
         .route("/:id/cancel", post(cancel_booking))
+        .route("/:id/slips", post(add_booking_slip))
         // Admin routes
         .route("/:id/complete", post(complete_booking))
         // Apply authentication middleware to all routes
@@ -1229,6 +1367,7 @@ pub fn router_without_auth() -> Router<AppState> {
         .route("/:id", get(get_booking))
         .route("/:id", put(update_booking))
         .route("/:id/cancel", post(cancel_booking))
+        .route("/:id/slips", post(add_booking_slip))
         .route("/:id/complete", post(complete_booking))
 }
 

--- a/backend-rust/tests/common/mod.rs
+++ b/backend-rust/tests/common/mod.rs
@@ -224,8 +224,7 @@ async fn ensure_template_db() -> Result<(), Box<dyn std::error::Error + Send + S
     let init_migration = include_str!("../../migrations/20240101000000_init.sql");
     template_pool.execute(init_migration).await?;
 
-    let booking_slips_migration =
-        include_str!("../../migrations/20260511000000_booking_slips.sql");
+    let booking_slips_migration = include_str!("../../migrations/20260511000000_booking_slips.sql");
     template_pool.execute(booking_slips_migration).await?;
 
     // Seed tiers

--- a/backend-rust/tests/common/mod.rs
+++ b/backend-rust/tests/common/mod.rs
@@ -219,9 +219,14 @@ async fn ensure_template_db() -> Result<(), Box<dyn std::error::Error + Send + S
         .connect(&template_url)
         .await?;
 
-    // Run migrations
-    let migration_sql = include_str!("../../migrations/20240101000000_init.sql");
-    template_pool.execute(migration_sql).await?;
+    // Run migrations in order. Each migration file must be applied separately
+    // so the file order matches `sqlx::migrate!()` at runtime.
+    let init_migration = include_str!("../../migrations/20240101000000_init.sql");
+    template_pool.execute(init_migration).await?;
+
+    let booking_slips_migration =
+        include_str!("../../migrations/20260511000000_booking_slips.sql");
+    template_pool.execute(booking_slips_migration).await?;
 
     // Seed tiers
     template_pool

--- a/backend-rust/tests/integration/booking_test.rs
+++ b/backend-rust/tests/integration/booking_test.rs
@@ -859,6 +859,219 @@ async fn test_list_bookings_pagination() {
     app.cleanup().await.ok();
 }
 
+// ============================================================================
+// test_add_booking_slip - POST /api/bookings/:id/slips
+// ============================================================================
+
+#[tokio::test]
+async fn test_add_booking_slip_success() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let user = TestUser::new("slip-add-success@test.com");
+    user.insert(app.db())
+        .await
+        .expect("Failed to insert test user");
+
+    let booking_id = create_test_booking(app.db(), user.id, "confirmed", 7, 10)
+        .await
+        .expect("Failed to create booking");
+
+    let client = app.authenticated_client(&user.id, &user.email);
+
+    let body = json!({
+        "slipUrl": "/storage/slips/test-slip-1.jpg",
+    });
+
+    let response = client
+        .post(&format!("/api/bookings/{}/slips", booking_id), &body)
+        .await;
+
+    assert!(
+        response.status == 201 || response.status == 200,
+        "Expected 201 or 200, got {}. Body: {}",
+        response.status,
+        response.body
+    );
+
+    let json: Value = response.json().expect("Response should be valid JSON");
+    assert!(json.get("id").is_some(), "Response should include slip id");
+    assert_eq!(
+        json.get("slipUrl").and_then(|v| v.as_str()),
+        Some("/storage/slips/test-slip-1.jpg"),
+        "Response should echo the submitted slip URL"
+    );
+    assert_eq!(
+        json.get("bookingId").and_then(|v| v.as_str()),
+        Some(booking_id.to_string()).as_deref(),
+        "Response should reference the correct booking"
+    );
+    assert!(
+        json.get("uploadedAt").is_some(),
+        "Response should include uploaded_at timestamp"
+    );
+
+    // Verify the row was actually persisted.
+    let row_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM booking_slips WHERE booking_id = $1")
+            .bind(booking_id)
+            .fetch_one(app.db())
+            .await
+            .expect("Failed to count slips");
+    assert_eq!(row_count.0, 1, "Exactly one slip row should be persisted");
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_add_booking_slip_requires_authentication() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let client = app.client();
+
+    let fake_booking_id = Uuid::new_v4();
+    let body = json!({ "slipUrl": "/storage/slips/anon.jpg" });
+
+    let response = client
+        .post(&format!("/api/bookings/{}/slips", fake_booking_id), &body)
+        .await;
+
+    response.assert_status(401);
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_add_booking_slip_forbidden_for_other_user() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let owner = TestUser::new("slip-owner@test.com");
+    owner
+        .insert(app.db())
+        .await
+        .expect("Failed to insert owner");
+
+    let intruder = TestUser::new("slip-intruder@test.com");
+    intruder
+        .insert(app.db())
+        .await
+        .expect("Failed to insert other user");
+
+    let booking_id = create_test_booking(app.db(), owner.id, "confirmed", 7, 10)
+        .await
+        .expect("Failed to create booking");
+
+    // Authenticated as the OTHER user, not the owner.
+    let client = app.authenticated_client(&intruder.id, &intruder.email);
+
+    let body = json!({ "slipUrl": "/storage/slips/intruder.jpg" });
+    let response = client
+        .post(&format!("/api/bookings/{}/slips", booking_id), &body)
+        .await;
+
+    response.assert_status(403);
+
+    // And nothing should have been written.
+    let row_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM booking_slips WHERE booking_id = $1")
+            .bind(booking_id)
+            .fetch_one(app.db())
+            .await
+            .expect("Failed to count slips");
+    assert_eq!(
+        row_count.0, 0,
+        "No slip should be persisted when authorization fails"
+    );
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_add_booking_slip_not_found_for_missing_booking() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let user = TestUser::new("slip-missing-booking@test.com");
+    user.insert(app.db())
+        .await
+        .expect("Failed to insert test user");
+
+    let client = app.authenticated_client(&user.id, &user.email);
+
+    let fake_booking_id = Uuid::new_v4();
+    let body = json!({ "slipUrl": "/storage/slips/ghost.jpg" });
+    let response = client
+        .post(&format!("/api/bookings/{}/slips", fake_booking_id), &body)
+        .await;
+
+    response.assert_status(404);
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_add_booking_slip_admin_can_add_for_other_user() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let admin = TestUser::admin("slip-admin@test.com");
+    admin
+        .insert(app.db())
+        .await
+        .expect("Failed to insert admin");
+
+    let user = TestUser::new("slip-customer@test.com");
+    user.insert(app.db())
+        .await
+        .expect("Failed to insert customer");
+
+    let booking_id = create_test_booking(app.db(), user.id, "confirmed", 7, 10)
+        .await
+        .expect("Failed to create booking");
+
+    let client = app.authenticated_client_with_role(&admin.id, &admin.email, "admin");
+
+    let body = json!({ "slipUrl": "/storage/slips/admin-attached.jpg" });
+    let response = client
+        .post(&format!("/api/bookings/{}/slips", booking_id), &body)
+        .await;
+
+    assert!(
+        response.status == 201 || response.status == 200,
+        "Admin should be allowed to attach slips. Got {}. Body: {}",
+        response.status,
+        response.body
+    );
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_add_booking_slip_rejects_empty_url() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let user = TestUser::new("slip-empty-url@test.com");
+    user.insert(app.db())
+        .await
+        .expect("Failed to insert test user");
+
+    let booking_id = create_test_booking(app.db(), user.id, "confirmed", 7, 10)
+        .await
+        .expect("Failed to create booking");
+
+    let client = app.authenticated_client(&user.id, &user.email);
+
+    let body = json!({ "slipUrl": "" });
+    let response = client
+        .post(&format!("/api/bookings/{}/slips", booking_id), &body)
+        .await;
+
+    assert!(
+        response.status == 400 || response.status == 422,
+        "Expected 400/422 for empty slipUrl, got {}. Body: {}",
+        response.status,
+        response.body
+    );
+
+    app.cleanup().await.ok();
+}
+
 #[tokio::test]
 async fn test_admin_can_view_all_bookings() {
     let app = TestApp::new().await.expect("Failed to create test app");


### PR DESCRIPTION
## Summary

The frontend's `bookingService.addSlip` (used by `BookingPage` and `MyBookingsPage`) has been calling `POST /api/bookings/:id/slips` for a while, but the backend never had a handler — every upload attempt returned 404. This PR fixes that.

## Protocol

**Request:**

```
POST /api/bookings/:id/slips
Authorization: Bearer <jwt>
Content-Type: application/json

{ "slipUrl": "/storage/slips/<uuid>.jpg" }
```

**Validation rules:**

- `slipUrl` is required, 1..=1024 chars after trimming, must be non-empty.

**Responses:**

| Status | When |
|--------|------|
| `201 Created` | Slip persisted |
| `400 Bad Request` | Missing/empty `slipUrl` or longer than 1024 chars |
| `401 Unauthorized` | No JWT |
| `403 Forbidden` | Authenticated user is neither the booking's owner nor an admin |
| `404 Not Found` | No booking with that id |

**Success body** (mirrors the frontend's `BookingSlip` type):

```json
{
  "id": "8c2a…",
  "bookingId": "1f4d…",
  "slipUrl": "/storage/slips/<uuid>.jpg",
  "uploadedBy": "9b71…",
  "uploadedAt": "2026-05-11T10:24:13Z",
  "slipokStatus": null,
  "adminStatus": null
}
```

`slipokStatus` and `adminStatus` are placeholders for the future SlipOK verification + admin review workflows; they always return `null` today.

## Migration

Yes — adds `backend-rust/migrations/20260511000000_booking_slips.sql`:

```sql
CREATE TABLE booking_slips (
  id          UUID PK DEFAULT gen_random_uuid(),
  booking_id  UUID NOT NULL REFERENCES bookings(id)  ON DELETE CASCADE,
  slip_url    TEXT NOT NULL,
  uploaded_by UUID NOT NULL REFERENCES users(id)     ON DELETE CASCADE,
  uploaded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
);
-- + indexes on booking_id and uploaded_at
```

A separate table (not a `bookings.slip_url` column) because the frontend already models multiple slips per booking (deposit + balance) and exposes a `DELETE /api/bookings/slips/:slipId` flow that needs row ids.

`tests/common/mod.rs` was updated to apply this second migration to the test template DB. Runtime `sqlx::query()` / `sqlx::query_as()` is used (matching `routes/admin_rooms.rs` and the rest of `routes/bookings.rs`), so no `.sqlx/` cache regeneration is needed.

## Frontend changes

None. `bookingService.addSlip(bookingId, slipUrl)` already sends `{ slipUrl }` to the exact path the new handler accepts.

## Test plan

- [ ] CI: `cargo build` and `cargo test` pass on the Rust backend
- [ ] CI: integration tests for the new endpoint pass (success, 401, 403 for other user, 404 for missing booking, admin override, empty-URL rejection)
- [ ] Manual: in staging, attach a payment slip from `BookingPage` and `MyBookingsPage` — confirm 201 response and slip appears on the booking
- [ ] Manual: confirm a non-owner gets 403 (try a second account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)