### PR TITLE
feat(auth): remove JSON-body refresh token (Phase 3, breaking)

### DIFF
--- a/backend-rust/src/openapi.rs
+++ b/backend-rust/src/openapi.rs
@@ -133,8 +133,9 @@ impl Modify for SecurityAddon {
             // Auth schemas
             schemas::RegisterRequest,
             schemas::LoginRequest,
-            schemas::LogoutRequest,
-            schemas::RefreshTokenRequest,
+            // LogoutRequest / RefreshTokenRequest removed in Phase 3 —
+            // both endpoints now take an empty body and read the refresh
+            // token from the HttpOnly cookie.
             schemas::ForgotPasswordRequest,
             schemas::ResetPasswordRequest,
             schemas::AuthResponse,
@@ -329,21 +330,10 @@ pub mod schemas {
         pub remember_me: bool,
     }
 
-    /// Logout request
-    #[derive(Debug, Serialize, Deserialize, ToSchema)]
-    pub struct LogoutRequest {
-        /// Optional refresh token to invalidate
-        #[serde(rename = "refreshToken")]
-        pub refresh_token: Option<String>,
-    }
-
-    /// Token refresh request
-    #[derive(Debug, Serialize, Deserialize, ToSchema)]
-    pub struct RefreshTokenRequest {
-        /// Refresh token
-        #[serde(rename = "refreshToken")]
-        pub refresh_token: String,
-    }
+    // Phase 3: `LogoutRequest` and `RefreshTokenRequest` are gone. Both
+    // endpoints take an empty JSON body and read the refresh token from
+    // the `refresh_token` HttpOnly cookie. See `routes::auth` for the
+    // handler signatures.
 
     /// Forgot password request
     #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -372,15 +362,17 @@ pub mod schemas {
         pub tokens: AuthTokens,
     }
 
-    /// Authentication tokens
+    /// Authentication tokens returned in the JSON body.
+    ///
+    /// Phase 3: only the access token is returned in the body. The refresh
+    /// token is delivered exclusively via the `refresh_token` HttpOnly
+    /// cookie (see the `Set-Cookie` response header on /auth/login,
+    /// /auth/register, /auth/refresh, and the OAuth callbacks).
     #[derive(Debug, Serialize, Deserialize, ToSchema)]
     pub struct AuthTokens {
         /// JWT access token
         #[serde(rename = "accessToken")]
         pub access_token: String,
-        /// Refresh token for obtaining new access tokens
-        #[serde(rename = "refreshToken")]
-        pub refresh_token: String,
     }
 
     /// Current user response
@@ -1491,12 +1483,16 @@ pub mod paths {
     )]
     pub async fn auth_login() {}
 
-    /// Logout and invalidate refresh token
+    /// Logout and invalidate refresh token.
+    ///
+    /// Phase 3: takes no JSON body. The refresh token to invalidate is
+    /// read from the `refresh_token` HttpOnly cookie that the browser
+    /// sends automatically. The response includes a `Set-Cookie:
+    /// refresh_token=; Max-Age=0` header that clears the cookie.
     #[utoipa::path(
         post,
         path = "/auth/logout",
         tag = "auth",
-        request_body = LogoutRequest,
         security(("bearer_auth" = [])),
         responses(
             (status = 200, description = "Logged out successfully", body = MessageResponse),
@@ -1505,15 +1501,19 @@ pub mod paths {
     )]
     pub async fn auth_logout() {}
 
-    /// Refresh access token
+    /// Refresh access token.
+    ///
+    /// Phase 3: takes no JSON body. The refresh token is read exclusively
+    /// from the `refresh_token` HttpOnly cookie. The response carries a
+    /// rotated cookie via `Set-Cookie` and returns the new access token
+    /// in the JSON body — never the refresh token.
     #[utoipa::path(
         post,
         path = "/auth/refresh",
         tag = "auth",
-        request_body = RefreshTokenRequest,
         responses(
             (status = 200, description = "Token refreshed successfully", body = TokenRefreshResponse),
-            (status = 401, description = "Invalid or expired refresh token", body = ErrorResponse)
+            (status = 401, description = "Missing, invalid, or expired refresh-token cookie", body = ErrorResponse)
         )
     )]
     pub async fn auth_refresh() {}

--- a/backend-rust/src/routes/auth.rs
+++ b/backend-rust/src/routes/auth.rs
@@ -833,7 +833,10 @@ async fn refresh(
     // Set-Cookie header — never in the JSON body. Max-Age matches the new
     // DB row's expiry.
     let refresh_max_age_secs = (refresh_expires_at - Utc::now()).num_seconds().max(0);
-    let jar = jar.add(build_refresh_cookie(new_refresh_token, refresh_max_age_secs));
+    let jar = jar.add(build_refresh_cookie(
+        new_refresh_token,
+        refresh_max_age_secs,
+    ));
 
     Ok((
         jar,

--- a/backend-rust/src/routes/auth.rs
+++ b/backend-rust/src/routes/auth.rs
@@ -71,26 +71,10 @@ pub struct LoginRequest {
     pub remember_me: bool,
 }
 
-/// Logout request payload
-#[derive(Debug, Clone, Deserialize)]
-pub struct LogoutRequest {
-    /// The refresh token to invalidate
-    #[serde(rename = "refreshToken")]
-    pub refresh_token: Option<String>,
-}
-
-/// Refresh token request payload.
-///
-/// `refresh_token` is optional because Phase 1 of the cookie migration accepts
-/// the token from EITHER this JSON body field OR the `refresh_token` HttpOnly
-/// cookie. If both are present, the body wins so the frontend can be migrated
-/// gradually without coordinating a flag day.
-#[derive(Debug, Clone, Default, Deserialize)]
-pub struct RefreshTokenRequest {
-    /// The refresh token (optional — falls back to the cookie if absent)
-    #[serde(default, rename = "refreshToken")]
-    pub refresh_token: Option<String>,
-}
+// Phase 3 (PR follows #208): the JSON-body refresh-token contract has been
+// removed. Logout and refresh both source the refresh token exclusively from
+// the `refresh_token` HttpOnly cookie. `LogoutRequest` and
+// `RefreshTokenRequest` no longer exist — see `logout` / `refresh` handlers.
 
 /// Forgot password request payload
 #[derive(Debug, Clone, Deserialize, Validate)]
@@ -149,13 +133,17 @@ pub struct UserResponse {
     pub membership_id: Option<String>,
 }
 
-/// Authentication tokens
+/// Authentication tokens returned in the JSON body.
+///
+/// Phase 3 of the HttpOnly-cookie migration: only the access token is
+/// returned in the JSON body. The refresh token is delivered exclusively
+/// via the `refresh_token` HttpOnly cookie (`Set-Cookie`) — JavaScript
+/// cannot read it, which removes the XSS exfiltration surface that the
+/// pre-migration localStorage contract was exposed to.
 #[derive(Debug, Clone, Serialize)]
 pub struct AuthTokens {
     #[serde(rename = "accessToken")]
     pub access_token: String,
-    #[serde(rename = "refreshToken")]
-    pub refresh_token: String,
 }
 
 /// Registration/Login response
@@ -404,12 +392,16 @@ async fn get_user_profile(db: &sqlx::PgPool, user_id: &Uuid) -> Result<UserRespo
 // ============================================================================
 
 /// POST /api/auth/register
-/// Creates a new user account
+///
+/// Creates a new user account. Phase 3: the refresh token is delivered
+/// exclusively in the `refresh_token` HttpOnly cookie — it is no longer
+/// returned in the JSON body.
 #[axum::debug_handler]
 async fn register(
     State(state): State<AppState>,
+    jar: CookieJar,
     Json(payload): Json<RegisterRequest>,
-) -> Result<Json<AuthResponse>, AppError> {
+) -> Result<(CookieJar, Json<AuthResponse>), AppError> {
     // Validate request
     payload
         .validate()
@@ -548,24 +540,30 @@ async fn register(
 
     tracing::info!("User registered: {}", user_response.id);
 
+    // Phase 3: deliver the refresh token via HttpOnly cookie only.
+    // Max-Age aligns with the DB row's expiry so the browser drops the
+    // cookie when the server-side token expires.
+    let refresh_max_age_secs = (refresh_expires_at - Utc::now()).num_seconds().max(0);
+    let jar = jar.add(build_refresh_cookie(refresh_token, refresh_max_age_secs));
+
     // Note: Returns 200 OK instead of 201 CREATED for compatibility
-    Ok(Json(AuthResponse {
-        user: user_response,
-        tokens: AuthTokens {
-            access_token,
-            refresh_token,
-        },
-    }))
+    Ok((
+        jar,
+        Json(AuthResponse {
+            user: user_response,
+            tokens: AuthTokens { access_token },
+        }),
+    ))
 }
 
 /// POST /api/auth/login
 /// Authenticates a user with email and password.
 ///
-/// Phase 1 of the HttpOnly-cookie migration: returns the refresh token in BOTH
-/// the JSON body (for backward compatibility with the localStorage frontend)
-/// AND a `refresh_token` HttpOnly cookie (for the migrated frontend in later
-/// phases). See `crate::middleware::auth::build_refresh_cookie` for the cookie
-/// attributes and rationale.
+/// Phase 3 of the HttpOnly-cookie migration: the refresh token is delivered
+/// EXCLUSIVELY via the `refresh_token` HttpOnly cookie. It is no longer
+/// returned in the JSON body — JavaScript (including any XSS payload)
+/// cannot read it. See `crate::middleware::auth::build_refresh_cookie` for
+/// the cookie attributes and rationale.
 async fn login(
     State(state): State<AppState>,
     jar: CookieJar,
@@ -669,23 +667,17 @@ async fn login(
 
     tracing::info!("User logged in: {}", user_response.id);
 
-    // Phase 1: also set the refresh token as an HttpOnly cookie. Cookie's
-    // Max-Age aligns with the DB row expiry so the browser drops the cookie
-    // when the server-side token expires.
+    // Phase 3: the refresh token is delivered only via the HttpOnly cookie.
+    // Cookie's Max-Age aligns with the DB row expiry so the browser drops
+    // the cookie when the server-side token expires.
     let refresh_max_age_secs = (refresh_expires_at - Utc::now()).num_seconds().max(0);
-    let jar = jar.add(build_refresh_cookie(
-        refresh_token.clone(),
-        refresh_max_age_secs,
-    ));
+    let jar = jar.add(build_refresh_cookie(refresh_token, refresh_max_age_secs));
 
     Ok((
         jar,
         Json(AuthResponse {
             user: user_response,
-            tokens: AuthTokens {
-                access_token,
-                refresh_token,
-            },
+            tokens: AuthTokens { access_token },
         }),
     ))
 }
@@ -693,13 +685,14 @@ async fn login(
 /// POST /api/auth/logout
 /// Invalidates the user's refresh token and clears the refresh-token cookie.
 ///
-/// Phase 1: in addition to the existing DB cleanup, emits a `Set-Cookie`
-/// header with `Max-Age=0` so the browser drops any cookie set during login.
+/// Phase 3: takes no JSON body — the refresh token to invalidate is read
+/// exclusively from the `refresh_token` HttpOnly cookie. The response
+/// always emits a `Set-Cookie: refresh_token=; Max-Age=0` so the browser
+/// drops the cookie even if it was already expired/missing.
 async fn logout(
     State(state): State<AppState>,
     Extension(auth_user): Extension<AuthUser>,
     jar: CookieJar,
-    Json(payload): Json<LogoutRequest>,
 ) -> Result<(CookieJar, Json<MessageResponse>), AppError> {
     let db = state.db();
 
@@ -707,19 +700,11 @@ async fn logout(
     let user_id = Uuid::parse_str(&auth_user.id)
         .map_err(|_| AppError::Unauthorized("Invalid user ID".to_string()))?;
 
-    // Delete refresh token if provided in the body. (Cookie-only logout falls
-    // back to relying on the cookie clear below; the server-side row will be
-    // garbage-collected on its `expires_at`.)
-    if let Some(refresh_token) = &payload.refresh_token {
-        sqlx::query("DELETE FROM refresh_tokens WHERE user_id = $1 AND token = $2")
-            .bind(&user_id)
-            .bind(refresh_token)
-            .execute(db)
-            .await
-            .map_err(|e| AppError::DatabaseQuery(e.to_string()))?;
-    } else if let Some(cookie_token) = jar.get(REFRESH_COOKIE_NAME).map(|c| c.value().to_string()) {
-        // If the body didn't carry the token but the cookie did, also delete
-        // the row so the server-side state matches the cleared cookie.
+    // Delete the server-side refresh-token row if the cookie carried one.
+    // If the cookie is missing we still proceed — the user's authenticated
+    // session is being torn down regardless, and the row (if any) will be
+    // garbage-collected on its `expires_at`.
+    if let Some(cookie_token) = jar.get(REFRESH_COOKIE_NAME).map(|c| c.value().to_string()) {
         sqlx::query("DELETE FROM refresh_tokens WHERE user_id = $1 AND token = $2")
             .bind(&user_id)
             .bind(&cookie_token)
@@ -756,34 +741,25 @@ async fn logout(
 /// POST /api/auth/refresh
 /// Issues a new access token using a refresh token.
 ///
-/// Phase 1: accepts the refresh token from EITHER (a) the JSON body
-/// `refreshToken` field OR (b) the `refresh_token` HttpOnly cookie. If both
-/// are present, the body wins so the frontend can switch over gradually.
-/// Both paths produce the same response and rotate the refresh-token cookie.
-///
-/// The body is itself optional — a cookie-only client can `POST /api/auth/refresh`
-/// with no body at all.
+/// Phase 3: the refresh token is read EXCLUSIVELY from the `refresh_token`
+/// HttpOnly cookie. The JSON-body `refreshToken` field accepted in Phase 1
+/// is no longer supported — clients that previously sent it must rely on
+/// the browser-managed cookie (axios `withCredentials: true`). Missing or
+/// empty cookies return 401.
 async fn refresh(
     State(state): State<AppState>,
     jar: CookieJar,
-    payload: Option<Json<RefreshTokenRequest>>,
 ) -> Result<(CookieJar, Json<TokenRefreshResponse>), AppError> {
     let db = state.db();
 
-    // Body precedence: if the body carries a non-empty refreshToken, use it;
-    // otherwise fall back to the cookie. Empty body strings are treated as
-    // absent so a buggy frontend sending {"refreshToken": ""} still works.
-    let body_token = payload
-        .and_then(|Json(req)| req.refresh_token)
-        .filter(|t| !t.is_empty());
-    let cookie_token = jar
+    // Phase 3: cookie-only. An empty cookie value is treated as missing so
+    // a stale `Set-Cookie: refresh_token=` (e.g., from a prior logout race)
+    // still produces a clean 401.
+    let supplied_token = jar
         .get(REFRESH_COOKIE_NAME)
         .map(|c| c.value().to_string())
-        .filter(|t| !t.is_empty());
-
-    let supplied_token = body_token.or(cookie_token).ok_or_else(|| {
-        AppError::Unauthorized("Missing refresh token (body or cookie required)".to_string())
-    })?;
+        .filter(|t| !t.is_empty())
+        .ok_or_else(|| AppError::Unauthorized("Missing refresh token cookie".to_string()))?;
 
     // Find valid refresh token
     let token_row: Option<(Uuid,)> = sqlx::query_as(
@@ -853,21 +829,16 @@ async fn refresh(
 
     tracing::debug!("Token refreshed for user: {}", user_row.id);
 
-    // Rotate the cookie too so cookie-using clients stay in sync with the new
-    // server-side token. Max-Age matches the new DB row's expiry.
+    // Phase 3: the rotated refresh token is delivered solely via the
+    // Set-Cookie header — never in the JSON body. Max-Age matches the new
+    // DB row's expiry.
     let refresh_max_age_secs = (refresh_expires_at - Utc::now()).num_seconds().max(0);
-    let jar = jar.add(build_refresh_cookie(
-        new_refresh_token.clone(),
-        refresh_max_age_secs,
-    ));
+    let jar = jar.add(build_refresh_cookie(new_refresh_token, refresh_max_age_secs));
 
     Ok((
         jar,
         Json(TokenRefreshResponse {
-            tokens: AuthTokens {
-                access_token,
-                refresh_token: new_refresh_token,
-            },
+            tokens: AuthTokens { access_token },
         }),
     ))
 }
@@ -1174,6 +1145,29 @@ mod tests {
 
         // Tokens should be unique
         assert_ne!(token1, token2);
+    }
+
+    #[test]
+    fn test_auth_tokens_serialization_omits_refresh_token() {
+        // Phase 3 contract: the AuthTokens body struct must only contain
+        // `accessToken`. A regression that re-adds `refreshToken` here
+        // would leak the token into JSON responses again.
+        let tokens = AuthTokens {
+            access_token: "header.payload.signature".to_string(),
+        };
+        let json = serde_json::to_string(&tokens).unwrap();
+        assert!(
+            json.contains("\"accessToken\":\"header.payload.signature\""),
+            "Serialized AuthTokens must carry accessToken: {json}"
+        );
+        assert!(
+            !json.contains("refreshToken"),
+            "Phase 3: AuthTokens JSON MUST NOT contain a refreshToken field: {json}"
+        );
+        assert!(
+            !json.contains("refresh_token"),
+            "Phase 3: AuthTokens JSON MUST NOT contain a refresh_token field: {json}"
+        );
     }
 
     #[test]

--- a/backend-rust/src/routes/oauth.rs
+++ b/backend-rust/src/routes/oauth.rs
@@ -588,13 +588,15 @@ async fn google_oauth_callback(
         tracing::warn!(error = ?e, "[OAuth] Failed to delete OAuth state");
     }
 
-    // Build success redirect URL
+    // Phase 3: the redirect URL carries only the access token. The refresh
+    // token is delivered exclusively via the `Set-Cookie` header attached
+    // below — never via a URL query parameter, where it would leak into
+    // browser history, server logs, and Referer headers.
     let return_url = validate_return_url(Some(&state_data.return_url), frontend_url);
     let success_url = format!(
-        "{}/oauth/success?token={}&refreshToken={}&isNewUser={}",
+        "{}/oauth/success?token={}&isNewUser={}",
         return_url,
         url_encode(&result.tokens.access_token),
-        url_encode(&result.tokens.refresh_token),
         result.is_new_user
     );
 
@@ -611,8 +613,7 @@ async fn google_oauth_callback(
         Redirect::to(&success_url).into_response()
     };
 
-    // Phase 1: also attach the refresh token as an HttpOnly cookie on the
-    // redirect so the migrated frontend can stop reading from the query string.
+    // Phase 3: the refresh token rides only on the HttpOnly cookie.
     let refresh_max_age_secs = state.config().auth.refresh_token_expiry_secs as i64;
     attach_refresh_cookie(response, result.tokens.refresh_token, refresh_max_age_secs)
 }
@@ -1064,13 +1065,15 @@ async fn line_oauth_callback(
         tracing::warn!(error = ?e, "[OAuth] Failed to delete OAuth state");
     }
 
-    // Build success redirect URL
+    // Phase 3: the redirect URL carries only the access token. The refresh
+    // token is delivered exclusively via the `Set-Cookie` header attached
+    // below — never via a URL query parameter, where it would leak into
+    // browser history, server logs, and Referer headers.
     let return_url = validate_return_url(Some(&state_data.return_url), frontend_url);
     let success_url = format!(
-        "{}/oauth/success?token={}&refreshToken={}&isNewUser={}",
+        "{}/oauth/success?token={}&isNewUser={}",
         return_url,
         url_encode(&result.tokens.access_token),
-        url_encode(&result.tokens.refresh_token),
         result.is_new_user
     );
 
@@ -1086,8 +1089,7 @@ async fn line_oauth_callback(
         Redirect::to(&success_url).into_response()
     };
 
-    // Phase 1: also attach the refresh token as an HttpOnly cookie on the
-    // redirect so the migrated frontend can stop reading from the query string.
+    // Phase 3: the refresh token rides only on the HttpOnly cookie.
     let refresh_max_age_secs = state.config().auth.refresh_token_expiry_secs as i64;
     attach_refresh_cookie(response, result.tokens.refresh_token, refresh_max_age_secs)
 }
@@ -1517,15 +1519,13 @@ async fn ensure_loyalty_enrollment(db: &sqlx::PgPool, user_id: Uuid) -> Result<(
     Ok(())
 }
 
-/// Append the Phase 1 refresh-token HttpOnly cookie to an OAuth redirect
-/// response.
+/// Append the refresh-token HttpOnly cookie to an OAuth redirect response.
 ///
-/// The OAuth callbacks issue a 302 (or HTML meta-refresh on mobile Safari) to
-/// `<frontend>/oauth/success?token=...&refreshToken=...`. The legacy frontend
-/// reads the refresh token from that query string and writes it to
-/// localStorage. Phase 1 also drops the same refresh token into a `Set-Cookie`
-/// header on this redirect so the migrated frontend (Phase 2) can pick it up
-/// from the cookie store instead.
+/// Phase 3: the OAuth callbacks issue a 302 (or HTML meta-refresh on mobile
+/// Safari) to `<frontend>/oauth/success?token=...&isNewUser=...`. The refresh
+/// token is delivered EXCLUSIVELY via the `Set-Cookie` header attached here —
+/// it is no longer emitted as a URL query parameter (Phase 1 contract, now
+/// removed) and never appears anywhere JavaScript can read it.
 ///
 /// `max_age_secs` should match the refresh-token expiry so the browser drops
 /// the cookie at the same time the server-side state is invalidated.

--- a/backend-rust/tests/integration/auth_test.rs
+++ b/backend-rust/tests/integration/auth_test.rs
@@ -3,12 +3,20 @@
 //! Tests for the authentication API endpoints including:
 //! - User registration
 //! - User login
-//! - Token refresh
-//! - Logout
+//! - Token refresh (Phase 3: cookie-only)
+//! - Logout (Phase 3: cookie-only)
+//!
+//! # Phase 3 cookie-only contract
+//!
+//! The JSON-body refresh-token contract has been removed. The refresh token
+//! is delivered exclusively via the `refresh_token` HttpOnly cookie. Tests
+//! that previously POSTed `{"refreshToken": "..."}` to `/auth/refresh` or
+//! `/auth/logout` no longer exist — see `test_refresh_with_body_only_is_rejected`
+//! and the cookie-only variants for the new contract.
 
 use serde_json::{json, Value};
 
-use crate::common::{TestApp, TestClient};
+use crate::common::{TestApp, TestClient, TestResponse};
 
 // ============================================================================
 // Test Helpers
@@ -76,9 +84,11 @@ async fn test_register_user_success() {
         tokens["accessToken"].is_string(),
         "Should have access token"
     );
+    // Phase 3: refresh token is delivered ONLY via the HttpOnly cookie.
     assert!(
-        tokens["refreshToken"].is_string(),
-        "Should have refresh token"
+        tokens.get("refreshToken").is_none(),
+        "Phase 3: response MUST NOT contain a refreshToken in the JSON body. \
+         Got tokens: {tokens}"
     );
 
     let access_token = tokens["accessToken"].as_str().unwrap();
@@ -86,6 +96,13 @@ async fn test_register_user_success() {
         access_token.split('.').count(),
         3,
         "Access token should be a valid JWT"
+    );
+
+    // Phase 3: registration must also emit the refresh_token cookie so the
+    // client has a session immediately without a follow-up login call.
+    assert!(
+        response.set_cookie_for("refresh_token").is_some(),
+        "Registration MUST emit a refresh_token Set-Cookie header (Phase 3)"
     );
 
     // Verify user was actually created in database
@@ -201,9 +218,11 @@ async fn test_login_success() {
         tokens["accessToken"].is_string(),
         "Should have access token"
     );
+    // Phase 3: refresh token is delivered ONLY via the HttpOnly cookie.
     assert!(
-        tokens["refreshToken"].is_string(),
-        "Should have refresh token"
+        tokens.get("refreshToken").is_none(),
+        "Phase 3: response MUST NOT contain a refreshToken in the JSON body. \
+         Got tokens: {tokens}"
     );
 
     let access_token = tokens["accessToken"].as_str().unwrap();
@@ -211,6 +230,13 @@ async fn test_login_success() {
         access_token.split('.').count(),
         3,
         "Access token should be a valid JWT"
+    );
+
+    // Phase 3: login MUST set the refresh_token cookie — that is the sole
+    // delivery channel now.
+    assert!(
+        login_response.set_cookie_for("refresh_token").is_some(),
+        "Login MUST emit a refresh_token Set-Cookie header (Phase 3)"
     );
 
     app.cleanup().await.ok();
@@ -271,6 +297,9 @@ async fn test_login_invalid_password() {
 
 #[tokio::test]
 async fn test_refresh_token() {
+    // Phase 3: refresh is cookie-only. We register to get the Set-Cookie,
+    // capture the cookie value, then POST /auth/refresh with the cookie
+    // attached and NO JSON body fields naming the token.
     let app = TestApp::new().await.expect("Failed to create test app");
 
     let client = app.client();
@@ -288,22 +317,17 @@ async fn test_refresh_token() {
     let register_response = client.post("/api/auth/register", &register_payload).await;
     register_response.assert_status(200);
 
-    let register_body: Value = register_response
-        .json()
-        .expect("Response should be valid JSON");
-    let original_refresh_token = register_body["tokens"]["refreshToken"]
-        .as_str()
-        .expect("Should have refresh token");
-    let _original_access_token = register_body["tokens"]["accessToken"]
-        .as_str()
-        .expect("Should have access token");
+    let original_cookie = register_response
+        .set_cookie_for("refresh_token")
+        .expect("Register must emit a refresh_token cookie (Phase 3)");
+    let original_cookie_value = parse_cookie_value(&original_cookie).to_string();
 
-    // Use refresh token to get new tokens
-    let refresh_payload = json!({
-        "refreshToken": original_refresh_token
-    });
-
-    let refresh_response = client.post("/api/auth/refresh", &refresh_payload).await;
+    // POST /auth/refresh with the cookie attached. Empty JSON body —
+    // there is no longer a body-side path.
+    let cookie_client = app
+        .client()
+        .with_cookie(&format!("refresh_token={original_cookie_value}"));
+    let refresh_response = cookie_client.post("/api/auth/refresh", &json!({})).await;
 
     refresh_response.assert_status(200);
 
@@ -320,18 +344,31 @@ async fn test_refresh_token() {
     let new_access_token = tokens["accessToken"]
         .as_str()
         .expect("Should have new access token");
-    let new_refresh_token = tokens["refreshToken"]
-        .as_str()
-        .expect("Should have new refresh token");
+    // Phase 3: NO refreshToken in body.
+    assert!(
+        tokens.get("refreshToken").is_none(),
+        "Phase 3: refresh response MUST NOT contain a refreshToken in the body"
+    );
 
     assert_eq!(
         new_access_token.split('.').count(),
         3,
         "New access token should be a valid JWT"
     );
+
+    // Phase 3: the rotated refresh token is delivered exclusively via
+    // Set-Cookie. The new cookie value must differ from the old one.
+    let rotated_cookie = refresh_response
+        .set_cookie_for("refresh_token")
+        .expect("Refresh must rotate the refresh_token cookie (Phase 3)");
+    let rotated_value = parse_cookie_value(&rotated_cookie);
     assert!(
-        !new_refresh_token.is_empty(),
-        "New refresh token should not be empty"
+        !rotated_value.is_empty(),
+        "Rotated cookie value must not be empty"
+    );
+    assert_ne!(
+        rotated_value, original_cookie_value,
+        "Refresh MUST rotate the refresh token (new cookie != old cookie)"
     );
 
     app.cleanup().await.ok();
@@ -343,6 +380,10 @@ async fn test_refresh_token() {
 
 #[tokio::test]
 async fn test_logout() {
+    // Phase 3: logout reads the refresh token from the HttpOnly cookie and
+    // accepts no JSON body. The handler always emits a clearing Set-Cookie,
+    // and after logout the underlying server-side row is gone so a refresh
+    // attempt with the (now-stale) cookie value must fail.
     let app = TestApp::new().await.expect("Failed to create test app");
 
     let client = app.client();
@@ -366,18 +407,18 @@ async fn test_logout() {
     let access_token = register_body["tokens"]["accessToken"]
         .as_str()
         .expect("Should have access token");
-    let refresh_token = register_body["tokens"]["refreshToken"]
-        .as_str()
-        .expect("Should have refresh token");
 
-    // Logout with the access token
-    let auth_client = TestClient::new(app.router()).with_auth(access_token);
+    let refresh_cookie = register_response
+        .set_cookie_for("refresh_token")
+        .expect("Register must emit a refresh_token cookie (Phase 3)");
+    let refresh_cookie_value = parse_cookie_value(&refresh_cookie).to_string();
 
-    let logout_payload = json!({
-        "refreshToken": refresh_token
-    });
+    // Logout with the access token AND the refresh cookie. Empty body.
+    let auth_client = TestClient::new(app.router())
+        .with_auth(access_token)
+        .with_cookie(&format!("refresh_token={refresh_cookie_value}"));
 
-    let logout_response = auth_client.post("/api/auth/logout", &logout_payload).await;
+    let logout_response = auth_client.post("/api/auth/logout", &json!({})).await;
 
     logout_response.assert_status(200);
 
@@ -397,17 +438,30 @@ async fn test_logout() {
         message
     );
 
-    // Try to use the refresh token - should fail
-    let refresh_payload = json!({
-        "refreshToken": refresh_token
-    });
+    // Logout must clear the cookie.
+    let clear_cookie = logout_response
+        .set_cookie_for("refresh_token")
+        .expect("Logout MUST emit a clearing refresh_token Set-Cookie");
+    assert!(
+        clear_cookie.contains("Max-Age=0"),
+        "Logout's clearing cookie must use Max-Age=0: {clear_cookie}"
+    );
 
-    let refresh_response = client.post("/api/auth/refresh", &refresh_payload).await;
+    // Try to refresh with the now-revoked cookie value — the server-side
+    // row was deleted during logout, so the cookie no longer maps to any
+    // user and the refresh must fail.
+    let stale_cookie_client = app
+        .client()
+        .with_cookie(&format!("refresh_token={refresh_cookie_value}"));
+    let refresh_response = stale_cookie_client
+        .post("/api/auth/refresh", &json!({}))
+        .await;
 
     assert!(
         refresh_response.status == 401 || refresh_response.status == 400,
-        "Refresh with invalidated token should fail with 401 or 400, got {}",
-        refresh_response.status
+        "Refresh with invalidated cookie should fail with 401 or 400, got {}: {}",
+        refresh_response.status,
+        refresh_response.body
     );
 
     app.cleanup().await.ok();
@@ -485,15 +539,14 @@ async fn test_login_nonexistent_email() {
 
 #[tokio::test]
 async fn test_refresh_invalid_token() {
+    // Phase 3: invalid cookie value must be rejected.
     let app = TestApp::new().await.expect("Failed to create test app");
 
-    let client = app.client();
+    let client = app
+        .client()
+        .with_cookie("refresh_token=invalid-refresh-token-that-does-not-exist");
 
-    let refresh_payload = json!({
-        "refreshToken": "invalid-refresh-token-that-does-not-exist"
-    });
-
-    let response = client.post("/api/auth/refresh", &refresh_payload).await;
+    let response = client.post("/api/auth/refresh", &json!({})).await;
 
     assert!(
         response.status == 401 || response.status == 400,
@@ -505,18 +558,31 @@ async fn test_refresh_invalid_token() {
 }
 
 // ============================================================================
-// Phase 1: HttpOnly refresh-token cookie tests
+// Phase 3: HttpOnly refresh-token cookie is the ONLY delivery channel
 // ============================================================================
 //
-// These tests cover the additive Phase 1 of the cookie migration:
-// - login also returns a `refresh_token` HttpOnly cookie
-// - /refresh works with body-only, cookie-only, or both (body wins)
-// - /logout clears the cookie
+// These tests pin the Phase 3 contract:
+// - login, register, and /refresh all emit `Set-Cookie: refresh_token=...`
+// - none of them include a `refreshToken` field in the JSON body
+// - /refresh and /logout ignore any JSON-body `refreshToken` field — the
+//   cookie is the sole source of truth
+// - /logout clears the cookie via Max-Age=0
+// - missing cookie → 401
 
-/// Register a user and return (email, refresh_token_from_body, set_cookie_header).
-async fn register_and_get_refresh_artifacts(
-    client: &TestClient,
-) -> (String, String, Option<String>) {
+/// Extract the cookie value (the part after `name=` and before `;`).
+///
+/// Named `parse_cookie_value` rather than `cookie_value` so tests can bind a
+/// `cookie_value` local without shadowing the helper.
+fn parse_cookie_value(set_cookie_header: &str) -> &str {
+    let after_eq = set_cookie_header
+        .split_once('=')
+        .map(|(_, rest)| rest)
+        .expect("Set-Cookie header must contain '='");
+    after_eq.split(';').next().unwrap_or(after_eq)
+}
+
+/// Register a user and return (email, login_response, refresh_cookie_value).
+async fn register_user(client: &TestClient) -> (String, TestResponse, String) {
     let email = unique_email();
     let register_payload = json!({
         "email": email,
@@ -527,47 +593,104 @@ async fn register_and_get_refresh_artifacts(
     let response = client.post("/api/auth/register", &register_payload).await;
     response.assert_status(200);
 
-    let body: Value = response.json().expect("Response should be valid JSON");
-    let refresh_token = body["tokens"]["refreshToken"]
-        .as_str()
-        .expect("Should have refresh token")
-        .to_string();
-    // Registration doesn't currently set the cookie (Phase 1 only modifies
-    // login/refresh/logout), but capture whatever Set-Cookie is present.
-    let set_cookie = response.set_cookie_for("refresh_token");
-    (email, refresh_token, set_cookie)
+    let cookie = response
+        .set_cookie_for("refresh_token")
+        .expect("Register MUST emit a refresh_token Set-Cookie header (Phase 3)");
+    let value = parse_cookie_value(&cookie).to_string();
+    (email, response, value)
 }
 
-/// Log a user in and return (refresh_token_from_body, full_set_cookie_header_value).
-async fn login_and_capture_cookie(
-    client: &TestClient,
-    email: &str,
-    password: &str,
-) -> (String, String) {
+/// Log a user in and return (login_response, refresh_cookie_value).
+async fn login_user(client: &TestClient, email: &str, password: &str) -> (TestResponse, String) {
     let login_payload = json!({ "email": email, "password": password });
     let response = client.post("/api/auth/login", &login_payload).await;
     response.assert_status(200);
 
-    let body: Value = response.json().expect("Response should be valid JSON");
-    let refresh_token = body["tokens"]["refreshToken"]
-        .as_str()
-        .expect("Login should return refresh token in body")
-        .to_string();
-
-    let set_cookie = response
+    let cookie = response
         .set_cookie_for("refresh_token")
-        .expect("Login MUST emit a refresh_token Set-Cookie header (Phase 1)");
-
-    (refresh_token, set_cookie)
+        .expect("Login MUST emit a refresh_token Set-Cookie header (Phase 3)");
+    let value = parse_cookie_value(&cookie).to_string();
+    (response, value)
 }
 
-/// Extract the cookie value (the part after `name=` and before `;`).
-fn cookie_value(set_cookie_header: &str) -> &str {
-    let after_eq = set_cookie_header
-        .split_once('=')
-        .map(|(_, rest)| rest)
-        .expect("Set-Cookie header must contain '='");
-    after_eq.split(';').next().unwrap_or(after_eq)
+#[tokio::test]
+async fn test_login_does_not_return_refresh_token_in_body() {
+    // Phase 3 contract: the JSON body carries only the access token.
+    // Any client still reading `data.tokens.refreshToken` will get `undefined`.
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let client = app.client();
+
+    let (email, _register_response, _) = register_user(&client).await;
+    let (login_response, _cookie_value) = login_user(&client, &email, "SecurePass123!").await;
+
+    let body: Value = login_response
+        .json()
+        .expect("Login response should be valid JSON");
+
+    assert!(
+        body["tokens"]["accessToken"].is_string(),
+        "Body must still carry accessToken"
+    );
+    assert!(
+        body["tokens"].get("refreshToken").is_none(),
+        "Phase 3: login response MUST NOT contain a refreshToken in the body. \
+         tokens={}",
+        body["tokens"]
+    );
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_register_does_not_return_refresh_token_in_body() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let client = app.client();
+
+    let (_email, register_response, _) = register_user(&client).await;
+    let body: Value = register_response
+        .json()
+        .expect("Register response should be valid JSON");
+
+    assert!(
+        body["tokens"]["accessToken"].is_string(),
+        "Body must still carry accessToken"
+    );
+    assert!(
+        body["tokens"].get("refreshToken").is_none(),
+        "Phase 3: register response MUST NOT contain a refreshToken in the body. \
+         tokens={}",
+        body["tokens"]
+    );
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_refresh_does_not_return_refresh_token_in_body() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let client = app.client();
+
+    let (_email, _register_response, cookie_value) = register_user(&client).await;
+
+    let cookie_client = app
+        .client()
+        .with_cookie(&format!("refresh_token={cookie_value}"));
+    let response = cookie_client.post("/api/auth/refresh", &json!({})).await;
+    response.assert_status(200);
+
+    let body: Value = response.json().expect("Response should be valid JSON");
+    assert!(
+        body["tokens"]["accessToken"].is_string(),
+        "Refresh body must carry accessToken"
+    );
+    assert!(
+        body["tokens"].get("refreshToken").is_none(),
+        "Phase 3: refresh response MUST NOT contain a refreshToken in the body. \
+         tokens={}",
+        body["tokens"]
+    );
+
+    app.cleanup().await.ok();
 }
 
 #[tokio::test]
@@ -575,22 +698,13 @@ async fn test_login_sets_refresh_token_cookie_with_security_attributes() {
     let app = TestApp::new().await.expect("Failed to create test app");
     let client = app.client();
 
-    // Register a user (registration doesn't set the cookie in Phase 1).
-    let (email, _initial_refresh, _) = register_and_get_refresh_artifacts(&client).await;
+    let (email, _register_response, _) = register_user(&client).await;
+    let (login_response, _cookie_value) = login_user(&client, &email, "SecurePass123!").await;
+    let set_cookie = login_response
+        .set_cookie_for("refresh_token")
+        .expect("Login MUST emit a refresh_token Set-Cookie header (Phase 3)");
 
-    // Log in — login MUST emit the refresh_token cookie.
-    let (body_refresh_token, set_cookie) =
-        login_and_capture_cookie(&client, &email, "SecurePass123!").await;
-
-    // The cookie value matches the refresh token returned in the JSON body.
-    assert_eq!(
-        cookie_value(&set_cookie),
-        body_refresh_token,
-        "Cookie value must match the refreshToken in the JSON response so both \
-         storage paths reference the same server-side row"
-    );
-
-    // Defense-in-depth attributes per Phase 1 spec.
+    // Defense-in-depth attributes.
     assert!(
         set_cookie.contains("HttpOnly"),
         "Cookie must be HttpOnly to prevent XSS exfiltration: {set_cookie}"
@@ -612,36 +726,39 @@ async fn test_login_sets_refresh_token_cookie_with_security_attributes() {
         "Cookie must carry an explicit Max-Age: {set_cookie}"
     );
 
+    // The cookie value is the actual refresh token: non-empty, opaque, and
+    // distinct from the access token in the body so a header logger can't
+    // be tricked into emitting it.
+    let value = parse_cookie_value(&set_cookie);
+    assert!(
+        !value.is_empty(),
+        "Refresh cookie value must not be empty: {set_cookie}"
+    );
+
     app.cleanup().await.ok();
 }
 
 #[tokio::test]
-async fn test_refresh_with_body_only_still_works() {
-    // Backwards-compatibility: existing localStorage frontend POSTs the token
-    // in the body. This must keep working unchanged.
+async fn test_refresh_with_body_only_is_rejected() {
+    // Phase 3 broke the body-side contract. A client that POSTs
+    // `{"refreshToken": "..."}` WITHOUT the cookie must get 401 — the body
+    // field is silently ignored.
     let app = TestApp::new().await.expect("Failed to create test app");
     let client = app.client();
 
-    let (email, _, _) = register_and_get_refresh_artifacts(&client).await;
-    let (body_refresh_token, _set_cookie) =
-        login_and_capture_cookie(&client, &email, "SecurePass123!").await;
+    let (_email, _register_response, cookie_value) = register_user(&client).await;
 
-    let refresh_payload = json!({ "refreshToken": body_refresh_token });
-    let response = client.post("/api/auth/refresh", &refresh_payload).await;
+    // Same client (no cookie attached) sends the (otherwise-valid) refresh
+    // token in the JSON body. The handler must NOT honour it.
+    let body_payload = json!({ "refreshToken": cookie_value });
+    let response = client.post("/api/auth/refresh", &body_payload).await;
 
-    response.assert_status(200);
-    let body: Value = response.json().expect("Response should be valid JSON");
-    assert!(body["tokens"]["accessToken"].is_string());
-    assert!(body["tokens"]["refreshToken"].is_string());
-
-    // Refresh should also rotate the cookie.
-    let new_set_cookie = response
-        .set_cookie_for("refresh_token")
-        .expect("Refresh must rotate the cookie too");
-    assert_eq!(
-        cookie_value(&new_set_cookie),
-        body["tokens"]["refreshToken"].as_str().unwrap(),
-        "Rotated cookie value must match the new refresh token in the body"
+    assert!(
+        response.status == 401 || response.status == 400,
+        "Phase 3: body-side refreshToken MUST be ignored. Expected 401/400, \
+         got {}: {}",
+        response.status,
+        response.body
     );
 
     app.cleanup().await.ok();
@@ -649,21 +766,15 @@ async fn test_refresh_with_body_only_still_works() {
 
 #[tokio::test]
 async fn test_refresh_with_cookie_only_works() {
-    // The Phase 2 frontend will stop sending the body and rely on the cookie.
-    // Verify that path right now so Phase 2 can ship without a backend change.
     let app = TestApp::new().await.expect("Failed to create test app");
     let client = app.client();
 
-    let (email, _, _) = register_and_get_refresh_artifacts(&client).await;
-    let (body_refresh_token, _set_cookie) =
-        login_and_capture_cookie(&client, &email, "SecurePass123!").await;
+    let (_email, _register_response, cookie_value) = register_user(&client).await;
 
-    // Build a client that sends the refresh-token cookie but no body.
     let cookie_client = app
         .client()
-        .with_cookie(&format!("refresh_token={body_refresh_token}"));
+        .with_cookie(&format!("refresh_token={cookie_value}"));
 
-    // Empty JSON object body — handler should fall back to the cookie.
     let response = cookie_client.post("/api/auth/refresh", &json!({})).await;
     response.assert_status(200);
 
@@ -676,37 +787,43 @@ async fn test_refresh_with_cookie_only_works() {
         3,
         "New access token should be a valid JWT"
     );
-    assert!(body["tokens"]["refreshToken"].is_string());
+
+    // Refresh rotates the cookie.
+    let rotated = response
+        .set_cookie_for("refresh_token")
+        .expect("Refresh must rotate the cookie");
+    let rotated_value = parse_cookie_value(&rotated);
+    assert_ne!(
+        rotated_value, cookie_value,
+        "Refresh MUST rotate the refresh-token value"
+    );
 
     app.cleanup().await.ok();
 }
 
 #[tokio::test]
-async fn test_refresh_with_both_body_and_cookie_uses_body() {
-    // Spec: "Body takes precedence if both present (so the frontend can switch
-    // over gradually)." Verify by sending a VALID body token and an INVALID
-    // cookie token — the request must succeed (proving the body was used).
+async fn test_refresh_with_body_and_invalid_cookie_fails() {
+    // Phase 3 inverts the Phase 1 precedence rule. Even if a (valid)
+    // refresh token is in the body, an INVALID cookie value must cause
+    // the request to fail — the cookie is now authoritative.
     let app = TestApp::new().await.expect("Failed to create test app");
     let client = app.client();
 
-    let (email, _, _) = register_and_get_refresh_artifacts(&client).await;
-    let (body_refresh_token, _set_cookie) =
-        login_and_capture_cookie(&client, &email, "SecurePass123!").await;
+    let (_email, _register_response, cookie_value) = register_user(&client).await;
 
     let cookie_client = app
         .client()
         .with_cookie("refresh_token=this-cookie-token-is-not-valid");
 
-    let refresh_payload = json!({ "refreshToken": body_refresh_token });
-    let response = cookie_client
-        .post("/api/auth/refresh", &refresh_payload)
-        .await;
+    let body_payload = json!({ "refreshToken": cookie_value });
+    let response = cookie_client.post("/api/auth/refresh", &body_payload).await;
 
-    response.assert_status(200);
-    let body: Value = response.json().expect("Response should be valid JSON");
     assert!(
-        body["tokens"]["accessToken"].is_string(),
-        "Body token must take precedence over the (invalid) cookie token"
+        response.status == 401 || response.status == 400,
+        "Phase 3: an invalid cookie must fail even if a valid token is in \
+         the body. Expected 401/400, got {}: {}",
+        response.status,
+        response.body
     );
 
     app.cleanup().await.ok();
@@ -734,21 +851,19 @@ async fn test_logout_clears_refresh_token_cookie() {
     let app = TestApp::new().await.expect("Failed to create test app");
     let client = app.client();
 
-    let (email, _, _) = register_and_get_refresh_artifacts(&client).await;
-    let (body_refresh_token, _set_cookie) =
-        login_and_capture_cookie(&client, &email, "SecurePass123!").await;
+    let (email, _register_response, _) = register_user(&client).await;
 
-    // Log in again to get an access token (we have body_refresh_token but
-    // need an access token for the logout endpoint).
-    let login_payload = json!({ "email": email, "password": "SecurePass123!" });
-    let login_response = client.post("/api/auth/login", &login_payload).await;
-    login_response.assert_status(200);
+    // Log in to get an access token paired with a fresh cookie.
+    let (login_response, cookie_value) = login_user(&client, &email, "SecurePass123!").await;
     let login_body: Value = login_response.json().unwrap();
     let access_token = login_body["tokens"]["accessToken"].as_str().unwrap();
 
-    let auth_client = TestClient::new(app.router()).with_auth(access_token);
-    let logout_payload = json!({ "refreshToken": body_refresh_token });
-    let logout_response = auth_client.post("/api/auth/logout", &logout_payload).await;
+    // Phase 3: logout reads the refresh token from the cookie, not the body.
+    let auth_client = TestClient::new(app.router())
+        .with_auth(access_token)
+        .with_cookie(&format!("refresh_token={cookie_value}"));
+
+    let logout_response = auth_client.post("/api/auth/logout", &json!({})).await;
     logout_response.assert_status(200);
 
     let clear_cookie = logout_response
@@ -756,7 +871,7 @@ async fn test_logout_clears_refresh_token_cookie() {
         .expect("Logout MUST emit a refresh_token Set-Cookie header to clear it");
 
     assert_eq!(
-        cookie_value(&clear_cookie),
+        parse_cookie_value(&clear_cookie),
         "",
         "Cleared cookie value must be empty"
     );

--- a/frontend/src/pages/auth/OAuthSuccessPage.tsx
+++ b/frontend/src/pages/auth/OAuthSuccessPage.tsx
@@ -28,13 +28,12 @@ export default function OAuthSuccessPage() {
       const error = searchParams.get('error');
       const isPWARedirect = searchParams.get('pwa_redirect') === 'true';
 
-      // Phase 2: the backend still appends `refreshToken=…` to the OAuth
-      // success redirect URL for the PWA deep-link handoff (Phase 3 will
-      // drop it from the URL too). For the in-browser path we ignore the
-      // URL param entirely — the same response carries `Set-Cookie:
-      // refresh_token=…; HttpOnly; Path=/api/auth`, and that cookie is
-      // the source of truth for refreshes from now on.
-      const pwaRedirectRefreshToken = searchParams.get('refreshToken');
+      // Phase 3: the backend no longer appends `refreshToken=…` to the
+      // OAuth success redirect URL. The refresh token rides exclusively
+      // on the `Set-Cookie: refresh_token=…; HttpOnly; Path=/api/auth`
+      // header attached to the same redirect — JavaScript can't read it
+      // and it never appears in browser history, server logs, or
+      // Referer headers.
 
       if (error) {
         notify.error('Social login failed. Please try again.');
@@ -42,9 +41,8 @@ export default function OAuthSuccessPage() {
         return;
       }
 
-      // Phase 2: only `token` (the access token) is required. The
-      // refresh token is no longer sourced from the URL — it lives in
-      // the HttpOnly cookie.
+      // Only `token` (the access token) is required. The refresh token
+      // lives in the HttpOnly cookie set on this same redirect response.
       if (!token) {
         notify.error('Invalid authentication response. Please try again.');
         navigate('/login');
@@ -54,17 +52,16 @@ export default function OAuthSuccessPage() {
       try {
         const pwaInfo = detectPWA();
 
-        // PWA deep-link handoff: an iOS PWA opens OAuth in Safari (a
-        // separate cookie jar from the standalone PWA). The round-trip
-        // back to the standalone window can't carry Safari's cookie, so
-        // until Phase 3 removes the URL param we still pass the
-        // URL-param refresh token through `handlePWAOAuthSuccess` to
-        // bridge the gap. If the param isn't present (e.g. Phase 3 has
-        // shipped or this isn't actually a PWA round-trip) we pass an
-        // empty string and the helper degrades gracefully.
+        // PWA deep-link handoff. The legacy URL-param refresh-token
+        // bridge was removed in Phase 3 — the cookie set by the backend
+        // is now the only delivery channel. `handlePWAOAuthSuccess`
+        // still receives the access token so it can fire the deep-link
+        // redirect, but the refresh-token field is intentionally empty;
+        // the standalone PWA picks the refresh token up from the
+        // browser's cookie jar on the next `/api/auth/refresh` call.
         const pwaTokens = {
           accessToken: token,
-          refreshToken: pwaRedirectRefreshToken ?? '',
+          refreshToken: '',
           isNewUser,
         };
 
@@ -90,7 +87,7 @@ export default function OAuthSuccessPage() {
           restoreIOSPWAManifest();
         }
 
-        // Phase 2: store the access token only. The refresh token is in
+        // Phase 3: store the access token only. The refresh token is in
         // the HttpOnly cookie set by the backend on the OAuth callback
         // redirect — the browser will send it automatically on the next
         // /api/auth/refresh call.
@@ -113,7 +110,7 @@ export default function OAuthSuccessPage() {
         const { user } = await response.json();
 
         // Update auth store with user data. (No `refreshToken` field —
-        // that lives in the HttpOnly cookie now.)
+        // that lives in the HttpOnly cookie now, Phase 3.)
         useAuthStore.setState({
           user,
           accessToken: token,

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -54,20 +54,19 @@ export const authService = {
   },
 
   async logout(): Promise<void> {
-    // Phase 2: refresh token lives in the HttpOnly `refresh_token` cookie
-    // (set by Phase 1 backend, PR #194). The browser sends it automatically
-    // because `api` is configured with `withCredentials: true`. The body is
-    // intentionally empty — the backend reads the token from the cookie and
-    // also clears it via `Set-Cookie: refresh_token=; Max-Age=0`.
+    // Phase 3: refresh token lives ONLY in the HttpOnly `refresh_token`
+    // cookie. The browser sends it automatically because `api` is
+    // configured with `withCredentials: true`. The body is empty and the
+    // backend ignores any body fields — it reads the token from the
+    // cookie and clears it via `Set-Cookie: refresh_token=; Max-Age=0`.
     await api.post<LogoutResponse>('/auth/logout', {});
   },
 
   async refreshToken(): Promise<RefreshTokenResponse> {
     logger.log('[Auth Debug] Token refresh attempt');
-    // Phase 2: empty body — backend reads `refresh_token` from the HttpOnly
-    // cookie (Phase 1 backend supports body OR cookie; sending no body forces
-    // the cookie path). The cookie travels because `api` uses
-    // `withCredentials: true`.
+    // Phase 3: empty body. The backend reads `refresh_token` from the
+    // HttpOnly cookie exclusively — the body-side contract was removed.
+    // The cookie travels because `api` uses `withCredentials: true`.
     const response = await api.post<RefreshTokenResponse>('/auth/refresh', {});
     logger.log('[Auth Debug] Token refresh response', {
       success: !!response.data.tokens,

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -50,9 +50,11 @@ interface AuthState {
   }) => Promise<void>;
   logout: () => Promise<void>;
   refreshAuth: () => Promise<void>;
-  // Phase 2: only the access token lives in the store; the refresh token
-  // is held by the browser as an HttpOnly cookie (`refresh_token`) set by
-  // the backend (Phase 1, PR #194) and never readable from JavaScript.
+  // Phase 3: only the access token lives in the store. The refresh token
+  // is held exclusively by the browser as an HttpOnly cookie
+  // (`refresh_token`) and is never readable from JavaScript. The Phase 1
+  // body-side contract has been removed from the backend, so any
+  // `response.tokens.refreshToken` field is now `undefined`.
   setTokens: (accessToken: string) => void;
   clearAuth: () => void;
   checkAuthStatus: () => Promise<boolean>;
@@ -71,9 +73,10 @@ export const useAuthStore = create<AuthState>()(
         set({ isLoading: true });
         try {
           const response = await authService.login(email, password, rememberMe);
-          // Phase 2: ignore `response.tokens.refreshToken` — the backend has
-          // also set it as an HttpOnly cookie (Phase 1, PR #194). The cookie
-          // is the source of truth; we never store the refresh token in JS.
+          // Phase 3: the response body carries only the access token. The
+          // refresh token lives exclusively in the HttpOnly cookie set on
+          // the same response (`Set-Cookie: refresh_token=...`). We never
+          // store the refresh token in JS — it is unreadable from here.
           set({
             user: response.user,
             accessToken: response.tokens.accessToken,
@@ -92,7 +95,7 @@ export const useAuthStore = create<AuthState>()(
         set({ isLoading: true });
         try {
           const response = await authService.register(data);
-          // Phase 2: same rationale as login — refresh token is in the
+          // Phase 3: same rationale as login — refresh token is in the
           // HttpOnly cookie set by the backend; we keep only the access
           // token in JS.
           set({
@@ -111,10 +114,10 @@ export const useAuthStore = create<AuthState>()(
 
       logout: async () => {
         try {
-          // Phase 2: no body argument — `authService.logout()` posts an
-          // empty body and the browser sends the `refresh_token` cookie
-          // automatically (axios `withCredentials: true`). The backend
-          // both deletes the row and clears the cookie via Set-Cookie.
+          // Phase 3: `authService.logout()` posts an empty body. The
+          // browser sends the `refresh_token` cookie automatically (axios
+          // `withCredentials: true`); the backend reads the cookie, deletes
+          // the server-side row, and clears the cookie via Set-Cookie.
           await authService.logout();
         } catch (_error) {
           // Logout error - continue with local logout
@@ -130,15 +133,16 @@ export const useAuthStore = create<AuthState>()(
           const controller = new AbortController();
           const timeoutId = setTimeout(() => controller.abort(), 10000); // 10s timeout
 
-          // Phase 2: no token argument — the refresh token rides as an
-          // HttpOnly cookie. The backend reads `refresh_token` from the
-          // cookie and rotates it (sets a new one in the response).
+          // Phase 3: no token argument — the refresh token rides only as
+          // an HttpOnly cookie. The backend reads `refresh_token` from
+          // the cookie, rotates it via Set-Cookie, and returns only the
+          // new access token in the JSON body.
           const response = await authService.refreshToken();
           clearTimeout(timeoutId);
 
-          // Phase 2: only the access token enters the store. The new
-          // refresh token in the JSON body is ignored — the cookie that
-          // the backend set on this same response is now authoritative.
+          // Phase 3: only the access token enters the store. The body
+          // never contains a refresh token any more — the rotated cookie
+          // is the source of truth.
           set({
             accessToken: response.tokens.accessToken,
           });
@@ -161,7 +165,7 @@ export const useAuthStore = create<AuthState>()(
       },
 
       setTokens: (accessToken: string) => {
-        // Phase 2: only the access token is settable from JS. The refresh
+        // Phase 3: only the access token is settable from JS. The refresh
         // token arrives as an HttpOnly cookie that the browser stores
         // automatically; we don't (and can't) touch it.
         set({ accessToken });
@@ -249,8 +253,8 @@ export const useAuthStore = create<AuthState>()(
           }
 
           // Token is invalid or expired — try to refresh. We can no longer
-          // gate on a JS-visible refresh token (Phase 2: it lives in the
-          // HttpOnly cookie). We just attempt the refresh; the backend
+          // gate on a JS-visible refresh token (Phase 3: it lives only in
+          // the HttpOnly cookie). We just attempt the refresh; the backend
           // returns 401 if the cookie is missing/expired and we fall
           // through to clearAuth() below.
           try {
@@ -298,11 +302,13 @@ export const useAuthStore = create<AuthState>()(
     }),
     {
       name: 'auth-storage',
-      // Phase 2: `refreshToken` is intentionally absent. It lives in the
+      // Phase 3: `refreshToken` is intentionally absent. It lives in the
       // browser's HttpOnly cookie jar (`refresh_token`) so JavaScript —
       // including any XSS payload — cannot read it. The one-time cleanup
-      // of any stale `refreshToken` left over from Phase 1 happens on
-      // app startup via `migrateAuthStorageForCookieRefreshToken()`.
+      // of any stale `refreshToken` left over from earlier builds happens
+      // on app startup via `migrateAuthStorageForCookieRefreshToken()`,
+      // which we retain permanently as cheap defense for offline-built
+      // clients that may upgrade from pre-Phase-2 versions.
       partialize: (state) => ({
         user: state.user,
         accessToken: state.accessToken,

--- a/frontend/src/utils/__tests__/axiosInterceptor.test.ts
+++ b/frontend/src/utils/__tests__/axiosInterceptor.test.ts
@@ -23,14 +23,14 @@ vi.mock('../apiConfig', () => ({
 
 // Mock auth store
 //
-// Phase 2 (HttpOnly-cookie refresh token): the store no longer exposes
-// `refreshToken`. The interceptor must NOT key on a JS-visible refresh
-// token any more — it always attempts the refresh, and the browser
-// supplies the `refresh_token` cookie automatically. The mock therefore
-// exposes only `accessToken`, `clearAuth`, and `refreshAuth`. If a
-// regression re-introduces a `state.refreshToken` read, the interceptor
-// will see `undefined` here and the test that asserts "refresh attempted
-// even without a JS refresh token" will fail.
+// Phase 3 (HttpOnly-cookie refresh token, body-side contract removed):
+// the store no longer exposes `refreshToken`. The interceptor must NOT
+// key on a JS-visible refresh token — it always attempts the refresh,
+// and the browser supplies the `refresh_token` cookie automatically.
+// The mock therefore exposes only `accessToken`, `clearAuth`, and
+// `refreshAuth`. If a regression re-introduces a `state.refreshToken`
+// read, the interceptor will see `undefined` here and the test that
+// asserts "refresh attempted even without a JS refresh token" will fail.
 const mockClearAuth = vi.fn();
 const mockRefreshAuth = vi.fn();
 let mockAccessToken: string | null = 'valid-token';
@@ -52,7 +52,7 @@ describe('axiosInterceptor - Auth Refresh Loop Prevention', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAccessToken = 'valid-token';
-    // Phase 2: no `mockRefreshToken` — see the mock-store comment above.
+    // Phase 3: no `mockRefreshToken` — see the mock-store comment above.
 
     // Mock window.location
     // @ts-expect-error - we're intentionally replacing window.location for testing
@@ -232,7 +232,7 @@ describe('addAuthTokenInterceptor - Instance interceptor', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockAccessToken = 'valid-token';
-    // Phase 2: no `mockRefreshToken` — see the mock-store comment above.
+    // Phase 3: no `mockRefreshToken` — see the mock-store comment above.
 
     // Create a new axios instance for each test
     axiosInstance = axios.create({
@@ -330,9 +330,9 @@ describe('Refresh loop scenario simulation', () => {
   it('should handle the complete refresh failure flow', async () => {
     // Simulate the scenario:
     // 1. User has expired access token; the HttpOnly refresh-token
-    //    cookie is also expired or missing (Phase 2: refresh token no
-    //    longer lives in JS, so the access token is the only thing the
-    //    interceptor sees up front).
+    //    cookie is also expired or missing (Phase 3: refresh token no
+    //    longer lives in JS at all, so the access token is the only
+    //    thing the interceptor sees up front).
     // 2. API call returns 401
     // 3. Interceptor calls refreshAuth (no longer gated on a JS refresh
     //    token — it always tries).
@@ -356,16 +356,18 @@ describe('Refresh loop scenario simulation', () => {
 });
 
 /**
- * Phase 2 contract: with the refresh token now in an HttpOnly cookie,
- * the interceptor and the auth axios instance must satisfy three
- * properties for the cookie path to actually work end-to-end.
+ * Phase 3 contract: the refresh token lives EXCLUSIVELY in the HttpOnly
+ * cookie. The backend has dropped the body-side `refreshToken` from
+ * /auth/login, /auth/register, and /auth/refresh responses, and ignores
+ * any `refreshToken` field clients try to send on /auth/refresh or
+ * /auth/logout. These tests pin the frontend half of that contract.
  *
- * These tests assert the contract via direct inspection of the modules
- * rather than firing real HTTP, because the existing global/instance
- * 401-handling tests in this file are already structural — full
- * network-level mocking is intentionally out of scope here.
+ * They assert the contract via direct inspection of the modules rather
+ * than firing real HTTP, because the existing global/instance 401-
+ * handling tests in this file are already structural — full network-
+ * level mocking is intentionally out of scope here.
  */
-describe('Phase 2 — HttpOnly cookie refresh contract', () => {
+describe('Phase 3 — HttpOnly cookie refresh contract', () => {
   it('the auth axios instance must send credentials so the refresh_token cookie travels', async () => {
     // The cookie won't ride on a cross-origin request unless
     // `withCredentials: true` is set on the axios instance posting to
@@ -378,36 +380,42 @@ describe('Phase 2 — HttpOnly cookie refresh contract', () => {
     expect(api.defaults.withCredentials).toBe(true);
   });
 
-  it('authService.refreshToken sends an empty body so the backend uses the cookie', async () => {
-    // Phase 1 backend prefers the body when both body and cookie are
-    // present; Phase 2 forces the cookie path by sending an empty body.
-    // We spy on the underlying axios instance to capture the actual
-    // payload that goes over the wire.
+  it('authService.refreshToken sends an empty body — the backend reads the cookie only', async () => {
+    // Phase 3 backend ignores any body-side `refreshToken`. Sending an
+    // empty body keeps the wire format honest and stops a future
+    // regression from accidentally putting a stale value back in JS.
     const apiModule = await import('../../services/authService');
     const api = apiModule.default;
     const { authService } = apiModule;
 
     const postSpy = vi
       .spyOn(api, 'post')
+      // Phase 3 server shape: tokens.accessToken only — NO refreshToken
+      // in the body. The mock matches the server contract so a
+      // regression that starts reading `response.data.tokens.refreshToken`
+      // would see `undefined`.
       .mockResolvedValueOnce({
         data: {
           success: true,
-          tokens: { accessToken: 'new-access', refreshToken: 'unused-by-frontend' },
+          tokens: { accessToken: 'new-access' },
         },
       });
 
-    await authService.refreshToken();
+    const result = await authService.refreshToken();
 
     expect(postSpy).toHaveBeenCalledTimes(1);
     const firstCall = postSpy.mock.calls[0];
     if (!firstCall) throw new Error('expected /auth/refresh post call');
     const [url, body] = firstCall;
     expect(url).toBe('/auth/refresh');
-    // Empty body — no `refreshToken` field. If a regression adds one,
-    // the backend will *prefer* it over the cookie (body wins) and any
-    // stale value will silently take precedence.
+    // Empty body — no `refreshToken` field. Phase 3 backend ignores
+    // body fields, so adding one would be silently dead code.
     expect(body).toEqual({});
     expect(body).not.toHaveProperty('refreshToken');
+
+    // Caller-visible response also has no refreshToken — Phase 3
+    // backend dropped that field.
+    expect(result.tokens).not.toHaveProperty('refreshToken');
 
     postSpy.mockRestore();
   });
@@ -449,5 +457,35 @@ describe('Phase 2 — HttpOnly cookie refresh contract', () => {
       refreshAuth: async () => undefined,
     };
     expect(stateShape).not.toHaveProperty('refreshToken');
+  });
+
+  it('refreshAuth surface does not depend on a body-side refreshToken', async () => {
+    // Phase 3 contract surface: the auth store's `refreshAuth` only
+    // reads `tokens.accessToken` from the response body. A regression
+    // that re-introduces a `tokens.refreshToken` read would not be
+    // satisfied by the Phase 3 server (which omits the field), so the
+    // refresh would silently end up with `undefined` and force a
+    // re-login. We pin the response shape the store consumes so that
+    // regression manifests here instead of at runtime.
+    const apiModule = await import('../../services/authService');
+    const api = apiModule.default;
+    const { authService } = apiModule;
+
+    const postSpy = vi.spyOn(api, 'post').mockResolvedValueOnce({
+      data: {
+        success: true,
+        // Phase 3 server: tokens.accessToken only.
+        tokens: { accessToken: 'rotated-access-token' },
+      },
+    });
+
+    const response = await authService.refreshToken();
+    expect(response.tokens.accessToken).toBe('rotated-access-token');
+    // The field genuinely is not there in Phase 3 responses.
+    expect(
+      (response.tokens as { refreshToken?: string }).refreshToken,
+    ).toBeUndefined();
+
+    postSpy.mockRestore();
   });
 });

--- a/frontend/src/utils/axiosInterceptor.ts
+++ b/frontend/src/utils/axiosInterceptor.ts
@@ -59,11 +59,12 @@ export function setupAxiosInterceptors() {
           return Promise.reject(createApiError(error));
         }
 
-        // Phase 2: always attempt the refresh — the refresh token is now
-        // an HttpOnly cookie that JS cannot see. The browser sends it
-        // automatically (axios `withCredentials: true` on the auth axios
-        // instance). The backend returns 401 if the cookie is absent or
-        // expired, which falls through to clearAuth + redirect below.
+        // Phase 3: always attempt the refresh — the refresh token lives
+        // exclusively in an HttpOnly cookie that JS cannot see. The
+        // browser sends it automatically (axios `withCredentials: true`
+        // on the auth axios instance). The backend returns 401 if the
+        // cookie is absent or expired, which falls through to clearAuth +
+        // redirect below.
         try {
           await authStore.refreshAuth();
 
@@ -184,9 +185,9 @@ export function addAuthTokenInterceptor(axiosInstance: AxiosInstance) {
           return Promise.reject(createApiError(error));
         }
 
-        // Phase 2: always attempt the refresh — see the global interceptor
-        // for the full rationale. The HttpOnly cookie is the source of
-        // truth; we cannot read it from JS, so we just try.
+        // Phase 3: always attempt the refresh — see the global interceptor
+        // for the full rationale. The HttpOnly cookie is the only source
+        // of truth; we cannot read it from JS, so we just try.
         try {
           await authStore.refreshAuth();
 


### PR DESCRIPTION
## Summary

Completes the HttpOnly-cookie migration for the refresh token. **Breaking change**: the JSON-body refresh-token contract is gone. The refresh token now exists only in the `refresh_token` HttpOnly cookie — JavaScript cannot read it, and any XSS payload that lands on the page cannot exfiltrate it.

## Three-phase migration recap

| Phase | PR | Status | What it did |
|------|-----|--------|------------|
| 1 | #194 | Merged to `main` | Backend dual-support: sets the HttpOnly cookie AND keeps `refreshToken` in JSON body. `/auth/refresh` accepts either (body wins). |
| 2 | #208 | Merged to `main` | Frontend uses cookie only: stops storing/sending refresh token in localStorage; one-time `authStorageMigration` scrub on startup. |
| 3 | **this PR** | — | Backend stops emitting + accepting the JSON-body refresh token. |

User has confirmed: no real users today, breaking change is authorised, no burn-in.

## Breaking-change surface

- **Any client reading `response.data.tokens.refreshToken`** from `/auth/login`, `/auth/register`, or `/auth/refresh` will see `undefined`. The Phase-2 frontend already stopped reading this; only out-of-date third-party clients are affected.
- **Any client POSTing `{\"refreshToken\": \"…\"}` to `/auth/refresh` without the cookie** will get 401. The body field is silently dropped — there is no fallback any more.
- **OAuth redirects no longer carry `refreshToken=` in the URL.** The `Set-Cookie` header on the same response is the only delivery channel. This stops leaks into browser history, server logs, and `Referer` headers.

## What changed

### Backend (`backend-rust/`)

- `AuthTokens` struct no longer carries `refresh_token`. Login, register, and refresh return only `accessToken` in JSON.
- `/auth/refresh` reads the refresh token EXCLUSIVELY from the `refresh_token` cookie. Body-side `refreshToken` is silently ignored.
- `/auth/logout` takes no JSON body; revokes the token from the cookie. Always emits `Set-Cookie: refresh_token=; Max-Age=0`.
- `/auth/register` now sets the refresh-token cookie (Phase 1 only did this on login).
- Google + LINE OAuth callbacks drop the `refreshToken=` URL param.
- `LogoutRequest` and `RefreshTokenRequest` structs deleted; OpenAPI schema updated.

### Frontend (`frontend/`)

- `authService.refreshToken()` and `.logout()` keep their empty-body signatures (Phase 2 already migrated the wire format).
- `authStore` doc comments updated to Phase 3 — only the access token is JS-visible.
- `OAuthSuccessPage` no longer reads `refreshToken` from the URL query string; the PWA deep-link bridge passes an empty string and relies on the cookie.
- `authStorageMigration` retained permanently as defence against offline-built clients upgrading from pre-Phase-2 builds (per spec).

## Tests added / changed

### Backend integration (`backend-rust/tests/integration/auth_test.rs`)

- `test_login_does_not_return_refresh_token_in_body` — pins the Phase 3 login response shape.
- `test_register_does_not_return_refresh_token_in_body` — same for register.
- `test_refresh_does_not_return_refresh_token_in_body` — same for refresh.
- `test_refresh_with_body_only_is_rejected` — POST with body-side `refreshToken` and no cookie returns 401.
- `test_refresh_with_cookie_only_works` — happy path; verifies cookie is rotated.
- `test_refresh_with_body_and_invalid_cookie_fails` — proves the cookie is authoritative (body no longer wins).
- `test_refresh_with_neither_body_nor_cookie_fails` — missing cookie returns 401.
- `test_logout_clears_refresh_token_cookie` — logout emits `Max-Age=0` clearing cookie.
- `test_login_sets_refresh_token_cookie_with_security_attributes` — `HttpOnly; Secure; SameSite=Strict; Path=/api/auth; Max-Age=`.
- Existing `test_register_user_success` and `test_login_success` extended to assert the body has no `refreshToken` and the response sets the cookie.

### Backend unit (`backend-rust/src/routes/auth.rs`)

- `test_auth_tokens_serialization_omits_refresh_token` — pins the serialised JSON shape of `AuthTokens` so a regression that re-adds the field is caught at compile-time-ish.

### Frontend (`frontend/src/utils/__tests__/axiosInterceptor.test.ts`)

- Updated mock responses to remove `refreshToken` (Phase 3 server shape).
- `refreshAuth surface does not depend on a body-side refreshToken` — pins the consumer-visible response shape.
- Pre-existing Phase 2 contract tests retitled for Phase 3.

## Test plan

- [ ] CI green on `feat/auth-cookie-phase3`.
- [ ] Manual end-to-end on staging:
  - [ ] Email + password login → `/auth/login` response has `tokens.accessToken` but no `tokens.refreshToken`; `Set-Cookie: refresh_token=…; HttpOnly; Secure; SameSite=Strict; Path=/api/auth; Max-Age=…` present.
  - [ ] Wait for access-token expiry (or force a 401) → axios interceptor fires `POST /auth/refresh` with empty body; the `refresh_token` cookie rides via `withCredentials`; new access token comes back; original request retries.
  - [ ] Refresh-token rotation: each `/auth/refresh` issues a new cookie value distinct from the previous one.
  - [ ] Logout → `POST /auth/logout` returns `Max-Age=0` clearing `Set-Cookie`; subsequent `/auth/refresh` returns 401.
  - [ ] OAuth (Google or LINE) → callback redirects to `/oauth/success?token=…&isNewUser=…` (no `refreshToken=` in URL); cookie is set; subsequent refresh works.
  - [ ] Tail the backend logs during the above and verify no refresh token ever appears in URL paths, query strings, or referer headers.
- [ ] DevTools: confirm the `auth-storage` localStorage value contains only `user`, `accessToken`, `isAuthenticated` — no `refreshToken` field.
- [ ] DevTools → Application → Cookies: `refresh_token` cookie shows `HttpOnly = ✓`, `Secure = ✓`, `SameSite = Strict`, `Path = /api/auth`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)