### PR TITLE
fix(migration): make booking_slips FK additions idempotent

### DIFF
--- a/backend-rust/migrations/20260511000000_booking_slips.sql
+++ b/backend-rust/migrations/20260511000000_booking_slips.sql
@@ -23,11 +23,23 @@ CREATE TABLE IF NOT EXISTS "public"."booking_slips" (
     CONSTRAINT "booking_slips_pkey" PRIMARY KEY ("id")
 );
 
-ALTER TABLE "public"."booking_slips" ADD CONSTRAINT "booking_slips_booking_id_fkey"
-    FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+-- ADD CONSTRAINT is not idempotent in Postgres. Staging + production already
+-- have a more-expanded booking_slips table (with slipok/admin columns) from
+-- an earlier migration not represented in this repo's migrations/ dir, and
+-- those FK constraints already exist. Wrap in DO blocks so the migration
+-- is a no-op when constraints exist and additive when they don't (e.g.
+-- e2e tests on a fresh DB).
+DO $$ BEGIN
+    ALTER TABLE "public"."booking_slips" ADD CONSTRAINT "booking_slips_booking_id_fkey"
+        FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
-ALTER TABLE "public"."booking_slips" ADD CONSTRAINT "booking_slips_uploaded_by_fkey"
-    FOREIGN KEY ("uploaded_by") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+DO $$ BEGIN
+    ALTER TABLE "public"."booking_slips" ADD CONSTRAINT "booking_slips_uploaded_by_fkey"
+        FOREIGN KEY ("uploaded_by") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
 
 CREATE INDEX IF NOT EXISTS "idx_booking_slips_booking_id"
     ON "public"."booking_slips" ("booking_id");


### PR DESCRIPTION
## Summary

Hotfix for PR #211. The new migration broke staging deploy at startup with:
\`\`\`
relation "booking_slips" already exists, skipping
Failed to run database migrations
\`\`\`

## Root cause

Staging + production postgres volumes have a *richer* \`booking_slips\` table (with \`slipok_status\`, \`admin_status\`, \`is_primary\`, etc. + the FK constraints) from an earlier migration that isn't in this repo's \`migrations/\` directory. PR #211's migration used \`CREATE TABLE IF NOT EXISTS\` (idempotent ✓) but then \`ALTER TABLE ... ADD CONSTRAINT\` (NOT idempotent), which raised \`duplicate_object\` on \`booking_slips_booking_id_fkey\` and aborted the whole migration (sqlx wraps each in a transaction).

## Fix

Wrap each \`ALTER TABLE ADD CONSTRAINT\` in a Postgres \`DO $$ ... EXCEPTION WHEN duplicate_object THEN NULL; END $$\` block. Behavior:
- **Fresh DB (e2e tests, new install)**: constraints don't exist → DO block runs the ALTER → constraints added. Same as before.
- **Existing DB (staging, prod)**: constraints exist → DO block raises \`duplicate_object\` → exception caught → no-op. Migration succeeds.

The indexes already use \`CREATE INDEX IF NOT EXISTS\` so they were fine.

## Why is staging's \`booking_slips\` richer than the migration?

Mystery for the team — the table has slipok/admin/is_primary columns + triggers that no current repo migration creates. Likely from a deleted Prisma migration or an older Rust migration that got squashed into the init. The pragmatic move is to coexist with what's there rather than reconcile schemas in this hotfix.

## Test plan
- [ ] CI green
- [ ] Staging deploy succeeds (the previous failure mode was the migration at backend startup)
- [ ] Backend \`/api/health\` returns \`{database: "healthy"}\` after deploy
- [ ] Manual: \`POST /api/bookings/<id>/slips\` works against the richer staging schema (extra columns default OK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)