### PR TITLE
feat(bookings): implement DELETE /api/bookings/slips/:id

### DIFF
--- a/backend-rust/.sqlx/query-7a3b5a77dd435ce2d14c6d1e4cbc9a059fcccf7125ce08601433a6b411c555ae.json
+++ b/backend-rust/.sqlx/query-7a3b5a77dd435ce2d14c6d1e4cbc9a059fcccf7125ce08601433a6b411c555ae.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, booking_id, slip_url, uploaded_by, uploaded_at,\n               slipok_status, admin_status\n        FROM booking_slips\n        WHERE id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "booking_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "slip_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "uploaded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "slipok_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "admin_status",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "7a3b5a77dd435ce2d14c6d1e4cbc9a059fcccf7125ce08601433a6b411c555ae"
+}

--- a/backend-rust/.sqlx/query-ca16fc4942a10f3ddd7c002348e3180dfaba59030c54c232fba796082629bc15.json
+++ b/backend-rust/.sqlx/query-ca16fc4942a10f3ddd7c002348e3180dfaba59030c54c232fba796082629bc15.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM booking_slips WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ca16fc4942a10f3ddd7c002348e3180dfaba59030c54c232fba796082629bc15"
+}

--- a/backend-rust/src/routes/bookings.rs
+++ b/backend-rust/src/routes/bookings.rs
@@ -7,7 +7,7 @@ use axum::{
     extract::{Extension, Path, Query, State},
     http::StatusCode,
     middleware,
-    routing::{get, post, put},
+    routing::{delete, get, post, put},
     Json, Router,
 };
 use chrono::{DateTime, NaiveDate, Utc};
@@ -547,6 +547,52 @@ async fn add_booking_slip(
     );
 
     Ok((StatusCode::CREATED, Json(slip)))
+}
+
+/// DELETE /api/bookings/slips/:slip_id - Remove a payment slip
+///
+/// Path parameter:
+/// - `slip_id`: The UUID of the slip row to delete.
+///
+/// Authentication is required (provided by the router layer). The caller must
+/// either be the user that originally uploaded the slip OR an admin; everyone
+/// else gets 403.
+///
+/// Returns 204 No Content on success. Returns 404 if the slip does not exist,
+/// matching the lookup-then-authorize ordering used by `add_booking_slip` and
+/// `get_booking`.
+async fn delete_booking_slip(
+    State(state): State<AppState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Path(slip_id): Path<Uuid>,
+) -> AppResult<StatusCode> {
+    // Look up the slip first; surfaces a 404 when it doesn't exist so callers
+    // can distinguish "you're not allowed" from "it isn't there".
+    let slip = query_booking_slip_by_id(state.db(), slip_id).await?;
+
+    // Ownership / admin authorization. Done AFTER the lookup so a missing slip
+    // returns 404 rather than 403 (matches `get_booking` / `add_booking_slip`).
+    let auth_user_id = Uuid::parse_str(&auth_user.id)
+        .map_err(|_| AppError::InvalidToken("Invalid user ID in token".to_string()))?;
+
+    let is_admin = has_role(&auth_user, "admin");
+    if slip.uploaded_by != auth_user_id && !is_admin {
+        return Err(AppError::Forbidden(
+            "You can only delete slips you uploaded".to_string(),
+        ));
+    }
+
+    delete_booking_slip_by_id(state.db(), slip_id).await?;
+
+    tracing::info!(
+        user_id = %auth_user.id,
+        slip_id = %slip_id,
+        booking_id = %slip.booking_id,
+        admin_delete = is_admin && slip.uploaded_by != auth_user_id,
+        "Booking slip deleted"
+    );
+
+    Ok(StatusCode::NO_CONTENT)
 }
 
 /// GET /api/bookings/availability - Check room availability
@@ -1241,11 +1287,14 @@ async fn award_loyalty_points(
     Ok(())
 }
 
-/// Row returned by `insert_booking_slip`.
+/// Raw `booking_slips` row used by slip insert/query/delete helpers.
 ///
 /// `uploaded_at` is nullable in the schema (the column carries a
 /// `DEFAULT CURRENT_TIMESTAMP` but no `NOT NULL`); the response substitutes
-/// "now" if it is somehow NULL on read.
+/// "now" if it is somehow NULL on read. Kept private to this module —
+/// handlers convert it to `BookingSlipResponse` via the `From` impl below
+/// before serialising, and the delete handler inspects `uploaded_by`
+/// directly to authorize the caller.
 #[derive(Debug, FromRow)]
 struct BookingSlipRow {
     pub id: Uuid,
@@ -1301,6 +1350,44 @@ async fn insert_booking_slip(
     Ok(row.into())
 }
 
+/// Fetch a slip row by id, surfacing a 404 when it doesn't exist.
+///
+/// We need the raw row (not the response DTO) because the delete handler has
+/// to authorize against `uploaded_by`, which the response DTO carries but is
+/// also used for logging the originating `booking_id`.
+async fn query_booking_slip_by_id(db: &PgPool, slip_id: Uuid) -> AppResult<BookingSlipRow> {
+    sqlx::query_as::<_, BookingSlipRow>(
+        r#"
+        SELECT id, booking_id, slip_url, uploaded_by, uploaded_at
+        FROM booking_slips
+        WHERE id = $1
+        "#,
+    )
+    .bind(slip_id)
+    .fetch_optional(db)
+    .await?
+    .ok_or_else(|| AppError::NotFound(format!("Slip {}", slip_id)))
+}
+
+/// Delete a slip row by id.
+///
+/// The caller is responsible for authorization; this function unconditionally
+/// removes the row. Returns an error if the row is missing — the handler
+/// should have already verified existence via `query_booking_slip_by_id`, so
+/// hitting that branch here means the row was deleted concurrently.
+async fn delete_booking_slip_by_id(db: &PgPool, slip_id: Uuid) -> AppResult<()> {
+    let result = sqlx::query("DELETE FROM booking_slips WHERE id = $1")
+        .bind(slip_id)
+        .execute(db)
+        .await?;
+
+    if result.rows_affected() == 0 {
+        return Err(AppError::NotFound(format!("Slip {}", slip_id)));
+    }
+
+    Ok(())
+}
+
 // ==================== HELPER FUNCTIONS ====================
 
 /// Parse room type string to enum
@@ -1337,6 +1424,7 @@ pub fn routes() -> Router<AppState> {
 /// - PUT /api/bookings/:id - Update a booking
 /// - POST /api/bookings/:id/cancel - Cancel a booking
 /// - POST /api/bookings/:id/slips - Attach a payment slip URL to a booking
+/// - DELETE /api/bookings/slips/:slip_id - Remove a payment slip
 /// - POST /api/bookings/:id/complete - Mark booking as completed (admin only)
 /// - GET /api/bookings/availability - Check room availability
 ///
@@ -1353,6 +1441,9 @@ pub fn router() -> Router<AppState> {
         .route("/:id", put(update_booking))
         .route("/:id/cancel", post(cancel_booking))
         .route("/:id/slips", post(add_booking_slip))
+        // Slip routes are flat (not nested under booking id) to match the
+        // contract the frontend already calls: `DELETE /api/bookings/slips/:id`.
+        .route("/slips/:slip_id", delete(delete_booking_slip))
         // Admin routes
         .route("/:id/complete", post(complete_booking))
         // Apply authentication middleware to all routes
@@ -1379,6 +1470,7 @@ pub fn router_without_auth() -> Router<AppState> {
         .route("/:id", put(update_booking))
         .route("/:id/cancel", post(cancel_booking))
         .route("/:id/slips", post(add_booking_slip))
+        .route("/slips/:slip_id", delete(delete_booking_slip))
         .route("/:id/complete", post(complete_booking))
 }
 

--- a/backend-rust/src/routes/bookings.rs
+++ b/backend-rust/src/routes/bookings.rs
@@ -1356,14 +1356,16 @@ async fn insert_booking_slip(
 /// to authorize against `uploaded_by`, which the response DTO carries but is
 /// also used for logging the originating `booking_id`.
 async fn query_booking_slip_by_id(db: &PgPool, slip_id: Uuid) -> AppResult<BookingSlipRow> {
-    sqlx::query_as::<_, BookingSlipRow>(
+    sqlx::query_as!(
+        BookingSlipRow,
         r#"
-        SELECT id, booking_id, slip_url, uploaded_by, uploaded_at
+        SELECT id, booking_id, slip_url, uploaded_by, uploaded_at,
+               slipok_status, admin_status
         FROM booking_slips
         WHERE id = $1
         "#,
+        slip_id,
     )
-    .bind(slip_id)
     .fetch_optional(db)
     .await?
     .ok_or_else(|| AppError::NotFound(format!("Slip {}", slip_id)))
@@ -1376,8 +1378,7 @@ async fn query_booking_slip_by_id(db: &PgPool, slip_id: Uuid) -> AppResult<Booki
 /// should have already verified existence via `query_booking_slip_by_id`, so
 /// hitting that branch here means the row was deleted concurrently.
 async fn delete_booking_slip_by_id(db: &PgPool, slip_id: Uuid) -> AppResult<()> {
-    let result = sqlx::query("DELETE FROM booking_slips WHERE id = $1")
-        .bind(slip_id)
+    let result = sqlx::query!("DELETE FROM booking_slips WHERE id = $1", slip_id)
         .execute(db)
         .await?;
 

--- a/backend-rust/tests/integration/booking_test.rs
+++ b/backend-rust/tests/integration/booking_test.rs
@@ -1072,6 +1072,215 @@ async fn test_add_booking_slip_rejects_empty_url() {
     app.cleanup().await.ok();
 }
 
+// ============================================================================
+// test_delete_booking_slip - DELETE /api/bookings/slips/:slip_id
+// ============================================================================
+
+/// Insert a slip row directly via SQL and return its id.
+///
+/// We use raw SQL (rather than going through `POST /api/bookings/:id/slips`)
+/// so each test can seed exactly the slip it needs without coupling the
+/// delete-path tests to the upload path.
+async fn insert_test_slip(
+    pool: &sqlx::PgPool,
+    booking_id: Uuid,
+    uploaded_by: Uuid,
+    slip_url: &str,
+) -> Result<Uuid, sqlx::Error> {
+    sqlx::query_scalar(
+        r#"
+        INSERT INTO booking_slips (booking_id, slip_url, uploaded_by)
+        VALUES ($1, $2, $3)
+        RETURNING id
+        "#,
+    )
+    .bind(booking_id)
+    .bind(slip_url)
+    .bind(uploaded_by)
+    .fetch_one(pool)
+    .await
+}
+
+#[tokio::test]
+async fn test_delete_booking_slip_success() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let user = TestUser::new("slip-delete-owner@test.com");
+    user.insert(app.db())
+        .await
+        .expect("Failed to insert test user");
+
+    let booking_id = create_test_booking(app.db(), user.id, "confirmed", 7, 10)
+        .await
+        .expect("Failed to create booking");
+
+    let slip_id = insert_test_slip(
+        app.db(),
+        booking_id,
+        user.id,
+        "/storage/slips/owner-delete.jpg",
+    )
+    .await
+    .expect("Failed to insert test slip");
+
+    let client = app.authenticated_client(&user.id, &user.email);
+
+    let response = client
+        .delete(&format!("/api/bookings/slips/{}", slip_id))
+        .await;
+
+    response.assert_status(204);
+
+    // Verify the row is gone.
+    let row_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM booking_slips WHERE id = $1")
+        .bind(slip_id)
+        .fetch_one(app.db())
+        .await
+        .expect("Failed to count slips");
+    assert_eq!(row_count.0, 0, "Slip row should be deleted from the database");
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_delete_booking_slip_requires_authentication() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let client = app.client();
+
+    let fake_slip_id = Uuid::new_v4();
+    let response = client
+        .delete(&format!("/api/bookings/slips/{}", fake_slip_id))
+        .await;
+
+    response.assert_status(401);
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_delete_booking_slip_forbidden_for_other_user() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let owner = TestUser::new("slip-delete-owner-other@test.com");
+    owner
+        .insert(app.db())
+        .await
+        .expect("Failed to insert owner");
+
+    let intruder = TestUser::new("slip-delete-intruder@test.com");
+    intruder
+        .insert(app.db())
+        .await
+        .expect("Failed to insert intruder");
+
+    let booking_id = create_test_booking(app.db(), owner.id, "confirmed", 7, 10)
+        .await
+        .expect("Failed to create booking");
+
+    let slip_id = insert_test_slip(
+        app.db(),
+        booking_id,
+        owner.id,
+        "/storage/slips/owner-protected.jpg",
+    )
+    .await
+    .expect("Failed to insert test slip");
+
+    // Authenticated as the OTHER (non-admin) user.
+    let client = app.authenticated_client(&intruder.id, &intruder.email);
+
+    let response = client
+        .delete(&format!("/api/bookings/slips/{}", slip_id))
+        .await;
+
+    response.assert_status(403);
+
+    // Row must still exist — authorization failure must not delete anything.
+    let row_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM booking_slips WHERE id = $1")
+        .bind(slip_id)
+        .fetch_one(app.db())
+        .await
+        .expect("Failed to count slips");
+    assert_eq!(
+        row_count.0, 1,
+        "Slip row should still exist when authorization fails"
+    );
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_delete_booking_slip_not_found_for_missing_slip() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let user = TestUser::new("slip-delete-missing@test.com");
+    user.insert(app.db())
+        .await
+        .expect("Failed to insert test user");
+
+    let client = app.authenticated_client(&user.id, &user.email);
+
+    let fake_slip_id = Uuid::new_v4();
+    let response = client
+        .delete(&format!("/api/bookings/slips/{}", fake_slip_id))
+        .await;
+
+    response.assert_status(404);
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_delete_booking_slip_admin_can_delete_other_users_slip() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let admin = TestUser::admin("slip-delete-admin@test.com");
+    admin
+        .insert(app.db())
+        .await
+        .expect("Failed to insert admin");
+
+    let owner = TestUser::new("slip-delete-customer@test.com");
+    owner
+        .insert(app.db())
+        .await
+        .expect("Failed to insert customer");
+
+    let booking_id = create_test_booking(app.db(), owner.id, "confirmed", 7, 10)
+        .await
+        .expect("Failed to create booking");
+
+    let slip_id = insert_test_slip(
+        app.db(),
+        booking_id,
+        owner.id,
+        "/storage/slips/admin-removed.jpg",
+    )
+    .await
+    .expect("Failed to insert test slip");
+
+    let client = app.authenticated_client_with_role(&admin.id, &admin.email, "admin");
+
+    let response = client
+        .delete(&format!("/api/bookings/slips/{}", slip_id))
+        .await;
+
+    response.assert_status(204);
+
+    // Verify the row is gone.
+    let row_count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM booking_slips WHERE id = $1")
+        .bind(slip_id)
+        .fetch_one(app.db())
+        .await
+        .expect("Failed to count slips");
+    assert_eq!(
+        row_count.0, 0,
+        "Admin should be able to delete another user's slip"
+    );
+
+    app.cleanup().await.ok();
+}
+
 #[tokio::test]
 async fn test_admin_can_view_all_bookings() {
     let app = TestApp::new().await.expect("Failed to create test app");

--- a/backend-rust/tests/integration/booking_test.rs
+++ b/backend-rust/tests/integration/booking_test.rs
@@ -1137,7 +1137,10 @@ async fn test_delete_booking_slip_success() {
         .fetch_one(app.db())
         .await
         .expect("Failed to count slips");
-    assert_eq!(row_count.0, 0, "Slip row should be deleted from the database");
+    assert_eq!(
+        row_count.0, 0,
+        "Slip row should be deleted from the database"
+    );
 
     app.cleanup().await.ok();
 }


### PR DESCRIPTION
## Summary

- Adds the missing `DELETE /api/bookings/slips/:slip_id` handler in `backend-rust/src/routes/bookings.rs`, completing the symmetric pair with the `POST /api/bookings/:id/slips` route added in #211. The frontend already calls this endpoint via `bookingService.removeSlip()`, so this fixes a 404 that users hit when removing an uploaded slip.
- Authorization mirrors the existing slip-add handler: the caller must be the user that originally uploaded the slip (`uploaded_by == auth_user.id`) OR have the admin role. The lookup is performed before the auth check so a missing slip returns 404 rather than 403 (matches the `get_booking` / `add_booking_slip` pattern).
- Returns 204 No Content on success. Logs include `admin_delete` so audit trails can distinguish admin overrides from user-initiated deletes.

## Endpoint

| Method | Path                                | Auth                    | Success | Errors                |
| ------ | ----------------------------------- | ----------------------- | ------- | --------------------- |
| DELETE | `/api/bookings/slips/:slip_id`      | required (Bearer JWT)   | 204     | 401 / 403 / 404       |

The flat (non-nested) path matches what the frontend's `bookingService.removeSlip(slipId)` already sends: `api.delete(\`/bookings/slips/${slipId}\`)`.

## Test plan

Integration tests added in `backend-rust/tests/integration/booking_test.rs`:

- [x] `test_delete_booking_slip_success` — owner deletes their own slip, expects 204 and the row is gone from the DB.
- [x] `test_delete_booking_slip_requires_authentication` — no auth header, expects 401.
- [x] `test_delete_booking_slip_forbidden_for_other_user` — different (non-admin) user, expects 403 and the row still exists.
- [x] `test_delete_booking_slip_not_found_for_missing_slip` — random UUID, expects 404.
- [x] `test_delete_booking_slip_admin_can_delete_other_users_slip` — admin deletes another user's slip, expects 204 and the row is gone.

Tests use raw SQL to seed slip rows so the delete-path tests are not coupled to the upload path.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>