### PR TITLE
chore(backend): canonical booking_slips schema + sqlx prepare workflow

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -135,7 +135,16 @@ jobs:
 
       - name: Run database migrations
         run: |
-          PGPASSWORD=loyalty_test_pass psql -h localhost -p 5438 -U loyalty_test -d loyalty_test_db -f backend-rust/migrations/20240101000000_init.sql
+          # Apply every migration in lexical (timestamp-ordered) order so the
+          # sqlx prepare --check step below sees the same schema the app
+          # expects. Hard-coding a single filename silently rotted as new
+          # migrations were added — see PR #215's booking_slips reconciliation.
+          set -euo pipefail
+          for f in backend-rust/migrations/*.sql; do
+            echo "Applying $f"
+            PGPASSWORD=loyalty_test_pass psql -h localhost -p 5438 -U loyalty_test -d loyalty_test_db \
+              -v ON_ERROR_STOP=1 -f "$f"
+          done
         env:
           PGPASSWORD: loyalty_test_pass
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,12 @@ production with manual approval).
 - The Rust backend uses `sqlx` with **compile-time** query macros validated
   against the offline cache in `.sqlx/`. Regenerate with
   `DATABASE_URL=... cargo sqlx prepare` against a live database; CI
-  verifies the cache with `cargo sqlx prepare --check`.
+  verifies the cache with `cargo sqlx prepare --check`. The helper
+  `backend-rust/scripts/regen-sqlx-cache.sh` automates the workflow: it
+  boots a throwaway Postgres container, applies every migration, runs
+  `cargo sqlx prepare --workspace -- --tests`, and tears the container
+  down. After adding or modifying any `sqlx::query!` / `sqlx::query_as!`
+  call, run that script and commit the resulting `.sqlx/*.json` files.
 - Use stored procedures (e.g., `award_points`, `recalculate_user_tier_by_nights`)
   rather than raw `UPDATE` statements for tier-affecting operations.
 

--- a/backend-rust/.sqlx/query-1cd49cdfb0d301cefaa231e1b7b627bdf66897975a81f57ea6c47509abdd4a10.json
+++ b/backend-rust/.sqlx/query-1cd49cdfb0d301cefaa231e1b7b627bdf66897975a81f57ea6c47509abdd4a10.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        DELETE FROM room_blocked_dates\n         WHERE room_id = $1\n           AND blocked_date = ANY($2::date[])\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "DateArray"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "1cd49cdfb0d301cefaa231e1b7b627bdf66897975a81f57ea6c47509abdd4a10"
+}

--- a/backend-rust/.sqlx/query-3e49ed4a6039ca2cf1db58a880b82af045d791fe38fbfefae1e1ae22c3758692.json
+++ b/backend-rust/.sqlx/query-3e49ed4a6039ca2cf1db58a880b82af045d791fe38fbfefae1e1ae22c3758692.json
@@ -1,0 +1,65 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT r.id,\n               r.room_type_id,\n               r.room_number,\n               r.floor,\n               r.is_active,\n               r.created_at,\n               r.updated_at,\n               rt.name AS \"rt_name?\"\n          FROM rooms r\n          JOIN room_types rt ON rt.id = r.room_type_id\n         WHERE ($1::uuid IS NULL OR r.room_type_id = $1)\n           AND ($2::bool OR r.is_active)\n         ORDER BY LENGTH(r.room_number), r.room_number ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "room_type_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "room_number",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "floor",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 6,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "rt_name?",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false,
+      true,
+      true,
+      false
+    ]
+  },
+  "hash": "3e49ed4a6039ca2cf1db58a880b82af045d791fe38fbfefae1e1ae22c3758692"
+}

--- a/backend-rust/.sqlx/query-7edc2d5d0ccf71e93d33a592432f7f4af071c09078e47e07c7e384ba61908d18.json
+++ b/backend-rust/.sqlx/query-7edc2d5d0ccf71e93d33a592432f7f4af071c09078e47e07c7e384ba61908d18.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, name, description, price_per_night, max_guests, is_active,\n               created_at, updated_at\n          FROM room_types\n         WHERE $1::bool OR is_active\n         ORDER BY LOWER(name) ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "name",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 2,
+        "name": "description",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "price_per_night",
+        "type_info": "Numeric"
+      },
+      {
+        "ordinal": 4,
+        "name": "max_guests",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 5,
+        "name": "is_active",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 6,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "updated_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "7edc2d5d0ccf71e93d33a592432f7f4af071c09078e47e07c7e384ba61908d18"
+}

--- a/backend-rust/.sqlx/query-8d024a7793c96eeee663367b374f9c42512a638ffed3bfa57d6ceac2de447e8b.json
+++ b/backend-rust/.sqlx/query-8d024a7793c96eeee663367b374f9c42512a638ffed3bfa57d6ceac2de447e8b.json
@@ -1,0 +1,60 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO booking_slips (booking_id, slip_url, uploaded_by)\n        VALUES ($1, $2, $3)\n        RETURNING id, booking_id, slip_url, uploaded_by, uploaded_at,\n                  slipok_status, admin_status\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "booking_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "slip_url",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "uploaded_by",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 4,
+        "name": "uploaded_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 5,
+        "name": "slipok_status",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 6,
+        "name": "admin_status",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "8d024a7793c96eeee663367b374f9c42512a638ffed3bfa57d6ceac2de447e8b"
+}

--- a/backend-rust/.sqlx/query-8f25de4033958249886aa012a40448707b4270ed8505428ecc33df64beaa965c.json
+++ b/backend-rust/.sqlx/query-8f25de4033958249886aa012a40448707b4270ed8505428ecc33df64beaa965c.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id FROM rooms WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "8f25de4033958249886aa012a40448707b4270ed8505428ecc33df64beaa965c"
+}

--- a/backend-rust/.sqlx/query-f8ccc323d0da07b3c742b62ddd625cd9589c5c487a1ddec444844de00ad26acd.json
+++ b/backend-rust/.sqlx/query-f8ccc323d0da07b3c742b62ddd625cd9589c5c487a1ddec444844de00ad26acd.json
@@ -1,0 +1,36 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO room_blocked_dates (room_id, blocked_date, reason)\n        SELECT $1, d, $3\n          FROM UNNEST($2::date[]) AS d\n        ON CONFLICT (room_id, blocked_date) DO NOTHING\n        RETURNING id, blocked_date, created_at\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "blocked_date",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 2,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "DateArray",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "f8ccc323d0da07b3c742b62ddd625cd9589c5c487a1ddec444844de00ad26acd"
+}

--- a/backend-rust/.sqlx/query-fb63ab94f0349ce1df5cc05034f4afef6be69f6d2ffe5519d6a412b7e662ee46.json
+++ b/backend-rust/.sqlx/query-fb63ab94f0349ce1df5cc05034f4afef6be69f6d2ffe5519d6a412b7e662ee46.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT bd.id,\n               bd.room_id,\n               r.room_number AS \"room_number!\",\n               bd.blocked_date,\n               bd.reason,\n               bd.created_at\n          FROM room_blocked_dates bd\n          JOIN rooms r ON r.id = bd.room_id\n         WHERE bd.blocked_date >= $1\n           AND bd.blocked_date <= $2\n           AND ($3::uuid IS NULL OR r.room_type_id = $3)\n         ORDER BY r.room_number ASC, bd.blocked_date ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "room_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "room_number!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "blocked_date",
+        "type_info": "Date"
+      },
+      {
+        "ordinal": 4,
+        "name": "reason",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "created_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Date",
+        "Date",
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      true
+    ]
+  },
+  "hash": "fb63ab94f0349ce1df5cc05034f4afef6be69f6d2ffe5519d6a412b7e662ee46"
+}

--- a/backend-rust/migrations/20260511000000_booking_slips.sql
+++ b/backend-rust/migrations/20260511000000_booking_slips.sql
@@ -1,48 +1,105 @@
 -- =====================================================
--- Migration: booking_slips
+-- Migration: booking_slips (canonical schema)
 -- =====================================================
--- Adds a table to record payment slips uploaded against a booking.
+-- Records payment slip uploads against a booking, plus the SlipOK and admin
+-- review workflow columns. A single booking may accumulate multiple slips
+-- (e.g. a deposit slip and a balance slip), so each row has its own primary
+-- key rather than attaching a `slip_url` column to `bookings`.
 --
--- A single booking can accumulate multiple slips (e.g. a deposit slip and a
--- balance slip), which is why each row has its own primary key rather than
--- attaching a `slip_url` column to `bookings`.
+-- The slip URL itself is produced by `POST /api/slips/upload`, which writes
+-- the file to `/storage/slips/<uuid>.<ext>` and returns the path. This table
+-- links those URLs to the booking they were uploaded against, who uploaded
+-- them, and the verification state (SlipOK auto-verification + admin
+-- review).
 --
--- The slip URL itself is produced by `POST /api/slips/upload`, which writes the
--- file to `/storage/slips/<uuid>.<ext>` and returns the path. This table just
--- links those URLs to the booking they were uploaded for, along with who
--- uploaded them and when.
+-- This migration is the canonical definition of the `booking_slips` table.
+-- It was produced by reconciling the on-disk Rust migration with the schema
+-- already deployed to production (which originated from a Prisma migration
+-- that was never copied into this repo). The migration row at
+-- `20260511000000` was inserted by a previous deploy with a partial body, so
+-- production will NOT re-execute this file; the rewrite only takes effect on
+-- fresh databases (e2e, local dev, tests) — and there it must reproduce the
+-- production schema exactly so that compile-time sqlx queries validate
+-- against the same shape they will see in prod.
+--
+-- Required extensions (`uuid-ossp` for `uuid_generate_v4()`) are created by
+-- `20240101000000_init.sql`, which runs first.
 -- =====================================================
 
-CREATE TABLE IF NOT EXISTS "public"."booking_slips" (
-    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
-    "booking_id" UUID NOT NULL,
-    "slip_url" TEXT NOT NULL,
-    "uploaded_by" UUID NOT NULL,
-    "uploaded_at" TIMESTAMPTZ(6) NOT NULL DEFAULT NOW(),
+-- ----- Table ------------------------------------------------------------
+
+CREATE TABLE "public"."booking_slips" (
+    "id"                 UUID                     NOT NULL DEFAULT uuid_generate_v4(),
+    "booking_id"         UUID                     NOT NULL,
+    "slip_url"           TEXT                     NOT NULL,
+    "uploaded_by"        UUID                     NOT NULL,
+    "uploaded_at"        TIMESTAMP WITH TIME ZONE          DEFAULT CURRENT_TIMESTAMP,
+    "slipok_status"      VARCHAR(20)                       DEFAULT 'pending',
+    "slipok_verified_at" TIMESTAMP WITH TIME ZONE,
+    "slipok_response"    JSONB,
+    "admin_status"       VARCHAR(20)                       DEFAULT 'pending',
+    "admin_verified_at"  TIMESTAMP WITH TIME ZONE,
+    "admin_verified_by"  UUID,
+    "admin_notes"        TEXT,
+    "is_primary"         BOOLEAN                           DEFAULT false,
+    "created_at"         TIMESTAMP WITH TIME ZONE          DEFAULT CURRENT_TIMESTAMP,
+    "updated_at"         TIMESTAMP WITH TIME ZONE          DEFAULT CURRENT_TIMESTAMP,
 
     CONSTRAINT "booking_slips_pkey" PRIMARY KEY ("id")
 );
 
--- ADD CONSTRAINT is not idempotent in Postgres. Staging + production already
--- have a more-expanded booking_slips table (with slipok/admin columns) from
--- an earlier migration not represented in this repo's migrations/ dir, and
--- those FK constraints already exist. Wrap in DO blocks so the migration
--- is a no-op when constraints exist and additive when they don't (e.g.
--- e2e tests on a fresh DB).
-DO $$ BEGIN
-    ALTER TABLE "public"."booking_slips" ADD CONSTRAINT "booking_slips_booking_id_fkey"
-        FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+-- ----- Foreign keys -----------------------------------------------------
+-- booking_id: cascade deletes — slips are meaningless without the parent
+-- booking. uploaded_by / admin_verified_by have NO cascade (matches
+-- production); deleting a user is rare and we want a FK error rather than
+-- silent data loss in the slip audit trail.
 
-DO $$ BEGIN
-    ALTER TABLE "public"."booking_slips" ADD CONSTRAINT "booking_slips_uploaded_by_fkey"
-        FOREIGN KEY ("uploaded_by") REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION;
-EXCEPTION WHEN duplicate_object THEN NULL;
-END $$;
+ALTER TABLE "public"."booking_slips"
+    ADD CONSTRAINT "booking_slips_booking_id_fkey"
+    FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id")
+    ON DELETE CASCADE;
 
-CREATE INDEX IF NOT EXISTS "idx_booking_slips_booking_id"
+ALTER TABLE "public"."booking_slips"
+    ADD CONSTRAINT "booking_slips_uploaded_by_fkey"
+    FOREIGN KEY ("uploaded_by") REFERENCES "public"."users"("id");
+
+ALTER TABLE "public"."booking_slips"
+    ADD CONSTRAINT "booking_slips_admin_verified_by_fkey"
+    FOREIGN KEY ("admin_verified_by") REFERENCES "public"."users"("id");
+
+-- ----- Indexes ----------------------------------------------------------
+
+CREATE INDEX "idx_booking_slips_booking_id"
     ON "public"."booking_slips" ("booking_id");
 
-CREATE INDEX IF NOT EXISTS "idx_booking_slips_uploaded_at"
+CREATE INDEX "idx_booking_slips_uploaded_by"
+    ON "public"."booking_slips" ("uploaded_by");
+
+CREATE INDEX "idx_booking_slips_uploaded_at"
     ON "public"."booking_slips" ("uploaded_at" DESC);
+
+CREATE INDEX "idx_booking_slips_slipok_status"
+    ON "public"."booking_slips" ("slipok_status");
+
+CREATE INDEX "idx_booking_slips_admin_status"
+    ON "public"."booking_slips" ("admin_status");
+
+-- ----- updated_at trigger -----------------------------------------------
+-- Keeps `updated_at` in sync on every UPDATE without the application having
+-- to remember. Matches the function body deployed in production
+-- (verified via `\sf update_booking_slips_updated_at`).
+
+CREATE OR REPLACE FUNCTION public.update_booking_slips_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER booking_slips_updated_at
+    BEFORE UPDATE ON "public"."booking_slips"
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_booking_slips_updated_at();

--- a/backend-rust/scripts/regen-sqlx-cache.sh
+++ b/backend-rust/scripts/regen-sqlx-cache.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# =============================================================================
+# regen-sqlx-cache.sh — Regenerate the .sqlx/ offline query cache
+# =============================================================================
+#
+# sqlx's compile-time query macros (`sqlx::query!`, `sqlx::query_as!`) validate
+# every query against a live database at build time, then cache the type
+# information under `.sqlx/`. CI (`cargo sqlx prepare --check`) and the
+# Distroless image build (offline mode) rely on this cache. Whenever you add
+# or modify a compile-time query, the cache must be regenerated and committed.
+#
+# This script:
+#   1. Boots a throwaway Postgres 15 container on port 5439.
+#   2. Applies every migration under `backend-rust/migrations/` in order
+#      (`cargo sqlx migrate run`).
+#   3. Runs `cargo sqlx prepare --workspace -- --tests` against it so the
+#      cache covers both library and test queries.
+#   4. Tears the container down on exit (even on failure).
+#
+# Usage:
+#   cd backend-rust
+#   ./scripts/regen-sqlx-cache.sh
+#
+# After it completes, review and `git add backend-rust/.sqlx/`. Then run
+# `cargo sqlx prepare --check` to confirm the cache is in sync.
+#
+# Requirements: docker, cargo, sqlx-cli >= 0.8 (`cargo install sqlx-cli
+# --no-default-features --features rustls,postgres`).
+# =============================================================================
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Config — keep port high enough to avoid collisions with the dev/test stack
+# (5432=local, 5434=prod, 5435=staging, 5436=e2e, 5437=integration, 5438=unit).
+# -----------------------------------------------------------------------------
+CONTAINER_NAME="${CONTAINER_NAME:-sqlx-prepare-pg}"
+PORT="${PORT:-5439}"
+DB_NAME="${DB_NAME:-loyalty_prepare}"
+DB_USER="${DB_USER:-loyalty}"
+DB_PASS="${DB_PASS:-loyalty_pass}"
+PG_IMAGE="${PG_IMAGE:-postgres:15-alpine}"
+READY_TIMEOUT_SEC="${READY_TIMEOUT_SEC:-30}"
+
+# Resolve the backend-rust directory regardless of caller's CWD so the script
+# can be invoked from anywhere in the repo.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# -----------------------------------------------------------------------------
+# Pre-flight: required tools must be present. Fail loudly with a clear hint
+# rather than producing cryptic errors deeper in the script.
+# -----------------------------------------------------------------------------
+require() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "error: '$1' is required but not on PATH." >&2
+        echo "       $2" >&2
+        exit 1
+    fi
+}
+
+require docker  "Install Docker Desktop / OrbStack / Colima and start the daemon."
+require cargo   "Install Rust via rustup: https://rustup.rs/"
+
+if ! cargo sqlx --version >/dev/null 2>&1; then
+    echo "error: sqlx-cli is not installed." >&2
+    echo "       cargo install sqlx-cli --no-default-features --features rustls,postgres" >&2
+    exit 1
+fi
+
+cd "$BACKEND_DIR"
+
+# -----------------------------------------------------------------------------
+# Cleanup on exit. Always remove the container so a previous run's leftovers
+# don't block the next one and so we don't leak resources. `|| true` because
+# the container may not exist yet if pre-flight failed.
+# -----------------------------------------------------------------------------
+cleanup() {
+    echo "==> Cleaning up container $CONTAINER_NAME"
+    docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+# Remove any stale container before starting fresh — makes the script
+# idempotent if a previous run was interrupted.
+docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+
+# -----------------------------------------------------------------------------
+# Boot Postgres
+# -----------------------------------------------------------------------------
+echo "==> Starting $PG_IMAGE as $CONTAINER_NAME on port $PORT"
+docker run -d --rm \
+    --name "$CONTAINER_NAME" \
+    -p "$PORT":5432 \
+    -e "POSTGRES_DB=$DB_NAME" \
+    -e "POSTGRES_USER=$DB_USER" \
+    -e "POSTGRES_PASSWORD=$DB_PASS" \
+    "$PG_IMAGE" >/dev/null
+
+echo "==> Waiting for Postgres to accept connections (timeout ${READY_TIMEOUT_SEC}s)"
+deadline=$(( $(date +%s) + READY_TIMEOUT_SEC ))
+until docker exec "$CONTAINER_NAME" pg_isready -U "$DB_USER" -d "$DB_NAME" >/dev/null 2>&1; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+        echo "error: Postgres did not become ready within ${READY_TIMEOUT_SEC}s" >&2
+        docker logs "$CONTAINER_NAME" >&2 || true
+        exit 1
+    fi
+    sleep 1
+done
+
+export DATABASE_URL="postgres://$DB_USER:$DB_PASS@localhost:$PORT/$DB_NAME"
+echo "==> DATABASE_URL=$DATABASE_URL"
+
+# -----------------------------------------------------------------------------
+# Apply migrations. We use sqlx's migrator (not raw psql) so that the same
+# code path that runs in production is exercised here — catches issues like
+# missing semicolons or out-of-order migrations.
+# -----------------------------------------------------------------------------
+echo "==> Applying migrations"
+cargo sqlx migrate run
+
+# -----------------------------------------------------------------------------
+# Regenerate the cache. `--workspace` covers every crate (just the one today,
+# but future-proof); `-- --tests` ensures test-only queries are cached too,
+# matching what CI's `cargo sqlx prepare --check` will validate.
+# -----------------------------------------------------------------------------
+echo "==> Regenerating .sqlx/ offline cache"
+cargo sqlx prepare --workspace -- --tests
+
+echo ""
+echo "==> Done. Review changes with: git status backend-rust/.sqlx/"
+echo "==> Then verify with:          cargo sqlx prepare --check"

--- a/backend-rust/src/routes/admin_rooms.rs
+++ b/backend-rust/src/routes/admin_rooms.rs
@@ -26,12 +26,12 @@
 //!
 //! ## sqlx note
 //!
-//! These handlers use **runtime** `sqlx::query()` / `sqlx::query_as()` rather
-//! than the compile-time `query!()` macros. The macros require regenerating
-//! `.sqlx/` against a live database (`cargo sqlx prepare`), which is not
-//! available in this worktree. Runtime queries are still parameterised, so
-//! injection-safe. CI's `cargo sqlx prepare --check` only validates entries
-//! that already exist in the cache — it does not require new ones.
+//! These handlers use compile-time `sqlx::query_as!` / `sqlx::query!`
+//! macros, validated against the offline cache in `backend-rust/.sqlx/`. To
+//! regenerate that cache after adding or changing a query, run
+//! `backend-rust/scripts/regen-sqlx-cache.sh` and commit the resulting
+//! `.sqlx/*.json` files. CI verifies the cache with `cargo sqlx prepare
+//! --check`.
 
 use axum::{
     extract::{Extension, Query, State},
@@ -295,24 +295,23 @@ async fn list_room_types(
 ) -> AppResult<Json<Vec<RoomTypeResponse>>> {
     require_admin(&user)?;
 
-    let sql = if query.include_inactive {
+    // The `is_active` filter is expressed as `$1::bool OR is_active`, so
+    // passing `true` includes every row (the predicate is short-circuited)
+    // and passing `false` keeps only the active ones. Doing it this way
+    // keeps the SQL static, which is what `sqlx::query_as!` requires.
+    let rows = sqlx::query_as!(
+        RoomTypeRow,
         r#"
         SELECT id, name, description, price_per_night, max_guests, is_active,
                created_at, updated_at
           FROM room_types
+         WHERE $1::bool OR is_active
          ORDER BY LOWER(name) ASC
-        "#
-    } else {
-        r#"
-        SELECT id, name, description, price_per_night, max_guests, is_active,
-               created_at, updated_at
-          FROM room_types
-         WHERE is_active = TRUE
-         ORDER BY LOWER(name) ASC
-        "#
-    };
-
-    let rows: Vec<RoomTypeRow> = sqlx::query_as(sql).fetch_all(state.db()).await?;
+        "#,
+        query.include_inactive
+    )
+    .fetch_all(state.db())
+    .await?;
 
     Ok(Json(rows.into_iter().map(RoomTypeResponse::from).collect()))
 }
@@ -333,46 +332,37 @@ async fn list_rooms(
 ) -> AppResult<Json<Vec<RoomResponse>>> {
     require_admin(&user)?;
 
-    // We build the SQL once with two optional WHERE clauses. Using runtime
-    // `query_as` lets us conditionally bind only the args that are present.
-    let mut sql = String::from(
+    // Optional filters expressed inline so the SQL stays static (a
+    // requirement for `sqlx::query_as!`). When `room_type_id` is None the
+    // first clause is always true; when `include_inactive` is true the
+    // second clause is always true. ORDER BY LENGTH() then the string
+    // itself handles natural numeric ordering ("9" before "10").
+    // `rt_name?` forces the joined `room_types.name` column to be modelled
+    // as Option<String> in the macro output, matching the `RoomRow` field
+    // (the INNER JOIN guarantees a value, but the macro can't tell).
+    let rows = sqlx::query_as!(
+        RoomRow,
         r#"
-        SELECT r.id, r.room_type_id, r.room_number, r.floor, r.is_active,
-               r.created_at, r.updated_at,
-               rt.name AS rt_name
+        SELECT r.id,
+               r.room_type_id,
+               r.room_number,
+               r.floor,
+               r.is_active,
+               r.created_at,
+               r.updated_at,
+               rt.name AS "rt_name?"
           FROM rooms r
           JOIN room_types rt ON rt.id = r.room_type_id
-         WHERE 1 = 1
+         WHERE ($1::uuid IS NULL OR r.room_type_id = $1)
+           AND ($2::bool OR r.is_active)
+         ORDER BY LENGTH(r.room_number), r.room_number ASC
         "#,
-    );
+        query.room_type_id,
+        query.include_inactive,
+    )
+    .fetch_all(state.db())
+    .await?;
 
-    let mut next_param: usize = 1;
-    if query.room_type_id.is_some() {
-        sql.push_str(&format!(" AND r.room_type_id = ${}", next_param));
-        next_param += 1;
-    }
-    if !query.include_inactive {
-        sql.push_str(&format!(" AND r.is_active = ${}", next_param));
-        next_param += 1;
-    }
-    // Order by numeric prefix when possible (so "10" sorts after "9"), then
-    // the raw string. Postgres' natural string sort would put "10" before
-    // "2"; using a substring cast handles common pure-numeric room numbers.
-    sql.push_str(" ORDER BY LENGTH(r.room_number), r.room_number ASC");
-    // Silence the "value assigned but never read" lint on the final
-    // increment — the counter is structural so future filter additions are
-    // a one-line change.
-    let _ = next_param;
-
-    let mut q = sqlx::query_as::<_, RoomRow>(&sql);
-    if let Some(rt_id) = query.room_type_id {
-        q = q.bind(rt_id);
-    }
-    if !query.include_inactive {
-        q = q.bind(true);
-    }
-
-    let rows: Vec<RoomRow> = q.fetch_all(state.db()).await?;
     Ok(Json(rows.into_iter().map(RoomResponse::from).collect()))
 }
 
@@ -406,29 +396,31 @@ async fn list_blocked_dates(
         ));
     }
 
-    let mut sql = String::from(
+    // Optional room-type filter expressed inline so the SQL is static
+    // (compile-time `query_as!` requirement). `room_number?` forces the
+    // joined column to Option<String> to match the row struct.
+    let rows = sqlx::query_as!(
+        BlockedDateRow,
         r#"
-        SELECT bd.id, bd.room_id, r.room_number, bd.blocked_date,
-               bd.reason, bd.created_at
+        SELECT bd.id,
+               bd.room_id,
+               r.room_number AS "room_number!",
+               bd.blocked_date,
+               bd.reason,
+               bd.created_at
           FROM room_blocked_dates bd
           JOIN rooms r ON r.id = bd.room_id
-         WHERE bd.blocked_date >= $1 AND bd.blocked_date <= $2
+         WHERE bd.blocked_date >= $1
+           AND bd.blocked_date <= $2
+           AND ($3::uuid IS NULL OR r.room_type_id = $3)
+         ORDER BY r.room_number ASC, bd.blocked_date ASC
         "#,
-    );
-
-    if query.room_type_id.is_some() {
-        sql.push_str(" AND r.room_type_id = $3");
-    }
-    sql.push_str(" ORDER BY r.room_number ASC, bd.blocked_date ASC");
-
-    let mut q = sqlx::query_as::<_, BlockedDateRow>(&sql)
-        .bind(start)
-        .bind(end);
-    if let Some(rt_id) = query.room_type_id {
-        q = q.bind(rt_id);
-    }
-
-    let rows: Vec<BlockedDateRow> = q.fetch_all(state.db()).await?;
+        start,
+        end,
+        query.room_type_id,
+    )
+    .fetch_all(state.db())
+    .await?;
 
     // Group rows by room so the frontend can iterate roomId → dates[]
     // directly. We use a Vec rather than a HashMap to preserve the
@@ -477,10 +469,10 @@ async fn block_dates(
         ));
     }
 
-    // Verify the room exists. A missing room would also fail the FK
-    // constraint, but explicit-then-friendly is nicer for the admin UI.
-    let room_exists: Option<(Uuid,)> = sqlx::query_as("SELECT id FROM rooms WHERE id = $1")
-        .bind(payload.room_id)
+    // Verify the room exists. A missing row would also fail the FK
+    // constraint at insert time, but the explicit lookup gives the admin
+    // UI a clean 404 instead of a generic 500.
+    let room_exists = sqlx::query_scalar!("SELECT id FROM rooms WHERE id = $1", payload.room_id)
         .fetch_optional(state.db())
         .await?;
     if room_exists.is_none() {
@@ -490,7 +482,13 @@ async fn block_dates(
     // Bulk insert via UNNEST so a single round-trip handles N dates.
     // ON CONFLICT collapses duplicates; RETURNING gives us back only the
     // rows we actually created.
-    let inserted: Vec<(Uuid, NaiveDate, Option<DateTime<Utc>>)> = sqlx::query_as(
+    struct InsertedRow {
+        id: Uuid,
+        blocked_date: NaiveDate,
+        created_at: Option<DateTime<Utc>>,
+    }
+    let inserted = sqlx::query_as!(
+        InsertedRow,
         r#"
         INSERT INTO room_blocked_dates (room_id, blocked_date, reason)
         SELECT $1, d, $3
@@ -498,21 +496,21 @@ async fn block_dates(
         ON CONFLICT (room_id, blocked_date) DO NOTHING
         RETURNING id, blocked_date, created_at
         "#,
+        payload.room_id,
+        &payload.dates,
+        payload.reason.as_deref(),
     )
-    .bind(payload.room_id)
-    .bind(&payload.dates)
-    .bind(&payload.reason)
     .fetch_all(state.db())
     .await?;
 
     let response: Vec<BlockedDateItem> = inserted
         .into_iter()
-        .map(|(id, blocked_date, created_at)| BlockedDateItem {
-            id,
+        .map(|row| BlockedDateItem {
+            id: row.id,
             room_id: payload.room_id,
-            blocked_date,
+            blocked_date: row.blocked_date,
             reason: payload.reason.clone(),
-            created_at: created_at.unwrap_or_else(Utc::now),
+            created_at: row.created_at.unwrap_or_else(Utc::now),
             created_by: None,
         })
         .collect();
@@ -545,15 +543,15 @@ async fn unblock_dates(
         ));
     }
 
-    let result = sqlx::query(
+    let result = sqlx::query!(
         r#"
         DELETE FROM room_blocked_dates
          WHERE room_id = $1
            AND blocked_date = ANY($2::date[])
         "#,
+        payload.room_id,
+        &payload.dates,
     )
-    .bind(payload.room_id)
-    .bind(&payload.dates)
     .execute(state.db())
     .await?;
 

--- a/backend-rust/src/routes/bookings.rs
+++ b/backend-rust/src/routes/bookings.rs
@@ -1242,13 +1242,19 @@ async fn award_loyalty_points(
 }
 
 /// Row returned by `insert_booking_slip`.
+///
+/// `uploaded_at` is nullable in the schema (the column carries a
+/// `DEFAULT CURRENT_TIMESTAMP` but no `NOT NULL`); the response substitutes
+/// "now" if it is somehow NULL on read.
 #[derive(Debug, FromRow)]
 struct BookingSlipRow {
     pub id: Uuid,
     pub booking_id: Uuid,
     pub slip_url: String,
     pub uploaded_by: Uuid,
-    pub uploaded_at: DateTime<Utc>,
+    pub uploaded_at: Option<DateTime<Utc>>,
+    pub slipok_status: Option<String>,
+    pub admin_status: Option<String>,
 }
 
 impl From<BookingSlipRow> for BookingSlipResponse {
@@ -1258,32 +1264,37 @@ impl From<BookingSlipRow> for BookingSlipResponse {
             booking_id: row.booking_id,
             slip_url: row.slip_url,
             uploaded_by: row.uploaded_by,
-            uploaded_at: row.uploaded_at,
-            // These are nullable placeholders for the SlipOK / admin review
-            // workflows. They aren't wired up yet, so we always return None.
-            slipok_status: None,
-            admin_status: None,
+            uploaded_at: row.uploaded_at.unwrap_or_else(Utc::now),
+            slipok_status: row.slipok_status,
+            admin_status: row.admin_status,
         }
     }
 }
 
 /// Insert a slip row and return it as a response DTO.
+///
+/// The `slipok_status` and `admin_status` columns default to `'pending'` in
+/// the schema, so they are returned in the response immediately — clients
+/// don't have to wait for the SlipOK / admin review workflows to fire
+/// before seeing a status value.
 async fn insert_booking_slip(
     db: &PgPool,
     booking_id: Uuid,
     slip_url: &str,
     uploaded_by: Uuid,
 ) -> AppResult<BookingSlipResponse> {
-    let row: BookingSlipRow = sqlx::query_as(
+    let row = sqlx::query_as!(
+        BookingSlipRow,
         r#"
         INSERT INTO booking_slips (booking_id, slip_url, uploaded_by)
         VALUES ($1, $2, $3)
-        RETURNING id, booking_id, slip_url, uploaded_by, uploaded_at
+        RETURNING id, booking_id, slip_url, uploaded_by, uploaded_at,
+                  slipok_status, admin_status
         "#,
+        booking_id,
+        slip_url,
+        uploaded_by,
     )
-    .bind(booking_id)
-    .bind(slip_url)
-    .bind(uploaded_by)
     .fetch_one(db)
     .await?;
 


### PR DESCRIPTION
## Summary

Foundation work for the next round of admin endpoints. Two debts retired:

**Debt A — `booking_slips` schema reconciled with production.**

The on-disk migration (`backend-rust/migrations/20260511000000_booking_slips.sql`,
landed in PR #211) created a minimal `booking_slips` table — only `id`,
`booking_id`, `slip_url`, `uploaded_by`, `uploaded_at`. Production and staging
postgres have a **much richer** table (verified via SSH into evergreen):
the SlipOK auto-verification columns (`slipok_status`, `slipok_verified_at`,
`slipok_response`), the admin review columns (`admin_status`,
`admin_verified_at`, `admin_verified_by`, `admin_notes`), `is_primary`,
`created_at`, `updated_at`, five supporting indexes, an FK from
`admin_verified_by` → `users(id)`, and a `BEFORE UPDATE` trigger
(`update_booking_slips_updated_at`) that keeps `updated_at` fresh.

That richer schema came from an old Prisma migration that was never copied
into this repo. The result was an inconsistency: production has one shape;
fresh databases (e2e, local dev, integration tests) had another. Compile-time
sqlx queries can only be valid against one of them.

This PR rewrites the existing migration body to **be** the canonical schema —
matching production exactly. Production already recorded `20260511000000` in
`_sqlx_migrations` on a prior deploy, so sqlx will not re-run it there. Fresh
databases now produce the production shape on first start. Zero production
impact, every other environment now matches.

The PR #213 stash entry with the DO-block FK idempotency hack is retired
along with the original partial migration body — neither is needed now that
the canonical definition is a plain `CREATE TABLE`.

**Debt B — runtime `sqlx::query()` calls converted to compile-time macros.**

PR #206 (admin_rooms) and PR #211 (booking_slips) introduced runtime
`sqlx::query()` / `sqlx::query_as()` calls instead of the compile-time
`sqlx::query!()` / `sqlx::query_as!()` macros that the rest of the codebase
uses. The agents who wrote those PRs couldn't reach a live database to
regenerate the `.sqlx/` offline cache, so runtime queries were the workaround.

This PR converts every one of those queries to compile-time macros and
commits the regenerated cache. CI's `cargo sqlx prepare --check` will now
validate them on every push.

A new helper script — `backend-rust/scripts/regen-sqlx-cache.sh` — boots a
throwaway Postgres container, applies every migration, runs
`cargo sqlx prepare --workspace -- --tests`, and tears the container down.
Contributors who add new compile-time queries can now regenerate the cache
with one command, removing the workaround pressure that produced the runtime
queries in the first place.

## Before / After: one converted query

**Before** (`backend-rust/src/routes/bookings.rs`, `insert_booking_slip`):

```rust
let row: BookingSlipRow = sqlx::query_as(
    r#"
    INSERT INTO booking_slips (booking_id, slip_url, uploaded_by)
    VALUES ($1, $2, $3)
    RETURNING id, booking_id, slip_url, uploaded_by, uploaded_at
    "#,
)
.bind(booking_id)
.bind(slip_url)
.bind(uploaded_by)
.fetch_one(db)
.await?;
```

**After**:

```rust
let row = sqlx::query_as!(
    BookingSlipRow,
    r#"
    INSERT INTO booking_slips (booking_id, slip_url, uploaded_by)
    VALUES ($1, $2, $3)
    RETURNING id, booking_id, slip_url, uploaded_by, uploaded_at,
              slipok_status, admin_status
    "#,
    booking_id,
    slip_url,
    uploaded_by,
)
.fetch_one(db)
.await?;
```

The macro version (a) is validated against the schema at compile time,
(b) catches column-typo and shape-drift bugs before they reach CI, and
(c) returns the SlipOK / admin status defaults (`'pending'`) in the response
instead of always emitting `None`.

The shape-changing conversions in `admin_rooms.rs` (`list_rooms`,
`list_blocked_dates`) collapse dynamic SQL strings into static SQL with
optional filters expressed as `($N::uuid IS NULL OR column = $N)` — same
semantics, planner short-circuits when the parameter is NULL, but the SQL
is now a literal the macro can validate.

## Using `regen-sqlx-cache.sh`

```bash
cd backend-rust
./scripts/regen-sqlx-cache.sh
git status .sqlx/        # review the cache diff
git add .sqlx/
cargo sqlx prepare --check    # confirms cache is in sync
```

Requirements: `docker`, `cargo`, `sqlx-cli >= 0.8`. The script is
idempotent (cleans up any previous container before starting), pre-flights
its tool requirements with clear install hints, and uses a trap to ensure
the container is torn down even if the script fails mid-run.

## Verification performed locally before push

- `cargo sqlx migrate run` against a fresh Postgres 15 applied both
  migrations cleanly, producing `\d booking_slips` output **identical**
  to staging.
- `cargo sqlx prepare --workspace -- --tests` succeeded and wrote 7 new
  cache entries to `.sqlx/`.
- `cargo sqlx prepare --check --workspace -- --tests` passes.
- `SQLX_OFFLINE=true cargo build` succeeds.
- `SQLX_OFFLINE=true cargo test --no-run` compiles every test.
- `SQLX_OFFLINE=true cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt --check` clean.
- `cargo test --lib admin_rooms::` — 3 / 3 unit tests pass.

Integration tests (those that need a live test DB on port 5438) run in CI
against fresh migrations, which now produce the canonical schema.

## Test plan

- [ ] CI runs `cargo sqlx prepare --check` and it passes
- [ ] CI runs `cargo test` (unit + integration) and it passes
- [ ] Fresh e2e DB starts cleanly and `booking_slips` has the full
      production schema (all 15 columns, 5 indexes, trigger present)
- [ ] Existing `add_booking_slip` integration tests in
      `tests/integration/booking_test.rs` still pass
- [ ] Existing `admin_rooms` runtime behavior unchanged
      (room-type / room / blocked-dates listings, block / unblock
      mutations all behave identically to before)
- [ ] Smoke-test on staging after merge: hit `GET /api/admin/rooms` and
      `POST /api/bookings/:id/slips` to confirm prod parity holds

🤖 Generated with [Claude Code](https://claude.com/claude-code)