### PR TITLE
perf(ci): consolidate Rust build, inline deploy-staging, cache playwright+cloudflared

### DIFF
--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -1,7 +1,9 @@
-name: CI Build & E2E
+name: CI Build & Deploy
 
 on:
   push:
+    branches: [main]
+  pull_request:
     branches: [main]
   workflow_dispatch:
     inputs:
@@ -31,20 +33,98 @@ env:
 
 jobs:
   # =============================================================================
-  # BUILD RUST BINARY
+  # LINT BACKEND (Rust) - fail-fast fmt + clippy on bare ubuntu, separate cache
   # =============================================================================
 
-  build-backend-binary:
-    name: "Build Backend Binary"
+  lint-backend:
+    name: "Lint Backend (Rust)"
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+          components: clippy, rustfmt
+
+      - name: Cache Rust dependencies (lint)
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "backend-rust -> target"
+          cache-on-failure: true
+          prefix-key: "v0-rust-lint"
+
+      - name: Check formatting
+        working-directory: ./backend-rust
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy (lints)
+        working-directory: ./backend-rust
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  # =============================================================================
+  # VALIDATE & BUILD BACKEND (Rust)
+  #
+  # Single Rust toolchain pass that:
+  #   1. Unit tests (debug)
+  #   2. Applies migrations to a service Postgres, verifies schema
+  #   3. Runs sqlx prepare --check against the live test DB
+  #   4. Runs integration tests against the live DB + Redis
+  #   5. Builds the release binary and uploads it as an artifact for the
+  #      build-and-push job to consume.
+  #
+  # Runs inside rust:1.93-bookworm so the same target/ cache (Swatinem rust-cache
+  # workspace key) is shared between tests and the release build. The previous
+  # two-job split used different OS environments + different cache prefixes,
+  # which made it impossible to share artifacts. See PR consolidating CI.
+  # =============================================================================
+
+  validate-and-build-backend:
+    name: "Validate & Build Backend (Rust)"
+    runs-on: ubuntu-latest
+    needs: [lint-backend]
+    timeout-minutes: 30
     container:
       image: rust:1.93-bookworm
-    timeout-minutes: 25
+
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: loyalty_test
+          POSTGRES_PASSWORD: loyalty_test_pass
+          POSTGRES_DB: loyalty_test_db
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Inside the job container, services are reachable by their service name
+      # on their original ports — no host port mapping required.
+      DATABASE_URL: postgresql://loyalty_test:loyalty_test_pass@postgres:5432/loyalty_test_db
+      TEST_DATABASE_URL: postgresql://loyalty_test:loyalty_test_pass@postgres:5432/loyalty_test_db
+      TEST_REDIS_URL: redis://redis:6379
+      PGPASSWORD: loyalty_test_pass
 
     steps:
       - name: Install system dependencies
         run: |
-          apt-get update && apt-get install -y --no-install-recommends pkg-config libssl-dev libpq-dev
+          apt-get update && apt-get install -y --no-install-recommends \
+            pkg-config libssl-dev libpq-dev postgresql-client
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -58,6 +138,113 @@ jobs:
           workspaces: "backend-rust -> target"
           cache-on-failure: true
           prefix-key: "v0-rust-container"
+
+      - name: Run unit tests
+        working-directory: ./backend-rust
+        run: cargo test --lib --bins
+        env:
+          RUST_BACKTRACE: 1
+          RUST_LOG: debug
+
+      - name: Grant CREATEDB for per-test database isolation
+        run: |
+          psql -h postgres -p 5432 -U loyalty_test -d loyalty_test_db \
+            -c "ALTER USER loyalty_test CREATEDB;"
+
+      - name: Run database migrations
+        run: |
+          # Apply every migration in lexical (timestamp-ordered) order so the
+          # sqlx prepare --check step below sees the same schema the app
+          # expects. Hard-coding a single filename silently rotted as new
+          # migrations were added — see PR #215's booking_slips reconciliation.
+          set -euo pipefail
+          for f in backend-rust/migrations/*.sql; do
+            echo "Applying $f"
+            psql -h postgres -p 5432 -U loyalty_test -d loyalty_test_db \
+              -v ON_ERROR_STOP=1 -f "$f"
+          done
+
+      - name: Verify database schema
+        run: |
+          TABLE_COUNT=$(psql -h postgres -p 5432 -U loyalty_test -d loyalty_test_db -t -c \
+            "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE';")
+          TABLE_COUNT=$(echo "$TABLE_COUNT" | tr -d ' ')
+          echo "Tables created: $TABLE_COUNT"
+          if [ "$TABLE_COUNT" -lt 25 ]; then
+            echo "::error::Expected 25+ tables, found $TABLE_COUNT. Migration may have failed."
+            psql -h postgres -p 5432 -U loyalty_test -d loyalty_test_db -c \
+              "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE' ORDER BY table_name;"
+            exit 1
+          fi
+
+          # Verify stored procedures exist
+          FUNC_COUNT=$(psql -h postgres -p 5432 -U loyalty_test -d loyalty_test_db -t -c \
+            "SELECT count(*) FROM information_schema.routines WHERE routine_schema = 'public' AND routine_type = 'FUNCTION';")
+          FUNC_COUNT=$(echo "$FUNC_COUNT" | tr -d ' ')
+          echo "Stored procedures/functions: $FUNC_COUNT"
+          if [ "$FUNC_COUNT" -lt 5 ]; then
+            echo "::error::Expected 5+ stored procedures, found $FUNC_COUNT."
+            exit 1
+          fi
+
+          echo "Database schema verification passed"
+
+      - name: Seed test data
+        run: |
+          psql -h postgres -p 5432 -U loyalty_test -d loyalty_test_db -c "
+            INSERT INTO tiers (name, min_points, min_nights, benefits, color, sort_order, is_active)
+            VALUES
+              ('Bronze', 0, 0, '{\"discount\": 0}', '#CD7F32', 1, true),
+              ('Silver', 0, 1, '{\"discount\": 5}', '#C0C0C0', 2, true),
+              ('Gold', 0, 10, '{\"discount\": 10}', '#FFD700', 3, true),
+              ('Platinum', 0, 20, '{\"discount\": 15}', '#E5E4E2', 4, true)
+            ON CONFLICT (name) DO NOTHING;
+
+            INSERT INTO membership_id_sequence (id, current_user_count)
+            VALUES (1, 0)
+            ON CONFLICT (id) DO NOTHING;
+          "
+          echo "Test data seeded successfully"
+
+      - name: Cache sqlx-cli
+        id: cache-sqlx
+        uses: actions/cache@v5
+        with:
+          path: /usr/local/cargo/bin/sqlx
+          key: sqlx-cli-container-${{ env.RUST_VERSION }}
+
+      - name: Install sqlx-cli
+        if: steps.cache-sqlx.outputs.cache-hit != 'true'
+        run: cargo install sqlx-cli --no-default-features --features postgres --locked
+
+      - name: Verify SQLx query cache
+        working-directory: ./backend-rust
+        run: cargo sqlx prepare --check
+
+      - name: Run integration tests
+        working-directory: ./backend-rust
+        run: cargo test --test '*'
+        env:
+          RUST_BACKTRACE: short
+          RUST_LOG: warn
+          JWT_SECRET: test-jwt-secret-key-for-testing-only-minimum-32-chars
+          JWT_REFRESH_SECRET: test-refresh-secret-key-for-testing-only-minimum-32-chars
+          SESSION_SECRET: test-session-secret-key-for-testing-only-minimum-32-chars
+          GOOGLE_CLIENT_ID: test-google-client-id
+          GOOGLE_CLIENT_SECRET: test-google-client-secret
+          GOOGLE_CALLBACK_URL: http://localhost:4001/api/oauth/google/callback
+          LINE_CLIENT_ID: test-line-channel-id
+          LINE_CLIENT_SECRET: test-line-channel-secret
+          LINE_CALLBACK_URL: http://localhost:4001/api/oauth/line/callback
+          FRONTEND_URL: http://localhost:3000
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
+
+      - name: Check for security vulnerabilities
+        working-directory: ./backend-rust
+        run: cargo audit || echo "Some vulnerabilities found - review output"
+        continue-on-error: true
 
       - name: Build release binary
         working-directory: ./backend-rust
@@ -81,7 +268,7 @@ jobs:
   build-and-push:
     name: "Build & Push to GHCR"
     runs-on: ubuntu-latest
-    needs: [build-backend-binary]
+    needs: [validate-and-build-backend]
     timeout-minutes: 15
     permissions:
       contents: read
@@ -107,7 +294,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # -------------------------------------------------------------------------
-      # Backend Image (Rust) - uses pre-built binary from build-backend-binary
+      # Backend Image (Rust) - uses pre-built binary from
+      # validate-and-build-backend
       # -------------------------------------------------------------------------
       - name: Download backend binary
         uses: actions/download-artifact@v4
@@ -230,8 +418,30 @@ jobs:
       - name: Install root dependencies (Playwright)
         run: npm ci
 
-      - name: Install Playwright browsers
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          # Read the resolved version from package-lock.json (semver-pinned),
+          # not the ^-prefixed range in package.json, so the cache key changes
+          # only when the lockfile changes.
+          PLAYWRIGHT_VERSION=$(node -p "require('./package-lock.json').packages['node_modules/@playwright/test'].version")
+          echo "version=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
+          echo "Playwright version: $PLAYWRIGHT_VERSION"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers (with system deps)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright OS deps (cache hit, browsers already present)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -352,3 +562,178 @@ jobs:
         run: |
           docker stop backend frontend 2>/dev/null || true
           docker rm backend frontend 2>/dev/null || true
+
+  # =============================================================================
+  # WAIT FOR CI Tests WORKFLOW (frontend jobs) BEFORE STAGING DEPLOY
+  #
+  # ci-test.yml runs the frontend lint and unit-test jobs for the same commit.
+  # We poll the gh API instead of using workflow_run (which adds 30-120s of
+  # orchestration latency and has a documented "skipped" race when two
+  # upstream workflows complete out of order).
+  # =============================================================================
+
+  wait-for-frontend-checks:
+    name: "Wait for Frontend Checks"
+    runs-on: ubuntu-latest
+    needs: [build-and-push]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    timeout-minutes: 15
+
+    steps:
+      - name: Poll ci-test.yml for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          echo "Polling ci-test.yml for commit $COMMIT_SHA"
+
+          # Poll for up to ~12 minutes (72 attempts x 10s). Fail closed if the
+          # frontend checks haven't succeeded by then.
+          for attempt in $(seq 1 72); do
+            CONCLUSION=$(gh run list -R ${{ github.repository }} \
+              --workflow=ci-test.yml --branch=main --commit="$COMMIT_SHA" \
+              --json conclusion,status --jq '.[0] | "\(.status):\(.conclusion // "pending")"')
+
+            echo "Attempt $attempt: ci-test.yml = ${CONCLUSION:-no-run-yet}"
+
+            case "$CONCLUSION" in
+              completed:success)
+                echo "ci-test.yml completed successfully"
+                exit 0
+                ;;
+              completed:failure|completed:cancelled|completed:timed_out|completed:action_required|completed:startup_failure)
+                echo "::error::ci-test.yml did not succeed (status=$CONCLUSION) — aborting staging deploy"
+                exit 1
+                ;;
+              *)
+                sleep 10
+                ;;
+            esac
+          done
+
+          echo "::error::Timed out waiting for ci-test.yml to complete for $COMMIT_SHA"
+          exit 1
+
+  # =============================================================================
+  # DEPLOY TO STAGING (no approval needed)
+  #
+  # Inlined here so the deploy starts the moment its prerequisites are green,
+  # instead of going through a workflow_run hop that adds 30-120s of latency
+  # and can race itself into "skipped" purgatory when two upstream workflows
+  # finish in the wrong order.
+  # =============================================================================
+
+  deploy-staging:
+    name: "Deploy to Staging"
+    runs-on: ubuntu-latest
+    needs: [build-and-push, e2e-tests, wait-for-frontend-checks]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    timeout-minutes: 10
+    environment:
+      name: development
+      url: http://loyalty-dev.saichon.com
+
+    steps:
+      - name: Checkout config files
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            docker-compose.yml
+            docker-compose.ghcr.yml
+            docker-compose.staging.yml
+            nginx/nginx.conf
+          sparse-checkout-cone-mode: false
+
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+            -o /tmp/cloudflared
+          sudo install -m 755 /tmp/cloudflared /usr/local/bin/cloudflared
+          cloudflared --version
+
+      - name: Install SSH key + known_hosts
+        env:
+          SSH_KEY:  ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
+          HOST_KEY: ${{ secrets.EVERGREEN_HOST_KEY }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY"  > ~/.ssh/deploy_key  && chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "$HOST_KEY" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+
+      - name: Deploy via SSH to evergreen
+        env:
+          COMMIT_SHA:           ${{ github.sha }}
+          GHCR_USER:            ${{ github.actor }}
+          GHCR_TOKEN:           ${{ secrets.GITHUB_TOKEN }}
+          JWT_SECRET:           ${{ secrets.DEV_JWT_SECRET }}
+          JWT_REFRESH_SECRET:   ${{ secrets.DEV_JWT_REFRESH_SECRET }}
+          SESSION_SECRET:       ${{ secrets.DEV_SESSION_SECRET }}
+          GOOGLE_CLIENT_ID:     ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          GOOGLE_CALLBACK_URL:  ${{ vars.GOOGLE_CALLBACK_URL }}
+          LINE_CHANNEL_ID:      ${{ secrets.LINE_CHANNEL_ID }}
+          LINE_CHANNEL_SECRET:  ${{ secrets.LINE_CHANNEL_SECRET }}
+          LINE_CALLBACK_URL:    ${{ vars.LINE_CALLBACK_URL }}
+          FRONTEND_URL:         ${{ vars.FRONTEND_URL }}
+          BACKEND_URL:          ${{ vars.BACKEND_URL }}
+          POSTGRES_USER:        ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD:    ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_DB:          ${{ secrets.POSTGRES_DB }}
+        run: |
+          set -euo pipefail
+          tar -czf /tmp/deploy.tar.gz \
+            docker-compose.yml docker-compose.ghcr.yml docker-compose.staging.yml \
+            nginx/nginx.conf
+
+          jq -n \
+            --arg commit_sha           "$COMMIT_SHA" \
+            --arg deploy_payload_b64   "$(base64 -w0 < /tmp/deploy.tar.gz)" \
+            --arg ghcr_user            "$GHCR_USER" \
+            --arg ghcr_token           "$GHCR_TOKEN" \
+            --arg JWT_SECRET           "$JWT_SECRET" \
+            --arg JWT_REFRESH_SECRET   "$JWT_REFRESH_SECRET" \
+            --arg SESSION_SECRET       "$SESSION_SECRET" \
+            --arg GOOGLE_CLIENT_ID     "$GOOGLE_CLIENT_ID" \
+            --arg GOOGLE_CLIENT_SECRET "$GOOGLE_CLIENT_SECRET" \
+            --arg GOOGLE_CALLBACK_URL  "$GOOGLE_CALLBACK_URL" \
+            --arg LINE_CHANNEL_ID      "$LINE_CHANNEL_ID" \
+            --arg LINE_CHANNEL_SECRET  "$LINE_CHANNEL_SECRET" \
+            --arg LINE_CALLBACK_URL    "$LINE_CALLBACK_URL" \
+            --arg FRONTEND_URL         "$FRONTEND_URL" \
+            --arg BACKEND_URL          "$BACKEND_URL" \
+            --arg POSTGRES_USER        "$POSTGRES_USER" \
+            --arg POSTGRES_PASSWORD    "$POSTGRES_PASSWORD" \
+            --arg POSTGRES_DB          "$POSTGRES_DB" \
+            '{
+              commit_sha: $commit_sha,
+              deploy_payload_b64: $deploy_payload_b64,
+              ghcr: { user: $ghcr_user, token: $ghcr_token },
+              env: {
+                RUST_ENV:             "staging",
+                NODE_ENV:             "staging",
+                RUST_LOG:             "info",
+                LOG_LEVEL:            "info",
+                JWT_SECRET:           $JWT_SECRET,
+                JWT_REFRESH_SECRET:   $JWT_REFRESH_SECRET,
+                SESSION_SECRET:       $SESSION_SECRET,
+                POSTGRES_USER:        $POSTGRES_USER,
+                POSTGRES_PASSWORD:    $POSTGRES_PASSWORD,
+                POSTGRES_DB:          $POSTGRES_DB,
+                DATABASE_URL:         ("postgresql://" + $POSTGRES_USER + ":" + $POSTGRES_PASSWORD + "@postgres:5432/" + $POSTGRES_DB),
+                REDIS_URL:            "redis://redis:6379",
+                FRONTEND_URL:         $FRONTEND_URL,
+                BACKEND_URL:          $BACKEND_URL,
+                GOOGLE_CLIENT_ID:     $GOOGLE_CLIENT_ID,
+                GOOGLE_CLIENT_SECRET: $GOOGLE_CLIENT_SECRET,
+                GOOGLE_CALLBACK_URL:  $GOOGLE_CALLBACK_URL,
+                LINE_CHANNEL_ID:      $LINE_CHANNEL_ID,
+                LINE_CHANNEL_SECRET:  $LINE_CHANNEL_SECRET,
+                LINE_CALLBACK_URL:    $LINE_CALLBACK_URL
+              }
+            }' \
+          | ssh -i ~/.ssh/deploy_key \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
+              deploy@evergreen.thehfhotel.org

--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -94,6 +94,14 @@ jobs:
     container:
       image: rust:1.93-bookworm
 
+    # Force bash as the default shell for all `run:` steps in this job.
+    # Without this, the rust:1.93-bookworm container's default shell is dash
+    # (Debian's /bin/sh), which does not support `set -o pipefail` or several
+    # other bashisms used below for migration scripts and schema checks.
+    defaults:
+      run:
+        shell: bash
+
     services:
       postgres:
         image: postgres:15-alpine

--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -51,6 +51,9 @@ jobs:
           toolchain: ${{ env.RUST_VERSION }}
           components: clippy, rustfmt
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
+
       - name: Cache Rust dependencies (lint)
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -17,13 +17,14 @@ permissions:
 
 env:
   NODE_VERSION: '24'
-  RUST_VERSION: '1.93'
-  SCCACHE_GHA_ENABLED: "true"
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   # =============================================================================
   # WORKSPACE PREPARATION (Node.js only)
+  #
+  # Backend (Rust) validation, lint, and build have moved to ci-build-e2e.yml so
+  # that the single Rust toolchain pass produces the release binary directly,
+  # sharing one target/ cache with build & deploy. See PR consolidating CI.
   # =============================================================================
 
   prepare:
@@ -60,186 +61,8 @@ jobs:
         run: npm ci
 
   # =============================================================================
-  # PARALLEL VALIDATION & TESTING
+  # FRONTEND VALIDATION & TESTING
   # =============================================================================
-
-  validate-backend:
-    name: "Validate Backend (Rust)"
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-
-    services:
-      postgres:
-        image: postgres:15-alpine
-        env:
-          POSTGRES_USER: loyalty_test
-          POSTGRES_PASSWORD: loyalty_test_pass
-          POSTGRES_DB: loyalty_test_db
-        ports:
-          - 5438:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      redis:
-        image: redis:7-alpine
-        ports:
-          - 6383:6379
-        options: >-
-          --health-cmd "redis-cli ping"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: ${{ env.RUST_VERSION }}
-          components: clippy, rustfmt
-
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "backend-rust -> target"
-          cache-on-failure: true
-
-      - name: Check formatting
-        working-directory: ./backend-rust
-        run: cargo fmt --all -- --check
-
-      - name: Run clippy (lints)
-        working-directory: ./backend-rust
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: Run unit tests
-        working-directory: ./backend-rust
-        run: cargo test --lib --bins
-        env:
-          RUST_BACKTRACE: 1
-          RUST_LOG: debug
-
-      - name: Grant CREATEDB for per-test database isolation
-        run: |
-          PGPASSWORD=loyalty_test_pass psql -h localhost -p 5438 -U loyalty_test -d loyalty_test_db -c "ALTER USER loyalty_test CREATEDB;"
-        env:
-          PGPASSWORD: loyalty_test_pass
-
-      - name: Run database migrations
-        run: |
-          # Apply every migration in lexical (timestamp-ordered) order so the
-          # sqlx prepare --check step below sees the same schema the app
-          # expects. Hard-coding a single filename silently rotted as new
-          # migrations were added — see PR #215's booking_slips reconciliation.
-          set -euo pipefail
-          for f in backend-rust/migrations/*.sql; do
-            echo "Applying $f"
-            PGPASSWORD=loyalty_test_pass psql -h localhost -p 5438 -U loyalty_test -d loyalty_test_db \
-              -v ON_ERROR_STOP=1 -f "$f"
-          done
-        env:
-          PGPASSWORD: loyalty_test_pass
-
-      - name: Verify database schema
-        run: |
-          TABLE_COUNT=$(PGPASSWORD=loyalty_test_pass psql -h localhost -p 5438 -U loyalty_test -d loyalty_test_db -t -c \
-            "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE';")
-          TABLE_COUNT=$(echo "$TABLE_COUNT" | tr -d ' ')
-          echo "Tables created: $TABLE_COUNT"
-          if [ "$TABLE_COUNT" -lt 25 ]; then
-            echo "::error::Expected 25+ tables, found $TABLE_COUNT. Migration may have failed."
-            PGPASSWORD=loyalty_test_pass psql -h localhost -p 5438 -U loyalty_test -d loyalty_test_db -c \
-              "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type = 'BASE TABLE' ORDER BY table_name;"
-            exit 1
-          fi
-
-          # Verify stored procedures exist
-          FUNC_COUNT=$(PGPASSWORD=loyalty_test_pass psql -h localhost -p 5438 -U loyalty_test -d loyalty_test_db -t -c \
-            "SELECT count(*) FROM information_schema.routines WHERE routine_schema = 'public' AND routine_type = 'FUNCTION';")
-          FUNC_COUNT=$(echo "$FUNC_COUNT" | tr -d ' ')
-          echo "Stored procedures/functions: $FUNC_COUNT"
-          if [ "$FUNC_COUNT" -lt 5 ]; then
-            echo "::error::Expected 5+ stored procedures, found $FUNC_COUNT."
-            exit 1
-          fi
-
-          echo "Database schema verification passed"
-        env:
-          PGPASSWORD: loyalty_test_pass
-
-      - name: Seed test data
-        run: |
-          PGPASSWORD=loyalty_test_pass psql -h localhost -p 5438 -U loyalty_test -d loyalty_test_db -c "
-            INSERT INTO tiers (name, min_points, min_nights, benefits, color, sort_order, is_active)
-            VALUES
-              ('Bronze', 0, 0, '{\"discount\": 0}', '#CD7F32', 1, true),
-              ('Silver', 0, 1, '{\"discount\": 5}', '#C0C0C0', 2, true),
-              ('Gold', 0, 10, '{\"discount\": 10}', '#FFD700', 3, true),
-              ('Platinum', 0, 20, '{\"discount\": 15}', '#E5E4E2', 4, true)
-            ON CONFLICT (name) DO NOTHING;
-
-            INSERT INTO membership_id_sequence (id, current_user_count)
-            VALUES (1, 0)
-            ON CONFLICT (id) DO NOTHING;
-          "
-          echo "Test data seeded successfully"
-        env:
-          PGPASSWORD: loyalty_test_pass
-
-      - name: Cache sqlx-cli
-        id: cache-sqlx
-        uses: actions/cache@v5
-        with:
-          path: ~/.cargo/bin/sqlx
-          key: sqlx-cli-${{ runner.os }}-${{ env.RUST_VERSION }}
-
-      - name: Install sqlx-cli
-        if: steps.cache-sqlx.outputs.cache-hit != 'true'
-        run: cargo install sqlx-cli --no-default-features --features postgres --locked
-
-      - name: Verify SQLx query cache
-        working-directory: ./backend-rust
-        run: cargo sqlx prepare --check
-        env:
-          DATABASE_URL: postgresql://loyalty_test:loyalty_test_pass@localhost:5438/loyalty_test_db
-
-      - name: Run integration tests
-        working-directory: ./backend-rust
-        run: cargo test --test '*'
-        env:
-          RUST_BACKTRACE: short
-          RUST_LOG: warn
-          TEST_DATABASE_URL: postgresql://loyalty_test:loyalty_test_pass@localhost:5438/loyalty_test_db
-          TEST_REDIS_URL: redis://localhost:6383
-          JWT_SECRET: test-jwt-secret-key-for-testing-only-minimum-32-chars
-          JWT_REFRESH_SECRET: test-refresh-secret-key-for-testing-only-minimum-32-chars
-          SESSION_SECRET: test-session-secret-key-for-testing-only-minimum-32-chars
-          GOOGLE_CLIENT_ID: test-google-client-id
-          GOOGLE_CLIENT_SECRET: test-google-client-secret
-          GOOGLE_CALLBACK_URL: http://localhost:4001/api/oauth/google/callback
-          LINE_CLIENT_ID: test-line-channel-id
-          LINE_CLIENT_SECRET: test-line-channel-secret
-          LINE_CALLBACK_URL: http://localhost:4001/api/oauth/line/callback
-          FRONTEND_URL: http://localhost:3000
-
-      - name: Install cargo-audit
-        uses: taiki-e/install-action@cargo-audit
-
-      - name: Check for security vulnerabilities
-        working-directory: ./backend-rust
-        run: cargo audit || echo "Some vulnerabilities found - review output"
-        continue-on-error: true
-
-      - name: Show sccache stats
-        run: sccache --show-stats
 
   lint-frontend:
     name: "Lint Frontend"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   workflow_run:
-    workflows: ["CI Tests", "CI Build & E2E"]
+    workflows: ["CI Tests", "CI Build & Deploy"]
     types: [completed]
     branches: [main]
 
@@ -19,10 +19,18 @@ env:
   REGISTRY: ghcr.io
   IMAGE_OWNER: thehfhotel
   IMAGE_REPO: loyalty-app
+  # Pin cloudflared so the cache key is stable across deploys. Bump this
+  # version (and the cache will repopulate on the next run) when the
+  # cloudflared release we want changes.
+  CLOUDFLARED_VERSION: "2024.10.0"
 
 jobs:
   # =============================================================================
   # CHECK THAT BOTH CI WORKFLOWS PASSED FOR THIS COMMIT
+  #
+  # Staging deploy moved into ci-build-e2e.yml (no workflow_run hop needed) —
+  # this workflow now exists solely to gate the manual-approval production
+  # deploy on both CI workflows succeeding for the same commit.
   # =============================================================================
 
   check-prerequisites:
@@ -49,11 +57,11 @@ jobs:
             --json conclusion --jq '.[0].conclusion // "pending"')
           echo "CI Tests status: $TEST_STATUS"
 
-          # Check CI Build & E2E workflow
+          # Check CI Build & Deploy workflow
           BUILD_STATUS=$(gh run list -R ${{ github.repository }} \
             --workflow=ci-build-e2e.yml --branch=main --commit=$SHA \
             --json conclusion --jq '.[0].conclusion // "pending"')
-          echo "CI Build & E2E status: $BUILD_STATUS"
+          echo "CI Build & Deploy status: $BUILD_STATUS"
 
           if [ "$TEST_STATUS" = "success" ] && [ "$BUILD_STATUS" = "success" ]; then
             echo "Both workflows passed - proceeding with deployment"
@@ -64,132 +72,13 @@ jobs:
           fi
 
   # =============================================================================
-  # DEPLOY TO STAGING (no approval needed)
-  # =============================================================================
-
-  deploy-staging:
-    name: "Deploy to Staging"
-    runs-on: ubuntu-latest
-    needs: [check-prerequisites]
-    if: needs.check-prerequisites.outputs.should-deploy == 'true'
-    timeout-minutes: 10
-    environment:
-      name: development
-      url: http://loyalty-dev.saichon.com
-
-    steps:
-      - name: Checkout config files
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.check-prerequisites.outputs.commit-sha }}
-          sparse-checkout: |
-            docker-compose.yml
-            docker-compose.ghcr.yml
-            docker-compose.staging.yml
-            nginx/nginx.conf
-          sparse-checkout-cone-mode: false
-
-      - name: Install cloudflared
-        run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
-            -o /tmp/cloudflared
-          sudo install -m 755 /tmp/cloudflared /usr/local/bin/cloudflared
-          cloudflared --version
-
-      - name: Install SSH key + known_hosts
-        env:
-          SSH_KEY:  ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
-          HOST_KEY: ${{ secrets.EVERGREEN_HOST_KEY }}
-        run: |
-          mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          printf '%s\n' "$SSH_KEY"  > ~/.ssh/deploy_key  && chmod 600 ~/.ssh/deploy_key
-          printf '%s\n' "$HOST_KEY" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
-
-      - name: Deploy via SSH to evergreen
-        env:
-          COMMIT_SHA:           ${{ needs.check-prerequisites.outputs.commit-sha }}
-          GHCR_USER:            ${{ github.actor }}
-          GHCR_TOKEN:           ${{ secrets.GITHUB_TOKEN }}
-          JWT_SECRET:           ${{ secrets.DEV_JWT_SECRET }}
-          JWT_REFRESH_SECRET:   ${{ secrets.DEV_JWT_REFRESH_SECRET }}
-          SESSION_SECRET:       ${{ secrets.DEV_SESSION_SECRET }}
-          GOOGLE_CLIENT_ID:     ${{ secrets.GOOGLE_CLIENT_ID }}
-          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          GOOGLE_CALLBACK_URL:  ${{ vars.GOOGLE_CALLBACK_URL }}
-          LINE_CHANNEL_ID:      ${{ secrets.LINE_CHANNEL_ID }}
-          LINE_CHANNEL_SECRET:  ${{ secrets.LINE_CHANNEL_SECRET }}
-          LINE_CALLBACK_URL:    ${{ vars.LINE_CALLBACK_URL }}
-          FRONTEND_URL:         ${{ vars.FRONTEND_URL }}
-          BACKEND_URL:          ${{ vars.BACKEND_URL }}
-          POSTGRES_USER:        ${{ secrets.POSTGRES_USER }}
-          POSTGRES_PASSWORD:    ${{ secrets.POSTGRES_PASSWORD }}
-          POSTGRES_DB:          ${{ secrets.POSTGRES_DB }}
-        run: |
-          set -euo pipefail
-          tar -czf /tmp/deploy.tar.gz \
-            docker-compose.yml docker-compose.ghcr.yml docker-compose.staging.yml \
-            nginx/nginx.conf
-
-          jq -n \
-            --arg commit_sha           "$COMMIT_SHA" \
-            --arg deploy_payload_b64   "$(base64 -w0 < /tmp/deploy.tar.gz)" \
-            --arg ghcr_user            "$GHCR_USER" \
-            --arg ghcr_token           "$GHCR_TOKEN" \
-            --arg JWT_SECRET           "$JWT_SECRET" \
-            --arg JWT_REFRESH_SECRET   "$JWT_REFRESH_SECRET" \
-            --arg SESSION_SECRET       "$SESSION_SECRET" \
-            --arg GOOGLE_CLIENT_ID     "$GOOGLE_CLIENT_ID" \
-            --arg GOOGLE_CLIENT_SECRET "$GOOGLE_CLIENT_SECRET" \
-            --arg GOOGLE_CALLBACK_URL  "$GOOGLE_CALLBACK_URL" \
-            --arg LINE_CHANNEL_ID      "$LINE_CHANNEL_ID" \
-            --arg LINE_CHANNEL_SECRET  "$LINE_CHANNEL_SECRET" \
-            --arg LINE_CALLBACK_URL    "$LINE_CALLBACK_URL" \
-            --arg FRONTEND_URL         "$FRONTEND_URL" \
-            --arg BACKEND_URL          "$BACKEND_URL" \
-            --arg POSTGRES_USER        "$POSTGRES_USER" \
-            --arg POSTGRES_PASSWORD    "$POSTGRES_PASSWORD" \
-            --arg POSTGRES_DB          "$POSTGRES_DB" \
-            '{
-              commit_sha: $commit_sha,
-              deploy_payload_b64: $deploy_payload_b64,
-              ghcr: { user: $ghcr_user, token: $ghcr_token },
-              env: {
-                RUST_ENV:             "staging",
-                NODE_ENV:             "staging",
-                RUST_LOG:             "info",
-                LOG_LEVEL:            "info",
-                JWT_SECRET:           $JWT_SECRET,
-                JWT_REFRESH_SECRET:   $JWT_REFRESH_SECRET,
-                SESSION_SECRET:       $SESSION_SECRET,
-                POSTGRES_USER:        $POSTGRES_USER,
-                POSTGRES_PASSWORD:    $POSTGRES_PASSWORD,
-                POSTGRES_DB:          $POSTGRES_DB,
-                DATABASE_URL:         ("postgresql://" + $POSTGRES_USER + ":" + $POSTGRES_PASSWORD + "@postgres:5432/" + $POSTGRES_DB),
-                REDIS_URL:            "redis://redis:6379",
-                FRONTEND_URL:         $FRONTEND_URL,
-                BACKEND_URL:          $BACKEND_URL,
-                GOOGLE_CLIENT_ID:     $GOOGLE_CLIENT_ID,
-                GOOGLE_CLIENT_SECRET: $GOOGLE_CLIENT_SECRET,
-                GOOGLE_CALLBACK_URL:  $GOOGLE_CALLBACK_URL,
-                LINE_CHANNEL_ID:      $LINE_CHANNEL_ID,
-                LINE_CHANNEL_SECRET:  $LINE_CHANNEL_SECRET,
-                LINE_CALLBACK_URL:    $LINE_CALLBACK_URL
-              }
-            }' \
-          | ssh -i ~/.ssh/deploy_key \
-              -o StrictHostKeyChecking=yes \
-              -o UserKnownHostsFile=~/.ssh/known_hosts \
-              -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
-              deploy@evergreen.thehfhotel.org
-
-  # =============================================================================
   # DEPLOY TO PRODUCTION (requires approval)
   # =============================================================================
 
   deploy-production:
     name: "Deploy to Production"
     runs-on: ubuntu-latest
-    needs: [check-prerequisites, deploy-staging]
+    needs: [check-prerequisites]
     if: needs.check-prerequisites.outputs.should-deploy == 'true'
     timeout-minutes: 10
     environment:
@@ -208,11 +97,25 @@ jobs:
             nginx/nginx.conf
           sparse-checkout-cone-mode: false
 
-      - name: Install cloudflared
+      - name: Cache cloudflared binary
+        id: cache-cloudflared
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/cloudflared
+          key: cloudflared-${{ runner.os }}-${{ env.CLOUDFLARED_VERSION }}
+
+      - name: Download cloudflared (cache miss)
+        if: steps.cache-cloudflared.outputs.cache-hit != 'true'
         run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
-            -o /tmp/cloudflared
-          sudo install -m 755 /tmp/cloudflared /usr/local/bin/cloudflared
+          mkdir -p ~/.cache/cloudflared
+          curl -fsSL \
+            "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64" \
+            -o ~/.cache/cloudflared/cloudflared
+          chmod +x ~/.cache/cloudflared/cloudflared
+
+      - name: Install cloudflared to /usr/local/bin
+        run: |
+          sudo install -m 755 ~/.cache/cloudflared/cloudflared /usr/local/bin/cloudflared
           cloudflared --version
 
       - name: Install SSH key + known_hosts


### PR DESCRIPTION
## Summary

Cuts merge-to-staging-deploy time from ~9 min to ~5 min by collapsing the
two-pass Rust pipeline into one and removing the `workflow_run` hop that
gates staging today.

### Change 1 - Consolidate Rust into one workflow path with a shared cache

`ci-test.yml::validate-backend` (debug build + tests on ubuntu-latest, native
toolchain) and `ci-build-e2e.yml::build-backend-binary` (release build in
`rust:1.93-bookworm`, different cache prefix) compiled the same crate twice
and couldn't share `target/`. Merged into a single `validate-and-build-backend`
job that runs inside `rust:1.93-bookworm` with `postgres:15-alpine` and
`redis:7-alpine` as services, does unit tests -> migrations -> schema verify
-> `cargo sqlx prepare --check` -> integration tests -> `cargo build --release`
-> upload binary artifact, all sharing one Swatinem/rust-cache workspace.
Inside the container, postgres and redis are addressed by service name
(`postgres:5432`, `redis:6379`) - dropped the `5438:5432` / `6383:6379`
host port mappings. `cargo audit` keeps its `continue-on-error: true` behavior.

### Change 2 - Fail-fast fmt + clippy

New `lint-backend` job: ubuntu-latest, `dtolnay/rust-toolchain@stable` with
1.93 + clippy + rustfmt, separate `Swatinem/rust-cache` prefix (`v0-rust-lint`)
so it doesn't fight the heavy job's cache, timeout 5 min. The heavy
`validate-and-build-backend` is `needs: [lint-backend]`, so a clippy
regression fails CI in ~45s instead of after the full cache warm-up +
integration tests.

### Change 3 - Inline deploy-staging, eliminate workflow_run

Moved `deploy-staging` from `deploy.yml` into `ci-build-e2e.yml`. It
`needs: [build-and-push, e2e-tests, wait-for-frontend-checks]` and only
runs on `github.ref == 'refs/heads/main' && github.event_name == 'push'`.
The new `wait-for-frontend-checks` job polls `gh run list --workflow=ci-test.yml --commit=$SHA`
every 10s for up to ~12 min and fails closed - same pattern that
`check-prerequisites` used. `deploy.yml` keeps `check-prerequisites` +
`deploy-production` only; production stays `workflow_run`-triggered so
the manual approval gate is unchanged. The workflow name listed in
`deploy.yml`'s `workflow_run.workflows` was updated to "CI Build & Deploy"
to match the renamed workflow.

### Change 4 - Cache Playwright browsers

`e2e-tests` now caches `~/.cache/ms-playwright` keyed on the version
resolved from `package-lock.json` (`packages['node_modules/@playwright/test'].version`,
currently `1.59.1`). On cache hit, swap `playwright install --with-deps chromium`
(re-downloads browsers + installs system libs) for `playwright install-deps chromium`
(installs OS deps only). Saves ~30-60s per e2e run when the lockfile is
stable.

### Change 5 - Cache cloudflared

`deploy-production` pins `CLOUDFLARED_VERSION: 2024.10.0` (instead of
`/releases/latest`), downloads to `~/.cache/cloudflared/cloudflared`,
caches that path, and `sudo install`s into `/usr/local/bin`. Saves ~8s
per prod deploy and removes a hidden "what version are we even
shipping?" foot-gun.

## Expected speedup

- Single Rust compile path: ~3 min off the critical path (release build
  no longer recompiles from scratch in a separate environment).
- No `workflow_run` hop for staging: 30-120s off, plus eliminates the
  "skipped and never re-fires" race.
- Playwright cache: ~30-60s when lockfile is unchanged.
- Total expected: merge -> staging-deploy drops from ~9 min to ~5 min.

## Test plan

- [ ] YAML parses cleanly (`python3 -c "import yaml, glob; [yaml.safe_load(open(f)) for f in __import__('glob').glob('.github/workflows/*.yml')]"`) - done locally, all four files parse.
- [ ] On this PR (non-main branch): confirm `Lint Backend (Rust)`,
  `Validate & Build Backend (Rust)`, frontend `Lint Frontend`,
  `Frontend Unit Tests`, `Build & Push to GHCR`, `E2E Tests` all
  pass. `wait-for-frontend-checks` and `deploy-staging` should NOT
  run on the PR because `github.ref != refs/heads/main`.
- [ ] Confirm `cargo sqlx prepare --check` runs cleanly inside the
  new container-based job (service hostnames are `postgres` and `redis`).
- [ ] After merge: verify staging deploy fires from `ci-build-e2e.yml`
  without going through `workflow_run`; verify total merge -> staging
  time drops below 6 min.
- [ ] After merge: confirm `deploy-production` still gates on manual
  approval and pulls cached cloudflared on the second run.

## Trade-offs / concerns

- The `wait-for-frontend-checks` poller fails closed at 12 min. If
  ci-test.yml is genuinely that slow, staging deploy will fail rather
  than hang forever; tune the loop count later if needed.
- Production deploy still uses `workflow_run` because user wants the
  manual approval gate and we're not optimizing past it. The
  `CLOUDFLARED_VERSION` pin (`2024.10.0`) replaces the previous
  `/releases/latest` behavior - intentional, but bump it when we
  want a newer cloudflared.
- Trivy workflow left untouched (parallel agent owns it per task brief).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>