### PR TITLE
fix(migrations): make admin column adds idempotent

### DIFF
--- a/backend-rust/migrations/20260512000000_room_management_columns.sql
+++ b/backend-rust/migrations/20260512000000_room_management_columns.sql
@@ -24,23 +24,32 @@
 -- sort_order: integer, defaults to 0. Used by the list endpoint to give
 --   admins a stable, deterministic ordering they control without renaming
 --   the room types.
+-- IF NOT EXISTS on each ADD COLUMN so re-running this migration after a
+-- partial application (sqlx doesn't wrap migrations in a transaction by
+-- default — a mid-statement failure leaves earlier columns in place)
+-- succeeds without manual cleanup. The check constraint and index are
+-- guarded the same way.
 ALTER TABLE "public"."room_types"
-    ADD COLUMN "bed_type"   VARCHAR(16),
-    ADD COLUMN "amenities"  TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
-    ADD COLUMN "images"     TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
-    ADD COLUMN "sort_order" INTEGER NOT NULL DEFAULT 0;
+    ADD COLUMN IF NOT EXISTS "bed_type"   VARCHAR(16),
+    ADD COLUMN IF NOT EXISTS "amenities"  TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    ADD COLUMN IF NOT EXISTS "images"     TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    ADD COLUMN IF NOT EXISTS "sort_order" INTEGER NOT NULL DEFAULT 0;
 
-ALTER TABLE "public"."room_types"
-    ADD CONSTRAINT "chk_room_types_bed_type"
-    CHECK (bed_type IS NULL OR bed_type IN ('single', 'double', 'twin', 'king'));
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'chk_room_types_bed_type'
+    ) THEN
+        ALTER TABLE "public"."room_types"
+            ADD CONSTRAINT "chk_room_types_bed_type"
+            CHECK (bed_type IS NULL OR bed_type IN ('single', 'double', 'twin', 'king'));
+    END IF;
+END $$;
 
--- The list endpoint orders by sort_order then name. An index on the
--- composite makes that ordering cheap even as the table grows.
 CREATE INDEX IF NOT EXISTS "idx_room_types_sort_order"
     ON "public"."room_types" ("sort_order", LOWER("name"));
 
 -- ----- rooms ------------------------------------------------------------
--- notes: free-form admin notes per room (e.g. "out of service until X").
---   Nullable; frontend renders '-' when missing.
 ALTER TABLE "public"."rooms"
-    ADD COLUMN "notes" TEXT;
+    ADD COLUMN IF NOT EXISTS "notes" TEXT;

--- a/backend-rust/migrations/20260512020000_booking_admin_fields.sql
+++ b/backend-rust/migrations/20260512020000_booking_admin_fields.sql
@@ -39,35 +39,50 @@
 -- audit actions (e.g. 'slip_verified') in a future PR doesn't require
 -- a schema migration.
 --
--- No `IF NOT EXISTS` / DO blocks: this is the first time these columns
--- and the audit table appear in any environment, so a plain `ADD COLUMN`
--- / `CREATE TABLE` is correct and any "already exists" outcome here
--- would indicate a deploy-order bug worth surfacing.
+-- Originally written without idempotency on the assumption that the
+-- migration runs exactly once. In practice, sqlx does not wrap a
+-- migration in a transaction by default, so a partial application
+-- (mid-file failure) leaves earlier statements in place and the next
+-- deploy attempt sees "column already exists" errors. Make the
+-- column adds and table creation idempotent.
 -- =====================================================
 
 -- ----- Add admin-only columns to bookings ------------------------------
 
 ALTER TABLE "public"."bookings"
-    ADD COLUMN "discount_amount" DECIMAL(10, 2),
-    ADD COLUMN "discount_reason" TEXT,
-    ADD COLUMN "admin_notes"     TEXT,
-    ADD COLUMN "payment_type"    VARCHAR(20),
-    ADD COLUMN "payment_amount"  DECIMAL(10, 2);
+    ADD COLUMN IF NOT EXISTS "discount_amount" DECIMAL(10, 2),
+    ADD COLUMN IF NOT EXISTS "discount_reason" TEXT,
+    ADD COLUMN IF NOT EXISTS "admin_notes"     TEXT,
+    ADD COLUMN IF NOT EXISTS "payment_type"    VARCHAR(20),
+    ADD COLUMN IF NOT EXISTS "payment_amount"  DECIMAL(10, 2);
 
--- Constrain payment_type to known values. NULL allowed (legacy rows /
--- bookings that haven't gone through the new payment flow yet).
-ALTER TABLE "public"."bookings"
-    ADD CONSTRAINT "chk_bookings_payment_type"
-    CHECK (payment_type IS NULL OR payment_type IN ('full', 'deposit'));
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'chk_bookings_payment_type'
+    ) THEN
+        ALTER TABLE "public"."bookings"
+            ADD CONSTRAINT "chk_bookings_payment_type"
+            CHECK (payment_type IS NULL OR payment_type IN ('full', 'deposit'));
+    END IF;
+END $$;
 
--- Constrain discount to non-negative. NULL = "no discount applied".
-ALTER TABLE "public"."bookings"
-    ADD CONSTRAINT "chk_bookings_discount_amount_nonneg"
-    CHECK (discount_amount IS NULL OR discount_amount >= 0);
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'chk_bookings_discount_amount_nonneg'
+    ) THEN
+        ALTER TABLE "public"."bookings"
+            ADD CONSTRAINT "chk_bookings_discount_amount_nonneg"
+            CHECK (discount_amount IS NULL OR discount_amount >= 0);
+    END IF;
+END $$;
 
 -- ----- booking_audit_log table -----------------------------------------
 
-CREATE TABLE "public"."booking_audit_log" (
+CREATE TABLE IF NOT EXISTS "public"."booking_audit_log" (
     "id"          UUID                     NOT NULL DEFAULT gen_random_uuid(),
     "booking_id"  UUID                     NOT NULL,
     "admin_id"    UUID                     NOT NULL,
@@ -80,17 +95,33 @@ CREATE TABLE "public"."booking_audit_log" (
     CONSTRAINT "booking_audit_log_pkey" PRIMARY KEY ("id")
 );
 
-ALTER TABLE "public"."booking_audit_log"
-    ADD CONSTRAINT "booking_audit_log_booking_id_fkey"
-    FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id")
-    ON DELETE CASCADE;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'booking_audit_log_booking_id_fkey'
+    ) THEN
+        ALTER TABLE "public"."booking_audit_log"
+            ADD CONSTRAINT "booking_audit_log_booking_id_fkey"
+            FOREIGN KEY ("booking_id") REFERENCES "public"."bookings"("id")
+            ON DELETE CASCADE;
+    END IF;
+END $$;
 
-ALTER TABLE "public"."booking_audit_log"
-    ADD CONSTRAINT "booking_audit_log_admin_id_fkey"
-    FOREIGN KEY ("admin_id") REFERENCES "public"."users"("id");
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'booking_audit_log_admin_id_fkey'
+    ) THEN
+        ALTER TABLE "public"."booking_audit_log"
+            ADD CONSTRAINT "booking_audit_log_admin_id_fkey"
+            FOREIGN KEY ("admin_id") REFERENCES "public"."users"("id");
+    END IF;
+END $$;
 
-CREATE INDEX "idx_booking_audit_log_booking_id"
+CREATE INDEX IF NOT EXISTS "idx_booking_audit_log_booking_id"
     ON "public"."booking_audit_log" ("booking_id");
 
-CREATE INDEX "idx_booking_audit_log_occurred_at"
+CREATE INDEX IF NOT EXISTS "idx_booking_audit_log_occurred_at"
     ON "public"."booking_audit_log" ("occurred_at" DESC);


### PR DESCRIPTION
## Summary
- Guards every ADD COLUMN in `20260512000000_room_management_columns.sql` and `20260512020000_booking_admin_fields.sql` with `IF NOT EXISTS`.
- Wraps each CHECK constraint and FK addition in a `DO` block that checks `pg_constraint`.
- Switches `CREATE INDEX` / `CREATE TABLE` to `IF NOT EXISTS`.

## Why
The CI Build & Deploy run for SHA `ceee9807` on main failed at the staging deploy step with `Failed to run database migrations`. Staging had #217's + #218's migrations partially applied from #218's earlier failed deploy attempt (the one silently dropped by the old `workflow_run` race). sqlx-migrate doesn't wrap each migration file in a transaction by default, so partial state survives a mid-file failure but the migration tracker still says "pending" — leading to "column already exists" on retry.

Making the migrations idempotent unblocks the staging server and protects future deploys from the same partial-application failure mode.

## Test plan
- [ ] CI green: fmt/clippy + integration tests still apply both migrations cleanly to a fresh DB.
- [ ] Once merged, the next deploy to staging should pass the migration step (whether staging is in clean state, partial state, or fully-applied state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)