### PR TITLE
perf(ci): use mold linker + disable incremental compilation

### DIFF
--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -30,6 +30,15 @@ env:
   IMAGE_REPO: loyalty-app
   SCCACHE_GHA_ENABLED: "true"
   RUSTC_WRAPPER: "sccache"
+  # Disable incremental compilation in CI. Every build starts from a
+  # Swatinem/rust-cache restore, so incremental data adds cache bloat
+  # without providing any speedup, and it interferes with sccache's
+  # ability to cache rustc invocations. This matches the explicit
+  # recommendation in mozilla-actions/sccache-action's README.
+  # (Swatinem/rust-cache also sets this internally; declaring it at the
+  # workflow level makes the intent visible to lint-backend and any
+  # future Rust jobs that don't go through rust-cache.)
+  CARGO_INCREMENTAL: "0"
 
 jobs:
   # =============================================================================
@@ -44,6 +53,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Install mold linker
+        # backend-rust/.cargo/config.toml selects `linker = "clang"` +
+        # `-fuse-ld=mold` for x86_64-unknown-linux-gnu. clang is already
+        # on ubuntu-latest; mold is not, so install it here. Without
+        # this, clippy --all-targets fails to link the test/bin targets.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends mold
+          mold --version
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -137,7 +156,13 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends \
-            pkg-config libssl-dev libpq-dev postgresql-client
+            pkg-config libssl-dev libpq-dev postgresql-client \
+            mold clang
+          # The .cargo/config.toml stanza for x86_64-unknown-linux-gnu
+          # wires `linker = "clang"` + `-fuse-ld=mold`; both binaries
+          # must be on PATH before cargo invokes rustc.
+          mold --version
+          clang --version | head -n1
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -281,7 +306,13 @@ jobs:
       - name: Install system dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends \
-            pkg-config libssl-dev libpq-dev
+            pkg-config libssl-dev libpq-dev \
+            mold clang
+          # The .cargo/config.toml stanza for x86_64-unknown-linux-gnu
+          # wires `linker = "clang"` + `-fuse-ld=mold`; both binaries
+          # must be on PATH before cargo invokes rustc.
+          mold --version
+          clang --version | head -n1
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -298,7 +329,11 @@ jobs:
 
       - name: Build release binary
         working-directory: ./backend-rust
-        run: cargo build --release --bin loyalty-backend
+        # `-v` so the log captures the rustc invocations that include
+        # `-C link-arg=-fuse-ld=mold`, confirming mold is actually
+        # selected at link time rather than silently falling back to
+        # the default linker.
+        run: cargo build --release --bin loyalty-backend -v
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -54,15 +54,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install mold linker
+      - name: Install mold linker + clang
         # backend-rust/.cargo/config.toml selects `linker = "clang"` +
-        # `-fuse-ld=mold` for x86_64-unknown-linux-gnu. clang is already
-        # on ubuntu-latest; mold is not, so install it here. Without
-        # this, clippy --all-targets fails to link the test/bin targets.
+        # `-fuse-ld=mold` for x86_64-unknown-linux-gnu. clang is *not*
+        # on ubuntu-latest by default (only versioned `clang-N`
+        # packages), so install both binaries explicitly. Without clang
+        # on PATH the rustc linker invocation wedges past the 5-min
+        # job timeout during `cargo clippy --all-targets`.
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends mold
+          sudo apt-get install -y --no-install-recommends mold clang
           mold --version
+          clang --version | head -n1
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable

--- a/backend-rust/.cargo/config.toml
+++ b/backend-rust/.cargo/config.toml
@@ -31,9 +31,18 @@ panic = "abort"
 opt-level = 2
 
 [target.x86_64-unknown-linux-gnu]
-# Note: target-cpu=native was removed because it causes SIGILL in CI
-# when sccache serves cached objects compiled with different CPU features.
-# For local performance, run: RUSTFLAGS="-C target-cpu=native" cargo build
+# Use the mold linker (https://github.com/rui314/mold) for substantially
+# faster linking on Linux x86_64. CI installs mold + clang in the
+# rust:1.93-bookworm container before invoking cargo; local Linux dev
+# machines benefit too if mold is on PATH. macOS dev is untouched because
+# this stanza only applies to the linux-gnu target.
+#
+# Note: target-cpu=native is intentionally NOT set here because it causes
+# SIGILL in CI when sccache serves cached objects compiled with different
+# CPU features. For local performance, run:
+#   RUSTFLAGS="-C target-cpu=native" cargo build
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
 [target.x86_64-unknown-linux-musl]
 # MUSL target for static binaries (Alpine Linux)

--- a/backend-rust/Dockerfile
+++ b/backend-rust/Dockerfile
@@ -3,10 +3,17 @@
 # ==============================================================================
 FROM rust:1.95-trixie AS chef
 
+# mold + clang are required because backend-rust/.cargo/config.toml
+# selects `linker = "clang"` + `-fuse-ld=mold` for
+# x86_64-unknown-linux-gnu. Without them, `cargo build` fails to spawn
+# the linker. They're cheap to install and substantially speed up the
+# final link step.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libssl-dev \
     libpq-dev \
+    mold \
+    clang \
     && rm -rf /var/lib/apt/lists/* \
     && cargo install cargo-chef --locked
 
@@ -47,11 +54,17 @@ RUN cargo build --release --bin loyalty-backend --bin healthcheck
 # ==============================================================================
 FROM rust:1.95-trixie AS development
 
+# mold + clang match the linker config in .cargo/config.toml. The
+# development stage runs cargo-watch against the bind-mounted source,
+# so cargo will follow the same x86_64-unknown-linux-gnu linker stanza
+# the builder uses.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     libssl-dev \
     libpq-dev \
     ca-certificates \
+    mold \
+    clang \
     && rm -rf /var/lib/apt/lists/* \
     && cargo install cargo-watch --locked
 


### PR DESCRIPTION
## Summary

Spike on backend Rust CI build-time savings via two surgical, runtime-neutral changes (no `Cargo.toml` deps, no `src/` changes, no runtime profile changes):

1. **mold linker** on `x86_64-unknown-linux-gnu` via `backend-rust/.cargo/config.toml`. Both heavy jobs (`test-backend`, `build-backend-release`) `apt-install mold clang` in their existing system-deps step. `lint-backend` gets a small dedicated install (clang is already on `ubuntu-latest`). The non-CI `backend-rust/Dockerfile` (used by `docker compose up -d` and the dev hot-reload stage) gets the same install so local builds don't break.
2. **`CARGO_INCREMENTAL: "0"`** at the workflow `env:` level. `Swatinem/rust-cache` already sets this internally; declaring it at the workflow level documents intent and ensures `lint-backend` and any future Rust jobs honor it per `mozilla-actions/sccache-action`'s README.

Linker config is scoped to `x86_64-unknown-linux-gnu` so **macOS local dev is untouched**.

## Baseline (warm cache, from PR #223's CI run on `main`, run 25748034651)

| Job                      | Time   |
| ------------------------ | ------ |
| Test Backend (Rust)      | 3m16s  |
| Build Backend Release    | 3m15s  |

Baseline sccache stats:
- Build job: 5 compile requests, 0 hits / 1 miss (the only cacheable rustc invocation was the final binary link)
- Test job: 17 compile requests, 1 hit / 2 misses (33% rate)

Both jobs were dominated by Swatinem's full-cache restore + the final-link step, which is exactly what mold targets.

## After (this PR)

_Placeholder — will be filled in once this PR's `CI Build & Deploy` run completes._

| Job                      | Before | After | Delta |
| ------------------------ | ------ | ----- | ----- |
| Test Backend (Rust)      | 3m16s  | TBD   | TBD   |
| Build Backend Release    | 3m15s  | TBD   | TBD   |

### Caveat about the first PR run

`-C link-arg=-fuse-ld=mold` is part of cargo's fingerprint, so the first PR run necessarily invalidates every fingerprint in the restored `target/` and rebuilds. The relevant comparison is the **second** run (re-run or a follow-up push), where the Swatinem cache contains a mold-linked `target/`. Both numbers will be reported below.

### Verification that mold is actually used

`Build Backend Release` runs `cargo build --release --bin loyalty-backend -v`. The verbose rustc invocation in the log should include `-C link-arg=-fuse-ld=mold`. Each apt step also prints `mold --version` and `clang --version` before cargo runs.

### sccache stats after the change

_Placeholder — copied from workflow logs after the run._

## Recommendation

_Filled in once we have numbers. Per the spike brief: if combined savings are <30s, close this PR rather than merge._

## Test plan

- [ ] `CI Build & Deploy` completes successfully (all jobs green)
- [ ] `mold --version` and `clang --version` appear in the Install system dependencies step of both heavy jobs
- [ ] `cargo build --release ... -v` log shows `-fuse-ld=mold` on a rustc invocation
- [ ] sccache hit rate is not catastrophically worse than baseline
- [ ] `Test Backend (Rust)` + `Build Backend Release` combined wall-time improves by >=30s, OR this PR is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)