### PR TITLE
perf(ci): e2e parallel with deploy, post-deploy healthcheck

### DIFF
--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -117,7 +117,19 @@ jobs:
           # would surface as link-time / runtime ABI failures.
           prefix-key: "v0-rust-unit"
 
+      - name: Cache cargo-nextest
+        id: cache-nextest
+        uses: actions/cache@v5
+        with:
+          # `taiki-e/install-action@nextest` installs a single binary;
+          # `cargo nextest ...` is dispatched through `cargo-nextest`.
+          # On bare ubuntu, dtolnay/rust-toolchain installs cargo under
+          # ~/.cargo, so cargo-installed binaries land there too.
+          path: ~/.cargo/bin/cargo-nextest
+          key: cargo-nextest-${{ env.RUST_VERSION }}-${{ runner.os }}-native
+
       - name: Install cargo-nextest
+        if: steps.cache-nextest.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@nextest
 
       - name: Run unit tests
@@ -189,7 +201,20 @@ jobs:
           cache-on-failure: true
           prefix-key: "v0-rust-container"
 
+      - name: Cache cargo-nextest
+        id: cache-nextest
+        uses: actions/cache@v5
+        with:
+          # In the rust:1.93-bookworm container, cargo lives at
+          # /usr/local/cargo, so cargo-installed binaries land in
+          # /usr/local/cargo/bin. Distinct key from the unit-job cache
+          # because the container glibc (2.36) differs from native
+          # ubuntu (2.39) and the binary is glibc-linked.
+          path: /usr/local/cargo/bin/cargo-nextest
+          key: cargo-nextest-${{ env.RUST_VERSION }}-${{ runner.os }}-container
+
       - name: Install cargo-nextest
+        if: steps.cache-nextest.outputs.cache-hit != 'true'
         uses: taiki-e/install-action@nextest
 
       - name: Grant CREATEDB for per-test database isolation
@@ -701,12 +726,19 @@ jobs:
   # instead of going through a workflow_run hop that adds 30-120s of latency
   # and can race itself into "skipped" purgatory when two upstream workflows
   # finish in the wrong order.
+  #
+  # E2E intentionally NOT in `needs:` — every PR runs full E2E before merge
+  # (the meaningful gate), production deploys require manual human approval,
+  # and `verify-staging` below catches deploy-itself-broken cases. On main,
+  # E2E still runs in parallel: a red E2E fails the overall workflow status
+  # and surfaces in the GitHub Environments panel before a human approves
+  # prod.
   # =============================================================================
 
   deploy-staging:
     name: "Deploy to Staging"
     runs-on: ubuntu-latest
-    needs: [test-backend-unit, test-backend-integration, build-and-push, e2e-tests, wait-for-frontend-checks]
+    needs: [test-backend-unit, test-backend-integration, build-and-push, wait-for-frontend-checks]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     timeout-minutes: 10
     environment:
@@ -816,3 +848,35 @@ jobs:
               -o UserKnownHostsFile=~/.ssh/known_hosts \
               -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
               deploy@evergreen.thehfhotel.org
+
+  # =============================================================================
+  # VERIFY STAGING HEALTH
+  #
+  # Catches deploy-itself-broken cases (image won't start, migration crashes
+  # at runtime, env var missing) that pre-merge tests can't see. Polls the
+  # staging /api/health endpoint until it returns HTTP 200 or 90s elapses.
+  # The matching environment URL is set on `deploy-staging` above.
+  # =============================================================================
+
+  verify-staging:
+    name: "Verify Staging"
+    runs-on: ubuntu-latest
+    needs: [deploy-staging]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    timeout-minutes: 5
+
+    steps:
+      - name: Poll staging /api/health
+        env:
+          STAGING_HEALTH_URL: http://loyalty-dev.saichon.com/api/health
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 30); do
+            if curl -fsS --max-time 5 "$STAGING_HEALTH_URL" >/dev/null; then
+              echo "Staging healthy after ${attempt} attempts"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::Staging /api/health not responding after 90s"
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,8 +112,15 @@ Three workflows fire on push to `main`:
 - `ci-test.yml` — frontend lint + frontend unit tests (Prepare Workspace
   + Lint Frontend + Frontend Unit Tests).
 - `ci-build-e2e.yml` — Lint Backend (Rust) → parallel
-  Test Backend / Build Backend Release → Build & Push to GHCR → E2E
-  Tests → Deploy to Staging (inline, on push to `main` only).
+  (Test Backend Unit, Test Backend Integration, Build Backend Release) →
+  Build & Push to GHCR → Deploy to Staging (inline, on push to `main`
+  only) → Verify Staging health check. **E2E Tests run in parallel with
+  Deploy to Staging**, not as a gate: every PR runs full E2E before
+  merge (which is the meaningful gate), production deploys require
+  manual human approval, and the staging health-check catches
+  deploy-itself-broken cases. A red E2E on `main` still fails the
+  workflow and surfaces in the GitHub Environments panel before a human
+  approves prod.
 - `trivy.yml` — Filesystem scan on push; backend/frontend image scans
   triggered by `workflow_run` from `ci-build-e2e.yml` (pulls images from
   GHCR instead of rebuilding).


### PR DESCRIPTION
## Summary

Move E2E off the staging-deploy critical path and add a post-deploy health check.

- `e2e-tests` is removed from `deploy-staging`'s `needs:`. The job keeps running on every push to `main` against its own ephemeral containers + service postgres/redis (unchanged) and still contributes to the overall workflow status — it just no longer blocks deploy. The meaningful E2E gate is the per-PR run before merge; production deploys then go through manual approval on the `production` GitHub environment.
- New `verify-staging` job runs after `deploy-staging` on push-to-main, polling `http://loyalty-dev.saichon.com/api/health` (matches `deploy-staging`'s `environment.url`) every 3s for up to 90s. Catches deploy-itself-broken cases (image won't start, migration crashes at runtime, env var missing) that pre-merge tests can't see.
- `cargo-nextest` is now cached on both `test-backend-unit` and `test-backend-integration` (analogous to the existing `sqlx-cli` cache). Distinct keys per host: `~/.cargo/bin/cargo-nextest` for the native-ubuntu unit job, `/usr/local/cargo/bin/cargo-nextest` for the `rust:1.93-bookworm` integration job, because the binary is glibc-linked and the two hosts ship different glibcs.
- `CLAUDE.md` updated to describe the new model (one paragraph rewrite in the CI/CD bullet).

## Critical-path math

Warm-cache baseline on `main`:

| Stage | Before | After |
| --- | --- | --- |
| Lint Backend | 57s | 57s |
| max(Test Unit, Test Integration, Build Release) | 2m09s | 2m09s |
| Build & Push GHCR | 22s | 22s |
| **E2E Tests (was on critical path)** | **2m05s** | **off critical path** |
| Deploy to Staging | ~30s | ~30s |
| Verify Staging (new) | — | ~5-15s |
| **End-to-end push -> staging-live** | **~6m01s** | **~3m56s + ~5-15s healthcheck** |

E2E continues running in parallel with deploy on push-to-main; if E2E is the longer tail, total wall-clock is unchanged but the deploy itself is no longer blocked, and a red E2E still fails the overall workflow conclusion before the production environment is offered for manual approval.

## E2E behavior matrix

| Trigger | E2E gates merge? | E2E gates deploy? |
| --- | --- | --- |
| Pull request | Yes — workflow conclusion blocks merge | N/A (no deploy on PR) |
| Push to `main` | N/A (already merged) | No — runs in parallel with deploy; red E2E still red workflow |

The pre-merge gate is the meaningful one; the staging health check covers what E2E can't (the actual deploy succeeding).

## Cache touches

`cargo-nextest` cache (new):
- `cargo-nextest-1.93-Linux-native` (unit job)
- `cargo-nextest-1.93-Linux-container` (integration job)

This PR's first run pays one cold-cache cost on `verify-staging` (~5s job spin-up) and on both `cargo-nextest` caches (a few seconds each). Subsequent runs are warm.

## CLAUDE.md diff

\`\`\`diff
- \`ci-build-e2e.yml\` — Lint Backend (Rust) → parallel
-   Test Backend / Build Backend Release → Build & Push to GHCR → E2E
-   Tests → Deploy to Staging (inline, on push to \`main\` only).
+ \`ci-build-e2e.yml\` — Lint Backend (Rust) → parallel
+   (Test Backend Unit, Test Backend Integration, Build Backend Release) →
+   Build & Push to GHCR → Deploy to Staging (inline, on push to \`main\`
+   only) → Verify Staging health check. **E2E Tests run in parallel with
+   Deploy to Staging**, not as a gate: every PR runs full E2E before
+   merge (which is the meaningful gate), production deploys require
+   manual human approval, and the staging health-check catches
+   deploy-itself-broken cases. A red E2E on \`main\` still fails the
+   workflow and surfaces in the GitHub Environments panel before a human
+   approves prod.
\`\`\`

## Test plan

- [ ] PR's own CI run passes (PR triggers run full E2E as a workflow gate; deploy-staging and verify-staging are skipped on PR per their `if:` conditions).
- [ ] After merge, observe the first push-to-main run: E2E and deploy-staging start in parallel from `build-and-push` / `wait-for-frontend-checks`; verify-staging fires after deploy-staging completes.
- [ ] Measure end-to-end push -> staging-live on the post-merge run; compare against the 6m01s baseline.
- [ ] Confirm `verify-staging` returns green against the live `/api/health` endpoint.

## Out of scope

- Migrating E2E to run against the real staging deployment (different URL, requires staging-side test users).
- Touching `deploy.yml` (production deploy) — already has manual approval as the user-facing gate.
- Caching the `rust:1.93-bookworm` container image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)