### PR TITLE
docs(audit): security audit 2026-05-13

### DIFF
--- a/docs/audits/security-2026-05-13.md
+++ b/docs/audits/security-2026-05-13.md
@@ -1,0 +1,164 @@
+# Security audit — 2026-05-13
+
+## Summary
+
+- **14 findings**: 0 critical, 4 high, 6 medium, 4 low.
+- **Overall posture**: solid for a pre-public-launch codebase. Phase 3 cookie-only refresh (HttpOnly + Secure + SameSite=Strict + path-scoped) is correct, JWT secret validation refuses-to-boot on weak/placeholder values in production, `DATABASE_URL` is also guarded, all admin handlers gate via `require_admin(&user)` *inside the handler* (not just middleware), and the new admin routes use compile-time `sqlx::query!` / `sqlx::query_as!` macros so SQL injection is mechanically prevented on the booking/slip/room/email paths. nginx ships proper security headers (X-Content-Type-Options, X-Frame-Options, HSTS, CSP, Referrer-Policy). OAuth state is per-request, Redis-backed, TTL'd, validated, and deleted after use. Public-repo scrub looks complete — no real credentials, customer data, or live secrets in tracked files.
+- **Top 3 to fix before public launch**:
+  1. **HIGH-1** — `admin.rs::update_user` / `update_user_role` lets any `admin` promote any user to `super_admin` (or demote another super_admin). Lateral-privilege path that bypasses the otherwise-enforced super_admin gate on `delete_user`.
+  2. **HIGH-2** — Rate limiter blindly trusts `X-Forwarded-For`/`X-Real-IP` from the client; an attacker can rotate these headers to bypass per-IP throttling on `/api/auth/*` (5/min) and the global limiter, defeating the most important production defense against credential stuffing.
+  3. **HIGH-3** — `cargo audit` is red as of today (RUSTSEC-2023-0071 against `rsa` 0.9.10, pulled in by `jsonwebtoken` 10). HS256 is what we use, so this isn't directly exploitable, but the audit is now blocking and there is no `audit.toml` allowlist documenting the call. Either pin/patch or add an explicit `[advisories.ignore]` entry with a rationale.
+
+## Findings
+
+### HIGH — Admin can self-elevate other users to super_admin
+- **Where**: `backend-rust/src/routes/admin.rs:459-566` (`update_user`), `:1009-1036` (`update_user_role`).
+- **What**: Both handlers guard with `require_admin(&user)` and then accept any `UserRole` in the payload, including `UserRole::SuperAdmin`. The only protection (lines 478-486) prevents the caller from demoting *themselves* to customer; nothing prevents an admin from setting another user's role to `super_admin` or demoting an existing super_admin.
+- **Impact**: Any compromised or rogue admin account becomes a super_admin via a single `PUT /api/admin/users/:id` or `PATCH /api/admin/users/:id/role`. Super_admin gates (`delete_user`) are then bypassable by self-promoting first. With ~25 admin endpoints landing this week, the blast radius of one compromised admin grew significantly.
+- **Fix**: In both handlers, require `require_super_admin` when `payload.role == UserRole::SuperAdmin` or when the target user is currently a super_admin. Add a unit test for "admin cannot promote to super_admin" and "admin cannot demote a super_admin".
+- **Effort**: small.
+
+### HIGH — Rate limiter trusts spoofable `X-Forwarded-For` / `X-Real-IP`
+- **Where**: `backend-rust/src/middleware/rate_limit.rs:166-195` (`get_client_ip`).
+- **What**: `get_client_ip` reads `X-Forwarded-For` first, then `X-Real-IP`, with no validation that the request actually came through nginx/Cloudflare. Any direct client can set those headers to arbitrary values and rotate them per request, getting a new bucket each time. Fall-through is hardcoded `127.0.0.1`, which would funnel every direct request into a single bucket — but that path only triggers if the proxy strips the headers.
+- **Impact**: Production runs behind Cloudflare → nginx → backend, so external traffic always carries forwarded headers — but those headers are populated from whatever the *client* sent unless cloudflare/nginx overwrite (cloudflare does append, nginx's `proxy_add_x_forwarded_for` *appends* rather than replaces). An attacker can include `X-Forwarded-For: 1.1.1.1,2.2.2.2,…` and the limiter will pick the leftmost (attacker-controlled) value. Result: the strict 5/min auth limit and global 100/min limit are both trivially bypassable, opening credential-stuffing and brute-force resets at scale on the public-launch endpoints.
+- **Fix**: Either (a) take only the *rightmost* trusted hop from `X-Forwarded-For` (nginx appends, so the rightmost is what nginx saw as `$remote_addr`), or (b) prefer `axum::extract::ConnectInfo<SocketAddr>` and ignore client-supplied headers entirely since nginx is the only legitimate proxy in the chain. Also set `proxy_set_header X-Forwarded-For $remote_addr;` (not `$proxy_add_x_forwarded_for`) in `nginx/nginx.conf:111` so nginx replaces rather than appends.
+- **Effort**: small.
+
+### HIGH — `cargo audit` is currently red (RUSTSEC-2023-0071 via jsonwebtoken→rsa)
+- **Where**: `backend-rust/Cargo.lock` (rsa 0.9.10), pulled by `jsonwebtoken 10.3.0` and (compile-time only) by `sqlx-mysql` through proc-macros.
+- **What**: The latest scheduled `cargo-audit` run failed (run id 25796241240, 2026-05-13 11:28 UTC) on RUSTSEC-2023-0071 — Marvin timing sidechannel in RSA. There is no fixed upgrade available upstream, and the project has no `audit.toml` allowlist documenting the call. CI's daily audit is now a permanent red.
+- **Impact**: Live exploitability is low — the codebase uses HS256 only (`backend-rust/src/middleware/auth.rs:211`, `backend-rust/src/routes/sse.rs:206`) and never calls RSA paths inside `jsonwebtoken`; sqlx-mysql is a compile-time-only proc-macro path, not runtime. But: (1) a future PR that adds an RS256 alg silently inherits the vuln; (2) a red audit drowns out any future *real* alert; (3) reviewers / launch checklists that grep "cargo audit clean" will fail and either bypass the check or stall.
+- **Fix**: Add `backend-rust/audit.toml` with `[advisories]\nignore = ["RUSTSEC-2023-0071"]` plus a comment explaining "HS256 only, RSA code path unused; revisit when jsonwebtoken upstream rotates to a fixed RSA". Re-evaluate when `jsonwebtoken` releases a version that drops `rsa` as a transitive (or pins a fixed one). Optionally also flip `sqlx`'s default features off to drop the mysql path — purely cosmetic but quiets the tree.
+- **Effort**: small (15 minutes including writing the rationale).
+
+### HIGH — Admin email test endpoint is a free open relay to arbitrary recipients
+- **Where**: `backend-rust/src/routes/admin_email.rs:232-339` (`send_test_email`).
+- **What**: `POST /api/admin/email/test` accepts an optional `to` field (validated as a well-formed email) and sends a real email through the configured SMTP relay. The intent (per the module doc) is "default to the admin's own email", but if the body includes any valid `to`, that wins. A compromised admin token, an internal threat, or a misconfigured frontend can use this as a free SMTP relay through the production mail account — burning sender reputation, blowing the relay's daily quota, or sending phishing under the hotel's domain.
+- **Impact**: Reputation damage and credential-burn for the production SMTP relay; legal exposure if used to send abusive content from a customer-facing domain.
+- **Fix**: Either drop the `to` field entirely and always send to `user.email` (the comment says this is already the intent), or restrict `to` to an allowlist of internal domains (e.g. starts with `@thehfhotel.com`). Apply a per-admin daily quota in Redis ("sent_test_emails:{admin_id}" with a small TTL'd counter). Log every send with the resolved recipient at info level (already done — keep it).
+- **Effort**: small.
+
+### MEDIUM — Slip URL accepted as free-form string with no ownership check
+- **Where**: `backend-rust/src/routes/bookings.rs:498-550` (`add_booking_slip`), `:105-112` (`AddSlipRequest`).
+- **What**: The handler accepts any `slipUrl` string up to 1024 chars and attaches it to the booking after an ownership check on the booking itself — but does not verify the URL points to a slip the caller actually uploaded, that the URL exists, or that it lives under `/storage/slips/`. A user can pick any storage URL (or any URL at all), associate it with their own booking, and have it surface in the admin booking detail UI.
+- **Impact**: (a) phishing/social-engineering against admins — a malicious customer attaches `https://attacker.com/fake-paid-slip.png` and an admin clicks through to a credential-harvest page; (b) confusion / fake "paid" status if an admin verifies a slip whose image was hosted off-platform. The signal sent through SlipOK validation is decoupled (the `slipok_status` is null until the SlipOK integration runs), so a forged URL never auto-verifies — but a tired ops person manually clicking "verify" could be tricked.
+- **Fix**: Reject `slipUrl` values that don't start with `/storage/slips/`. Optionally also verify the file exists on disk before inserting the row. Treat anything else as `400 Bad Request`.
+- **Effort**: small.
+
+### MEDIUM — `delete_user` only deactivates; super_admin bypass still works in practice
+- **Where**: `backend-rust/src/routes/admin.rs:568-607`.
+- **What**: The handler is gated by `require_super_admin` (correct), but it never actually deletes — it only sets `is_active = false`. There is no separate "permanently delete" code path; the docstring on `super_admin only for hard delete` is misleading. Combined with **HIGH-1** above, the only protection against unwanted deactivations is the same protection that's already breakable: any admin can promote themselves to super_admin first.
+- **Impact**: A compromised or rogue admin can deactivate any user (locking them out, removing their loyalty points UI access) without going through super_admin — by first promoting themselves.
+- **Fix**: Once HIGH-1 is fixed, this becomes a non-issue. Independently, consider also enforcing "super_admin cannot deactivate another super_admin" so the role hierarchy is symmetric, and clarify the docstring (no hard delete is currently implemented).
+- **Effort**: small (mostly doc + one extra check).
+
+### MEDIUM — `multipart` slip upload reads full body before size check
+- **Where**: `backend-rust/src/routes/slips.rs:128-153`.
+- **What**: `field.bytes().await` reads the entire multipart field into memory before the `data.len() > config.max_slip_file_size` check on line 151. The global `DefaultBodyLimit::max(16 MiB)` in `main.rs:239` caps total request size, but a 16 MiB malicious multipart can still pass through the handler-local 10 MiB check after already buffering 16 MiB into RAM per concurrent upload. With public users about to land, N concurrent attackers each pinning 16 MiB on the slip endpoint can pressure backend memory.
+- **Impact**: Memory pressure / DoS path on a publicly authenticated endpoint. Not a confidentiality issue — just a cost-driver.
+- **Fix**: Stream the field with `field.chunk().await` and bail as soon as the cumulative byte count exceeds `max_slip_file_size`. Or set a per-field body limit (axum 0.7 supports `DefaultBodyLimit::max` at the handler level — apply `Router::new().route(...).layer(DefaultBodyLimit::max(10 * 1024 * 1024))` on the slip-upload route).
+- **Effort**: small.
+
+### MEDIUM — Slip MIME type comes from client-supplied header only; no magic-byte check
+- **Where**: `backend-rust/src/routes/slips.rs:126`, `backend-rust/src/services/storage.rs:115-148`.
+- **What**: The handler trusts the multipart field's `content_type` (which the client controls) and the filename extension it derives. There's no inspection of the file's actual magic bytes (FF D8 FF for JPEG, 89 50 4E 47 for PNG). An attacker can upload an HTML file labelled `image/jpeg`; the file lands at `/storage/slips/<uuid>.jpg` and is served back with `Content-Type: image/jpeg` (`storage.rs:331`).
+- **Impact**: Direct XSS is mitigated because `X-Content-Type-Options: nosniff` is set in `nginx.conf:41` AND the served Content-Type is image/jpeg — modern browsers refuse to script-execute. The remaining risk is: (a) phishing kits / HTML smuggling — the URL is a public asset accessible to anyone with the link; (b) future regression if `nosniff` is ever weakened, the polyglot becomes executable.
+- **Fix**: Validate the first few bytes match the claimed MIME (use the `infer` crate or check magic bytes by hand for jpeg/png — three signatures). Reject anything that doesn't match, even if the multipart says `image/jpeg`. Optional but cheap.
+- **Effort**: small.
+
+### MEDIUM — `admin.rs::list_users` builds dynamic ORDER BY via `format!()`
+- **Where**: `backend-rust/src/routes/admin.rs:299-364`.
+- **What**: `sort_by` and `sort_order` are interpolated into a SQL string via `format!("ORDER BY {} {} NULLS LAST", sort_by, sort_order)`. **Both values are allowlisted just above** (lines 299-306: `match query.sort_by.as_str() { "email" | "created_at" | "role" | "is_active" => …, _ => "created_at" }`), so this is currently safe — but the pattern is exactly the type that drifts under maintenance. The same file has `broadcast_notification` (line 935-945) building a dynamic `WHERE` from string fragments, with all values bound via `.bind(…)` — also currently safe, also fragile.
+- **Impact**: No exploit today. If a future commit adds a new sort column without extending the allowlist, or refactors and forgets the match arm, the codebase has an immediate SQL injection on an admin endpoint. CI's `sqlx prepare --check` doesn't help because these aren't compile-time queries.
+- **Fix**: Move the sort column to a typed enum (`SortBy { CreatedAt, Email, Role, IsActive }`) with `Deserialize` and a single `to_sql_column()` mapping. Reject the request with 400 on unknown values, instead of silently falling back. This collapses the surface to a typed-only path and makes the next reviewer's life cheaper. Same approach for `broadcast_notification`'s dynamic WHERE.
+- **Effort**: medium (touches ~80 lines, but mechanical).
+
+### MEDIUM — Storage files (avatars, slips) are publicly served with no authorization check
+- **Where**: `backend-rust/src/routes/storage.rs:263-289` (`serve_file`, `serve_avatar`, `serve_slip`).
+- **What**: `GET /api/storage/slips/:filename` is a plain public read. The filename is a UUID v4 (unguessable in practice — 122 bits of entropy), but anyone with the URL can fetch the slip indefinitely (no expiry, no signed URL, `Cache-Control: public, max-age=31536000` — one year). Slip URLs are stored in `booking_slips.slip_url` and surfaced through `/api/admin/bookings/:id` — anyone who phishes one admin can persist access to every slip whose URL they captured.
+- **Impact**: Slips contain banking info (account number, name, amount, transaction ID). PDPA scope. The UUID-as-secret model only works as long as no slip URL leaks via logs, referrer headers, browser history, error pages, or the admin's screen share. Defense-in-depth would tie slip access to an authenticated session.
+- **Fix**: Require `auth_middleware` on `GET /api/storage/slips/:filename` and enforce "user owns this slip's booking OR caller is admin" inside the handler. Avatars are less sensitive — leaving those public is reasonable.
+- **Effort**: medium (need to look up the slip→booking→user chain on each fetch; can cache).
+
+### MEDIUM — `admin_slips` does not write to `booking_audit_log`
+- **Where**: `backend-rust/src/routes/admin_slips.rs:152-274`.
+- **What**: Verify and needs-action mutations stamp `admin_verified_by`/`admin_verified_at` on the slip row but do **not** insert a parallel entry in `booking_audit_log`. The module doc acknowledges this ("the slip row itself is the audit trail"), but compared to the carefully transactional audit logging in `admin_bookings.rs` (every PUT/discount/cancel writes a row inside the same transaction), slip moderation has weaker forensics. An admin can verify a slip that turns out to be fraudulent; the only trail is the *latest* admin_verified_by — re-verifying overwrites it.
+- **Impact**: Compliance/forensics gap. Not exploitable on its own, but reduces the ability to reconstruct who verified what and when after a chargeback or dispute.
+- **Fix**: Insert a row into `booking_audit_log` (action `slip_verified` / `slip_needs_action`) inside the same transaction as the slip update. Reference the existing helper `admin_bookings::insert_audit_row`.
+- **Effort**: small.
+
+### LOW — OAuth state's `ip` field is hard-coded to `"unknown"`
+- **Where**: `backend-rust/src/routes/oauth.rs:441-459` and `:916-935` (in both Google and LINE init).
+- **What**: The OAuth state record stores `ip: "unknown".to_string()` rather than reading `$remote_addr` / `X-Forwarded-For`. This means the state object can never be cross-checked against the originating IP on callback — but the callback never does that check anyway. Whether IP binding is desirable for OAuth state is debatable (mobile users roam between networks mid-flow), so the field being a placeholder is consistent with the actual behaviour. The state-key + Redis TTL + delete-after-use already provide the CSRF protection.
+- **Impact**: None today — the field is unused. Worth removing or wiring up correctly so future maintainers don't assume IP binding exists when it doesn't.
+- **Fix**: Either remove the `ip` field from `OAuthStateData` (and re-deserialise existing in-flight records as missing → ok), or populate it with the connection IP via `ConnectInfo` and use it as a soft signal for anomaly logs (not as an enforced check, because of legitimate mobile roaming).
+- **Effort**: small.
+
+### LOW — OAuth success URL carries access token in query string
+- **Where**: `backend-rust/src/routes/oauth.rs:596-601` (Google) and `:1073-1078` (LINE).
+- **What**: After OAuth callback succeeds, the user is redirected to `<frontend>/oauth/success?token=<JWT>&isNewUser=<bool>`. The refresh token is correctly delivered via HttpOnly cookie (Phase 3); the *access* token rides in the URL. URLs leak via browser history, server access logs (if the SPA host logs query strings), referrer headers (mitigated by `Referrer-Policy: strict-origin-when-cross-origin` in nginx), and shoulder-surfing.
+- **Impact**: Low because (a) access tokens are short-lived (15 minutes default per `default_access_token_expiry`), (b) `Referrer-Policy` is strict, (c) the SPA reads `?token=` once and stashes in memory. Still a recognised pattern smell — the official "token in URL fragment (#)" alternative leaks less because fragments aren't sent to servers.
+- **Fix**: Switch the redirect to `<frontend>/oauth/success#token=<JWT>&isNewUser=<bool>`. Update the frontend handler to read `window.location.hash`. Or post the token via a one-time-use Redis key and have the SPA exchange a code for it. Not urgent — flagged for the next OAuth-hardening pass.
+- **Effort**: small (one-line server change + matching frontend tweak).
+
+### LOW — `delete_room` cascades through bookings without explicit confirmation flow
+- **Where**: `backend-rust/src/routes/admin_rooms.rs:738-754`.
+- **What**: The handler does a `DELETE FROM rooms WHERE id = $1` with no preflight count of attached bookings. The docstring says "Cascading FK on `room_blocked_dates` and `bookings` means any related rows go with it — the admin UI surfaces a separate confirmation flow before invoking this, so we trust the request." Trusting the UI is fine for an internal-only tool, but with public users arriving the "delete room" action could nuke historical booking rows that loyalty/billing/audit features depend on.
+- **Impact**: Data-loss / loyalty-integrity. The frontend confirmation flow is the only barrier; one stray click (or one curl-based admin) wipes the booking history for that room.
+- **Fix**: Mirror `delete_room_type`'s pattern — count `SELECT COUNT(*) FROM bookings WHERE room_id = $1` first, and if > 0 return `409 Conflict` with `bookingsAttached` so the admin must reassign or soft-delete instead. Soft-delete (`is_active = false`) is already supported via `PATCH /rooms/:id` and is probably the right default.
+- **Effort**: small.
+
+### LOW — Admin email test endpoint logs recipient via `Display`, not sanitized
+- **Where**: `backend-rust/src/routes/admin_email.rs:297-322`.
+- **What**: The success/failure tracing log lines write `recipient = %recipient` where `recipient` is a user-supplied email. The `validator::Validate` email regex is permissive; certain edge characters in local-parts (whitespace via quoted form, dots, plus addressing) can carry through. Log injection (newlines + fake log lines) is unlikely because email regex rejects newlines, but the value is still attacker-controlled and surfaces in production logs.
+- **Impact**: Defence-in-depth only. No known exploit.
+- **Fix**: Either log a hash of the recipient (sufficient for correlation, doesn't store PII in logs at all), or trim/sanitize control bytes before logging. Same pattern in OAuth's `tracing::info!(..., email = %email, ...)` (oauth.rs:603-607) — worth a follow-up sweep.
+- **Effort**: small.
+
+## Not-findings (verified clean)
+
+- **JWT secret defaults** — refuses to boot in production on weak/placeholder values; `EXAMPLE_DO_NOT_USE_*` and `REPLACE_ME_*` prefixes are explicitly rejected; 64-char minimum in prod; tested (`config/mod.rs:622-668` + tests at `:879-948`).
+- **Hardcoded credentials in source** — none. `.env.example` ships placeholder `EXAMPLE_DO_NOT_USE_*` secrets; `.env.production.example` uses `CHANGE_ME_*`. `.gitignore` correctly excludes `.env*` except `.env.example` / `.env.production.example`. No real customer data or admin emails in `migrations/`, `seed.rs`, or committed configs.
+- **Database URL guard** — `main.rs::enforce_safe_database_url` refuses production boot on legacy `loyalty:loyalty_pass`, `CHANGE_ME_*`, `password@`, empty-password URLs (tested).
+- **Refresh cookie attributes** — `HttpOnly`, `Secure`, `SameSite=Strict`, `Path=/api/auth`, `Max-Age` clamped non-negative. CSRF on `/api/auth/refresh` is implicitly enforced by SameSite=Strict (Phase 3 cookie-only). Tested.
+- **OAuth state** — random 32-byte URL-safe base64, stored in Redis with 10-minute TTL, validated and deleted on callback, return URL allowlisted to same-origin as `frontend_url` (open-redirect tested).
+- **SQL injection on new admin endpoints** — `admin_bookings.rs`, `admin_email.rs`, `admin_rooms.rs`, `admin_slips.rs` all use compile-time `sqlx::query!` / `sqlx::query_as!` macros. The dynamic-`format!()`-SQL pattern survives only in older `admin.rs` (`list_users`, `update_user`, `broadcast_notification`) with allowlisted columns and parameter binding (MEDIUM finding above).
+- **Path traversal on uploads** — filenames are server-generated `Uuid::new_v4().<ext>`; client `name`/`filename` from multipart are never used.
+- **Body limits** — `DefaultBodyLimit::max(16 MiB)` applied globally in `main.rs:239`. nginx `client_max_body_size 15M`.
+- **Security headers in nginx** — X-Content-Type-Options, X-Frame-Options DENY, Referrer-Policy, HSTS (1 year + includeSubDomains), CSP (default-src 'self', restrictive). `frame-ancestors 'none'` is set.
+- **CORS** — production layer reads only configured frontend_url; `allow_credentials(true)` and explicit method/header allowlists; permissive layer is dev-only.
+- **Auth + admin role propagation** — every admin handler in the four new modules calls `require_admin(&user)` (and `require_super_admin` where appropriate) at the top, defence-in-depth over the `auth_middleware` layer applied in `routes::admin::router`.
+- **OAuth account linking** — checks the OAuth provider ID is not already linked to another user before linking; returns 409 Conflict on collision.
+- **Slip upload MIME allowlist** — only `image/jpeg` and `image/png` accepted at the slip endpoint (not the broader avatar/general allowlist). PDF is not accepted for slips.
+- **Public-repo leakage post-#196-197 scrub** — no real values in `.env.example` / `.env.production.example`, no real customer emails in seed/migrations, `SECURITY.md` points to GitHub private advisories, `docs/secrets-runbook.md` documents rotation procedure.
+
+## Suggested follow-up
+
+### Bundle A (critical + high) — before public launch
+
+- HIGH-1 — Block role escalation to super_admin in `admin.rs::update_user` and `update_user_role` (and the symmetric demote-another-super_admin case).
+- HIGH-2 — Switch rate-limiter to `ConnectInfo`-based IP, fix nginx `proxy_set_header X-Forwarded-For` to replace (not append).
+- HIGH-3 — Add `backend-rust/audit.toml` ignoring RUSTSEC-2023-0071 with a rationale comment; re-evaluate when `jsonwebtoken` drops the `rsa` transitive.
+- HIGH-4 — Lock down `POST /api/admin/email/test` to admin's own email and add a per-admin daily quota in Redis.
+
+### Bundle B (medium) — first iteration after launch
+
+- MED-1 — Restrict `slipUrl` in `add_booking_slip` to `/storage/slips/` prefix.
+- MED-2 — Clarify `delete_user` docstring + symmetric super_admin protection.
+- MED-3 — Stream slip upload bytes with a per-field cap; or apply per-route body limit.
+- MED-4 — Magic-byte validation on slip image uploads.
+- MED-5 — Convert `list_users` / `broadcast_notification` dynamic SQL to typed enums.
+- MED-6 — Authn-gate `GET /api/storage/slips/:filename` (slip-owner or admin).
+- MED-7 — Write `booking_audit_log` rows from `admin_slips` verify / needs-action mutations.
+
+### Bundle C (low / doc) — opportunistic
+
+- LOW-1 — Remove or wire up `OAuthStateData::ip`.
+- LOW-2 — Move OAuth access token from query string to URL fragment.
+- LOW-3 — Mirror `delete_room_type`'s preflight count in `delete_room`.
+- LOW-4 — Hash or sanitize email values logged in admin-email / OAuth handlers.
+
+---
+
+*Audit notes — methodology and scope*: read-only review against the worktree branch `docs/audit-security-2026-05-13` (forked from `main` at commit `fc532591`). Files audited line-by-line: `backend-rust/src/{main,state,error,config/mod}.rs`, `backend-rust/src/middleware/{auth,admin,cors,rate_limit}.rs`, `backend-rust/src/routes/{admin,admin_bookings,admin_email,admin_rooms,admin_slips,auth,oauth,slips,storage,bookings}.rs`, `backend-rust/src/services/storage.rs`, `nginx/nginx.conf`, `.env.example`, `.env.production.example`, `docker-compose*.yml`, `.gitignore`, `docs/secrets-runbook.md`, `SECURITY.md`, `.github/workflows/cargo-audit.yml`, latest `cargo-audit` run log (id 25796241240). Cross-cutting correctness/operational issues (e.g. slip→booking foreign-key behaviour, schema drift) are out of scope for this lens and were flagged-and-passed-along.


### PR DESCRIPTION
## Summary

Pre-public-launch security audit covering the ~25 admin endpoints shipped in the past week (#216 #217 #218), Phase 3 cookie-only refresh flow (#208 #212), OAuth state handling, rate limiting, file upload, CORS/security headers, the daily `cargo audit` signal, and the post-#196-#197 public-repo leakage scrub.

Read-only — adds `docs/audits/security-2026-05-13.md` and nothing else. Single commit, no implementation changes.

**Counts:** 14 findings — 0 critical, 4 high, 6 medium, 4 low.

**Top 3 to fix before public launch:**

1. `admin.rs::update_user` / `update_user_role` lets any `admin` promote any user to `super_admin` (or demote another super_admin). Self-elevation path.
2. Rate limiter trusts client-supplied `X-Forwarded-For` / `X-Real-IP` — credential-stuffing and brute-force-reset bypass.
3. Today's `cargo audit` run is red (RUSTSEC-2023-0071 via `jsonwebtoken`→`rsa`). Not directly exploitable (HS256 only), but no `audit.toml` allowlist documents the call, so CI's signal is now permanently broken.

Three follow-up bundles (HIGH → before launch, MEDIUM → first post-launch iteration, LOW → opportunistic) plus a "not-findings" list documenting what was verified clean (JWT secret validation, refresh-cookie attrs, OAuth state CSRF, secrets-in-source, public-repo scrub, etc.).

## Test plan

- [ ] Maintainer reads `docs/audits/security-2026-05-13.md`
- [ ] Confirm Bundle A items are tracked as follow-up issues / PRs
- [ ] No code changes in this PR — nothing to test mechanically

🤖 Generated with [Claude Code](https://claude.com/claude-code)