### PR TITLE
fix(audit): ops infra (graceful shutdown, backups, alerting, logs, runbooks, resource limits)

### DIFF
--- a/.github/workflows/backup-production.yml
+++ b/.github/workflows/backup-production.yml
@@ -1,0 +1,199 @@
+name: Backup Production Database
+
+# Daily off-host backup of the production Postgres volume.
+#
+# Flow:
+#   1. SSH through cloudflared to evergreen (same tunnel deploy.yml uses).
+#   2. `pg_dump` the loyalty DB inside the postgres container.
+#   3. Encrypt the dump with `age` using the public key in BACKUP_AGE_RECIPIENT.
+#   4. Upload to S3-compatible storage (S3 / R2 / Backblaze B2).
+#   5. Apply server-side retention (30 days) via S3 lifecycle policy (set
+#      out of band on the bucket; documented in docs/restore-runbook.md).
+#
+# Scheduling note: 18:00 UTC = 01:00 ICT (Bangkok) — outside the typical
+# user traffic window for a hospitality app.
+#
+# Secrets required (configure in repo Settings → Secrets and variables →
+# Actions → Repository secrets):
+#   - EVERGREEN_DEPLOY_SSH_KEY    (existing — reused from deploy.yml)
+#   - EVERGREEN_HOST_KEY          (existing — reused from deploy.yml)
+#   - POSTGRES_USER               (existing — for pg_dump auth)
+#   - POSTGRES_PASSWORD           (existing — for pg_dump auth)
+#   - POSTGRES_DB                 (existing — DB name)
+#   - BACKUP_AGE_RECIPIENT        (new — age public key, single line
+#                                  starting with `age1...`)
+#   - BACKUP_S3_BUCKET            (new — bucket name)
+#   - BACKUP_S3_ENDPOINT          (new — e.g. `https://<account>.r2.cloudflarestorage.com`
+#                                  for R2, `https://s3.us-east-005.backblazeb2.com` for
+#                                  Backblaze B2, or omit for AWS S3)
+#   - BACKUP_S3_REGION            (new — e.g. `auto` for R2, `us-east-005` for B2)
+#   - BACKUP_S3_ACCESS_KEY_ID     (new)
+#   - BACKUP_S3_SECRET_ACCESS_KEY (new)
+#
+# Until BACKUP_* secrets are wired, the schedule trigger is disabled and
+# only manual `workflow_dispatch` runs (which fail at the upload step with
+# a clear error). See docs/restore-runbook.md for the secret-wiring
+# follow-up checklist.
+
+on:
+  schedule:
+    # Daily at 18:00 UTC (01:00 ICT). Picks a low-traffic window for the
+    # hospitality booking app.
+    - cron: '0 18 * * *'
+  workflow_dispatch: {}
+
+concurrency:
+  group: backup-production
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  CLOUDFLARED_VERSION: "2024.10.0"
+
+jobs:
+  backup:
+    name: "Backup Production DB"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # Disable the schedule trigger until BACKUP_* secrets are wired. Manual
+    # workflow_dispatch runs are still allowed so the operator who wires
+    # secrets can sanity-check the path immediately.
+    #
+    # TODO: flip this guard to a `BACKUP_S3_BUCKET != ''` check once
+    # secrets land.
+    if: github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Validate required secrets are configured
+        env:
+          BACKUP_S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET }}
+          BACKUP_AGE_RECIPIENT: ${{ secrets.BACKUP_AGE_RECIPIENT }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -z "${BACKUP_S3_BUCKET:-}" ] && missing+=("BACKUP_S3_BUCKET")
+          [ -z "${BACKUP_AGE_RECIPIENT:-}" ] && missing+=("BACKUP_AGE_RECIPIENT")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing required secrets: ${missing[*]}. See docs/restore-runbook.md."
+            exit 1
+          fi
+
+      - name: Install age (encryption) and AWS CLI v2
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends age
+          # AWS CLI v2 is the supported uploader for S3-compatible
+          # endpoints (R2, Backblaze B2, AWS S3).
+          if ! command -v aws >/dev/null 2>&1; then
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp
+            sudo /tmp/aws/install
+          fi
+          age --version
+          aws --version
+
+      - name: Cache cloudflared binary
+        id: cache-cloudflared
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/cloudflared
+          key: cloudflared-${{ runner.os }}-${{ env.CLOUDFLARED_VERSION }}
+
+      - name: Download cloudflared (cache miss)
+        if: steps.cache-cloudflared.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/.cache/cloudflared
+          curl -fsSL \
+            "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64" \
+            -o ~/.cache/cloudflared/cloudflared
+          chmod +x ~/.cache/cloudflared/cloudflared
+
+      - name: Install cloudflared to /usr/local/bin
+        run: |
+          sudo install -m 755 ~/.cache/cloudflared/cloudflared /usr/local/bin/cloudflared
+          cloudflared --version
+
+      - name: Install SSH key + known_hosts
+        env:
+          SSH_KEY:  ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
+          HOST_KEY: ${{ secrets.EVERGREEN_HOST_KEY }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY"  > ~/.ssh/deploy_key  && chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "$HOST_KEY" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+
+      - name: Stream pg_dump to runner and encrypt
+        id: dump
+        env:
+          POSTGRES_USER:        ${{ secrets.POSTGRES_USER }}
+          POSTGRES_PASSWORD:    ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_DB:          ${{ secrets.POSTGRES_DB }}
+          BACKUP_AGE_RECIPIENT: ${{ secrets.BACKUP_AGE_RECIPIENT }}
+        run: |
+          set -euo pipefail
+          TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+          BACKUP_NAME="loyalty_pg_${TIMESTAMP}.sql.gz.age"
+          echo "backup_name=$BACKUP_NAME" >> "$GITHUB_OUTPUT"
+
+          # Stream pg_dump through gzip on the remote, pipe over SSH to the
+          # runner, then encrypt to disk with age. The DB password is passed
+          # over the SSH session via env so it never appears in `ps`.
+          #
+          # `docker compose exec -T` (no TTY) is required so the SSH stdout
+          # stays binary-clean for the gzip stream.
+          ssh -i ~/.ssh/deploy_key \
+              -o StrictHostKeyChecking=yes \
+              -o UserKnownHostsFile=~/.ssh/known_hosts \
+              -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
+              -o SendEnv=PGPASSWORD \
+              deploy@evergreen.thehfhotel.org \
+              "PGPASSWORD='${POSTGRES_PASSWORD}' docker exec -i loyalty_postgres_production \
+                pg_dump -U '${POSTGRES_USER}' -d '${POSTGRES_DB}' --no-owner --no-acl \
+                | gzip -9" \
+            | age --recipient "$BACKUP_AGE_RECIPIENT" --output "/tmp/$BACKUP_NAME"
+
+          BACKUP_SIZE=$(stat -c%s "/tmp/$BACKUP_NAME")
+          if [ "$BACKUP_SIZE" -lt 1024 ]; then
+            echo "::error::Backup file is suspiciously small ($BACKUP_SIZE bytes) — pg_dump probably failed."
+            exit 1
+          fi
+          echo "backup_size_bytes=$BACKUP_SIZE" >> "$GITHUB_OUTPUT"
+          echo "Backup created: $BACKUP_NAME ($BACKUP_SIZE bytes)"
+
+      - name: Upload encrypted dump to S3-compatible storage
+        env:
+          AWS_ACCESS_KEY_ID:     ${{ secrets.BACKUP_S3_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.BACKUP_S3_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION:    ${{ secrets.BACKUP_S3_REGION }}
+          BACKUP_S3_BUCKET:      ${{ secrets.BACKUP_S3_BUCKET }}
+          BACKUP_S3_ENDPOINT:    ${{ secrets.BACKUP_S3_ENDPOINT }}
+          BACKUP_NAME:           ${{ steps.dump.outputs.backup_name }}
+        run: |
+          set -euo pipefail
+          ENDPOINT_FLAG=()
+          if [ -n "${BACKUP_S3_ENDPOINT:-}" ]; then
+            ENDPOINT_FLAG=(--endpoint-url "$BACKUP_S3_ENDPOINT")
+          fi
+          aws "${ENDPOINT_FLAG[@]}" s3 cp \
+            "/tmp/$BACKUP_NAME" \
+            "s3://$BACKUP_S3_BUCKET/daily/$BACKUP_NAME" \
+            --no-progress
+          echo "Uploaded s3://$BACKUP_S3_BUCKET/daily/$BACKUP_NAME"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## Production Backup"
+            echo ""
+            echo "- Trigger: \`${{ github.event_name }}\`"
+            echo "- Backup name: \`${{ steps.dump.outputs.backup_name }}\`"
+            echo "- Size: \`${{ steps.dump.outputs.backup_size_bytes }}\` bytes"
+            echo "- Destination: \`s3://\${BACKUP_S3_BUCKET}/daily/\`"
+            echo ""
+            echo "See \`docs/restore-runbook.md\` for restore instructions."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -8,9 +8,9 @@ name: Cargo Audit
 # scan time on every run. Pulling it into a daily workflow keeps the
 # advisory database fresh in the Actions tab without the per-push tax.
 #
-# A future enhancement could file a GitHub issue on red audit
-# (hence the `issues: write` permission); for now we just rely on
-# the workflow appearing red on the Actions tab.
+# On a red audit run, a GitHub issue is filed (or the existing open
+# audit issue is touched) so the failure surfaces somewhere a human
+# actually looks. See the `notify-on-failure` job below.
 
 on:
   schedule:
@@ -41,5 +41,55 @@ jobs:
         uses: taiki-e/install-action@cargo-audit
 
       - name: Run cargo audit
+        id: audit
         working-directory: ./backend-rust
         run: cargo audit
+
+  # File a GitHub issue on audit failure so the red workflow doesn't just
+  # sit unseen in the Actions tab. Reuses an open issue when one already
+  # exists for the same workflow to avoid noise on multi-day-red windows.
+  notify-on-failure:
+    name: "Notify on audit failure"
+    runs-on: ubuntu-latest
+    needs: [audit]
+    if: failure()
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: File or update audit-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="cargo audit failing on main"
+          EXISTING=$(gh issue list -R "${{ github.repository }}" \
+            --search "$TITLE in:title is:open" \
+            --json number --jq '.[0].number // empty')
+
+          BODY=$(cat <<EOF
+          The scheduled \`Cargo Audit\` workflow failed.
+
+          - Run: $RUN_URL
+          - Commit: \`${{ github.sha }}\`
+          - Triggered: \`${{ github.event_name }}\`
+
+          Inspect the run log for the advisory ID and the affected dependency.
+          A red audit on \`main\` is a security signal — do not close this issue
+          until \`cargo audit\` is green again.
+          EOF
+          )
+
+          if [ -n "${EXISTING:-}" ]; then
+            gh issue comment "$EXISTING" -R "${{ github.repository }}" --body "$BODY"
+            echo "Updated existing issue #$EXISTING"
+          else
+            # No --label: keep this dependency-free on label config. Label
+            # the issue manually after triage so we don't depend on a label
+            # that may not exist in the repo.
+            gh issue create -R "${{ github.repository }}" \
+              --title "$TITLE" \
+              --body "$BODY"
+            echo "Filed new audit-failure issue"
+          fi

--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -21,6 +21,9 @@ permissions:
   contents: read
   actions: read
   packages: write
+  # Needed by the verify-staging-on-failure job below so a red staging
+  # deploy surfaces as a GitHub issue, not just a tab nobody opens.
+  issues: write
 
 env:
   NODE_VERSION: '24'
@@ -880,3 +883,61 @@ jobs:
           done
           echo "::error::Staging /api/health not responding after 90s"
           exit 1
+
+  # =============================================================================
+  # NOTIFY ON STAGING HEALTHCHECK FAILURE
+  #
+  # Files (or comments on) a GitHub issue when the verify-staging poll fails
+  # so the failure is visible somewhere a human actually reads, not just the
+  # red X in the Actions tab. The cargo-audit workflow uses the same pattern;
+  # see `cargo-audit.yml`. Slack / email channels can be added later via an
+  # OPS_ALERT_SLACK_WEBHOOK secret without touching the verify job.
+  # =============================================================================
+
+  notify-verify-staging-failure:
+    name: "Notify on Verify Staging failure"
+    runs-on: ubuntu-latest
+    needs: [verify-staging]
+    if: failure() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: File or update verify-staging-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Verify Staging failed on main"
+          EXISTING=$(gh issue list -R "${{ github.repository }}" \
+            --search "$TITLE in:title is:open" \
+            --json number --jq '.[0].number // empty')
+
+          BODY=$(cat <<EOF
+          The post-deploy \`Verify Staging\` step failed after a push to \`main\`.
+
+          - Run: $RUN_URL
+          - Commit: \`${{ github.sha }}\`
+          - Author: @${{ github.actor }}
+
+          Staging is now in an undefined state (the new image is up but
+          \`/api/health\` is not responding). Investigate:
+          1. Open the run log linked above for the failing curl attempts.
+          2. SSH to evergreen and check container status / backend logs.
+          3. Roll back via \`docs/rollback-runbook.md\` if root cause is not
+             a quick fix.
+          EOF
+          )
+
+          if [ -n "${EXISTING:-}" ]; then
+            gh issue comment "$EXISTING" -R "${{ github.repository }}" --body "$BODY"
+            echo "Updated existing issue #$EXISTING"
+          else
+            gh issue create -R "${{ github.repository }}" \
+              --title "$TITLE" \
+              --body "$BODY"
+            echo "Filed new verify-staging-failure issue"
+          fi

--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -866,10 +866,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [deploy-staging]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Poll staging /api/health
+        id: poll
         env:
           STAGING_HEALTH_URL: http://loyalty-dev.saichon.com/api/health
         run: |
@@ -883,6 +884,69 @@ jobs:
           done
           echo "::error::Staging /api/health not responding after 90s"
           exit 1
+
+      # The rest of this job runs only when the poll above fails, to grab
+      # backend logs + container state from the staging host before the
+      # next push overwrites them. Without this, every red verify-staging
+      # is a black box.
+
+      - name: Install cloudflared (on failure)
+        if: failure()
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
+            -o /tmp/cloudflared
+          sudo install -m 755 /tmp/cloudflared /usr/local/bin/cloudflared
+
+      - name: Install SSH key + known_hosts (on failure)
+        if: failure()
+        env:
+          SSH_KEY:  ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
+          HOST_KEY: ${{ secrets.EVERGREEN_HOST_KEY }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY"  > ~/.ssh/deploy_key  && chmod 600 ~/.ssh/deploy_key
+          printf '%s\n' "$HOST_KEY" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+
+      - name: Capture staging logs + container state (on failure)
+        if: failure()
+        run: |
+          set -uo pipefail
+          mkdir -p staging-failure-logs
+
+          # Tolerate per-command failure: even partial output is useful when
+          # the box is sick. We `|| true` each remote invocation so a missing
+          # service or auth error doesn't truncate the rest.
+          SSH_CMD=(ssh -i ~/.ssh/deploy_key
+            -o StrictHostKeyChecking=yes
+            -o UserKnownHostsFile=~/.ssh/known_hosts
+            -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h"
+            -o ConnectTimeout=15
+            deploy@evergreen.thehfhotel.org)
+
+          "${SSH_CMD[@]}" 'docker ps --filter "name=loyalty_" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"' \
+            > staging-failure-logs/containers.txt 2>&1 || true
+
+          "${SSH_CMD[@]}" 'docker logs --tail 200 loyalty_backend_dev 2>&1' \
+            > staging-failure-logs/backend.log 2>&1 || true
+
+          "${SSH_CMD[@]}" 'docker logs --tail 100 loyalty_postgres_dev 2>&1' \
+            > staging-failure-logs/postgres.log 2>&1 || true
+
+          "${SSH_CMD[@]}" 'docker logs --tail 100 loyalty_nginx_dev 2>&1' \
+            > staging-failure-logs/nginx.log 2>&1 || true
+
+          echo "--- containers.txt ---"
+          cat staging-failure-logs/containers.txt || true
+          echo "--- backend.log (tail) ---"
+          tail -40 staging-failure-logs/backend.log || true
+
+      - name: Upload failure logs as artifact (on failure)
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: staging-failure-logs-${{ github.sha }}
+          path: staging-failure-logs/
+          retention-days: 14
 
   # =============================================================================
   # NOTIFY ON STAGING HEALTHCHECK FAILURE

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ permissions:
   contents: read
   actions: read
   packages: read
+  # Needed by `notify-on-failure` so a red prod deploy surfaces as a
+  # GitHub issue. The Actions tab is not a paging channel.
+  issues: write
 
 env:
   REGISTRY: ghcr.io
@@ -238,3 +241,54 @@ jobs:
           echo "- **Image Tag**: \`${{ needs.check-prerequisites.outputs.commit-sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "- **URL**: https://loyalty.saichon.com" >> $GITHUB_STEP_SUMMARY
           echo "- **Backend**: Rust (loyalty-backend)" >> $GITHUB_STEP_SUMMARY
+
+  # =============================================================================
+  # NOTIFY ON PRODUCTION DEPLOY FAILURE
+  #
+  # Files (or comments on) a GitHub issue if the prod deploy job fails so the
+  # operator who approved the deploy isn't the only person with the failure
+  # signal. Slack / email channels can be added later by adding a step here
+  # that consumes an `OPS_ALERT_SLACK_WEBHOOK` secret — no other change.
+  # =============================================================================
+
+  notify-on-failure:
+    name: "Notify on production deploy failure"
+    runs-on: ubuntu-latest
+    needs: [deploy-production]
+    if: failure()
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: File or update prod-deploy-failure issue
+        env:
+          GH_TOKEN:   ${{ github.token }}
+          RUN_URL:    ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ needs.check-prerequisites.outputs.commit-sha }}
+        run: |
+          set -euo pipefail
+          TITLE="Production deploy failed"
+          EXISTING=$(gh issue list -R "${{ github.repository }}" \
+            --search "$TITLE in:title is:open" \
+            --json number --jq '.[0].number // empty')
+
+          BODY=$(cat <<EOF
+          The production deploy job failed.
+
+          - Run: $RUN_URL
+          - Commit: \`$COMMIT_SHA\`
+          - Approver: @${{ github.actor }}
+
+          Production is now in an undefined state. See
+          \`docs/rollback-runbook.md\` for the redeploy-previous-SHA path.
+          EOF
+          )
+
+          if [ -n "${EXISTING:-}" ]; then
+            gh issue comment "$EXISTING" -R "${{ github.repository }}" --body "$BODY"
+          else
+            gh issue create -R "${{ github.repository }}" \
+              --title "$TITLE" \
+              --body "$BODY"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,9 @@ Platinum 20+ nights. Tiers are computed from `total_nights`, not
 - Migration *rewrites* (e.g., canonical reconciliations) need an entry
   in `REBRIDGED_MIGRATIONS` (`backend-rust/src/db/migrations.rs`)
   because sqlx tracks a source checksum and refuses to proceed when
-  the file changes.
+  the file changes. Full procedure (when it's safe, schema-diff
+  pre-flight, two-piece review, staging verification) lives in
+  [`docs/migration-rewrite-runbook.md`](docs/migration-rewrite-runbook.md).
 - Use stored procedures (e.g., `award_points`,
   `recalculate_user_tier_by_nights`) instead of raw `UPDATE`s for
   tier-affecting operations.

--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -4140,9 +4140,11 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -3379,6 +3379,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3926,6 +3936,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -20,7 +20,7 @@ tokio = { version = "1", features = [
     "signal",            # SIGTERM/SIGINT handlers for graceful shutdown
 ] }
 tower = "0.4"
-tower-http = { version = "0.5", features = ["cors", "trace", "fs", "limit", "timeout", "compression-gzip"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "fs", "limit", "timeout", "compression-gzip", "request-id", "util"] }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono", "json", "migrate", "rust_decimal", "macros"] }

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -17,6 +17,7 @@ tokio = { version = "1", features = [
     "io-util",           # tokio::io::AsyncWriteExt for streaming writes
     "sync",              # broadcast + RwLock in services::sse
     "time",              # tokio::time::sleep + tower-http timeout layer
+    "signal",            # SIGTERM/SIGINT handlers for graceful shutdown
 ] }
 tower = "0.4"
 tower-http = { version = "0.5", features = ["cors", "trace", "fs", "limit", "timeout", "compression-gzip"] }

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -15,6 +15,12 @@ use tower_http::trace::{self, TraceLayer};
 use tracing::{error, info, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+/// Maximum time the server waits for in-flight requests to finish after a
+/// shutdown signal before forcing exit. Picked just under docker compose's
+/// default `--timeout 30` so the runtime returns control to the OS before
+/// the container is killed.
+const SHUTDOWN_GRACE_PERIOD_SECS: u64 = 25;
+
 /// Global request body limit. 16 MiB matches `client_max_body_size 15M` in
 /// nginx/nginx.conf with a small headroom for multipart framing overhead;
 /// per-route handlers (e.g. JSON endpoints) can tighten this further.
@@ -147,9 +153,65 @@ async fn main() -> anyhow::Result<()> {
     // Log configured features
     log_startup_info(&config);
 
-    axum::serve(listener, app).await?;
+    // Serve with a graceful shutdown signal. Without this, every container
+    // rotation (docker compose up / restart) drops in-flight slip uploads,
+    // SSE long-poll connections, and any other request that the runtime
+    // happens to be holding when SIGTERM lands.
+    let serve_result = axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await;
 
+    // Close the db pool after the server has stopped accepting / completing
+    // requests. Bound the close itself so a pathologically stuck connection
+    // can't block container exit past the docker-compose stop timeout.
+    if let Err(close_err) =
+        tokio::time::timeout(Duration::from_secs(SHUTDOWN_GRACE_PERIOD_SECS), db.close()).await
+    {
+        warn!(
+            "Database pool close did not complete within {}s grace period: {}",
+            SHUTDOWN_GRACE_PERIOD_SECS, close_err
+        );
+    }
+
+    serve_result?;
+
+    info!("Server shutdown complete");
     Ok(())
+}
+
+/// Resolve when the process should begin graceful shutdown.
+///
+/// SIGINT (`Ctrl-C`) covers interactive use; SIGTERM is what `docker stop` /
+/// `docker compose` / `kubectl rollout` send before SIGKILL. We race both
+/// and resolve on whichever fires first.
+///
+/// On non-Unix targets only the Ctrl-C branch is active.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl-C signal handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {
+            info!("Received SIGINT (Ctrl-C); beginning graceful shutdown");
+        },
+        _ = terminate => {
+            info!("Received SIGTERM; beginning graceful shutdown");
+        },
+    }
 }
 
 /// Initialize tracing/logging subscriber

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -6,14 +6,22 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use axum::extract::DefaultBodyLimit;
+use axum::extract::{DefaultBodyLimit, Request};
+use axum::http::HeaderName;
 use axum::Router;
 use tokio::net::TcpListener;
 use tower_http::compression::CompressionLayer;
+use tower_http::request_id::{
+    MakeRequestUuid, PropagateRequestIdLayer, RequestId, SetRequestIdLayer,
+};
 use tower_http::timeout::TimeoutLayer;
 use tower_http::trace::{self, TraceLayer};
 use tracing::{error, info, warn, Level};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+/// HTTP header used to carry a request's correlation ID into and out of
+/// the backend. Lowercase per HTTP/2.
+const REQUEST_ID_HEADER: HeaderName = HeaderName::from_static("x-request-id");
 
 /// Maximum time the server waits for in-flight requests to finish after a
 /// shutdown signal before forcing exit. Picked just under docker compose's
@@ -344,7 +352,19 @@ fn create_app(state: AppState, config: &Settings) -> Router {
     // The routes::create_router function handles setting up all API endpoints
     let app = routes::create_router(state);
 
-    // Apply middleware layers (order matters - applied bottom to top)
+    // Apply middleware layers.
+    //
+    // Layer ordering note (axum / tower): `.layer(X)` wraps the inner
+    // service in X, so the LAST `.layer` call is the OUTERMOST layer the
+    // request hits. Conversely, layers earlier in the source see the
+    // response after later ones. Order matters for request-id propagation:
+    //
+    //   request flow:    set_request_id → trace → ... → handler
+    //   response flow:   handler → ... → trace → propagate_request_id
+    //
+    // so we add set_request_id LAST (outermost) and propagate_request_id
+    // SECOND-LAST so it wraps everything below trace but is wrapped by
+    // set_request_id.
     app
         // Compression (gzip, deflate, br)
         .layer(CompressionLayer::new())
@@ -355,15 +375,45 @@ fn create_app(state: AppState, config: &Settings) -> Router {
         .layer(DefaultBodyLimit::max(DEFAULT_BODY_LIMIT_BYTES))
         // Request timeout (30 seconds default)
         .layer(TimeoutLayer::new(Duration::from_secs(30)))
-        // Request tracing/logging
+        // Request tracing/logging — `make_span_with` injects the
+        // request_id (set by SetRequestIdLayer above us in the request
+        // flow) into the span so every log line for the request carries
+        // the same correlation field.
         .layer(
             TraceLayer::new_for_http()
-                .make_span_with(trace::DefaultMakeSpan::new().level(Level::INFO))
+                .make_span_with(make_http_span)
                 .on_response(trace::DefaultOnResponse::new().level(Level::INFO))
                 .on_failure(trace::DefaultOnFailure::new().level(Level::ERROR)),
         )
         // CORS configuration based on environment
         .layer(build_cors_layer(config))
+        // Echo the request_id back to the caller as `x-request-id`. Must
+        // wrap the trace layer (request flow) so the response header is
+        // set after the handler has returned but before the response
+        // leaves the trace span.
+        .layer(PropagateRequestIdLayer::new(REQUEST_ID_HEADER))
+        // Generate (or accept and pass through) `x-request-id`. v4 UUID.
+        // Must be the outermost layer so every downstream layer sees the
+        // ID and the trace span can include it.
+        .layer(SetRequestIdLayer::new(REQUEST_ID_HEADER, MakeRequestUuid))
+}
+
+/// Build the per-request tracing span. Threads the `x-request-id` header
+/// (set by `SetRequestIdLayer`) onto the span so every log line emitted
+/// while handling the request carries the same correlation field.
+fn make_http_span(request: &Request) -> tracing::Span {
+    let request_id = request
+        .extensions()
+        .get::<RequestId>()
+        .and_then(|id| id.header_value().to_str().ok())
+        .unwrap_or("");
+
+    tracing::info_span!(
+        "http_request",
+        method = %request.method(),
+        uri = %request.uri().path(),
+        request_id = %request_id,
+    )
 }
 
 /// Build CORS layer based on configuration

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -55,8 +55,10 @@ async fn main() -> anyhow::Result<()> {
     let config = match Settings::new() {
         Ok(cfg) => cfg,
         Err(e) => {
-            error!("Failed to load configuration: {}", e);
-            return Err(anyhow::anyhow!("Configuration error: {}", e));
+            // `{:#}` walks the anyhow cause chain so the underlying config /
+            // dotenvy / env-var error is visible, not just the top frame.
+            error!("Failed to load configuration: {:#}", e);
+            return Err(anyhow::anyhow!("Configuration error: {:#}", e));
         },
     };
 
@@ -70,7 +72,7 @@ async fn main() -> anyhow::Result<()> {
     // Refuse to boot in production with well-known development credentials.
     // In dev/staging this only emits a warning so iteration is unblocked.
     if let Err(e) = enforce_safe_database_url(&config.database.url, &config.environment) {
-        error!("Refusing to start: {}", e);
+        error!("Refusing to start: {:#}", e);
         return Err(e);
     }
 
@@ -88,8 +90,12 @@ async fn main() -> anyhow::Result<()> {
             db
         },
         Err(e) => {
-            error!("Failed to connect to PostgreSQL: {}", e);
-            return Err(anyhow::anyhow!("Database connection error: {}", e));
+            // `{:#}` walks the anyhow cause chain so the underlying sqlx /
+            // io error (TLS handshake, DNS, auth, pool-acquire timeout) is
+            // visible. The top frame alone is a generic "Database connection
+            // error" that hides the root cause.
+            error!("Failed to connect to PostgreSQL: {:#}", e);
+            return Err(anyhow::anyhow!("Database connection error: {:#}", e));
         },
     };
 
@@ -107,7 +113,9 @@ async fn main() -> anyhow::Result<()> {
     // Seed essential data (runs in all environments)
     info!("Seeding essential data...");
     if let Err(e) = db::seed::seed_essential_data(db.pool()).await {
-        error!("Failed to seed essential data: {}", e);
+        // `{:#}` walks the anyhow cause chain — seed failures are non-fatal
+        // here, so we want all the context the underlying sqlx error has.
+        error!("Failed to seed essential data: {:#}", e);
         // Continue startup even if seeding fails - data may already exist
     }
 
@@ -115,7 +123,7 @@ async fn main() -> anyhow::Result<()> {
     if config.environment == Environment::Development {
         info!("Seeding sample data (development mode)...");
         if let Err(e) = db::seed::seed_sample_data(db.pool()).await {
-            error!("Failed to seed sample data: {}", e);
+            error!("Failed to seed sample data: {:#}", e);
             // Continue startup even if sample seeding fails
         }
     }
@@ -128,8 +136,10 @@ async fn main() -> anyhow::Result<()> {
             r
         },
         Err(e) => {
-            error!("Failed to connect to Redis: {}", e);
-            return Err(anyhow::anyhow!("Redis connection error: {}", e));
+            // `{:#}` walks the anyhow cause chain to surface the underlying
+            // redis crate / io error, not just the wrapper message.
+            error!("Failed to connect to Redis: {:#}", e);
+            return Err(anyhow::anyhow!("Redis connection error: {:#}", e));
         },
     };
 

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -224,23 +224,67 @@ async fn shutdown_signal() {
     }
 }
 
-/// Initialize tracing/logging subscriber
+/// Initialize tracing/logging subscriber.
+///
+/// In non-development environments (staging / production / anything other
+/// than `RUST_ENV=development`) the subscriber emits JSON-line output so
+/// downstream log aggregators (Loki, ELK, Cloudflare Logs, etc.) can
+/// parse structured fields out of the box. In development it emits
+/// human-readable text, which is far easier to scan in a terminal.
+///
+/// Settings::new() runs *after* init_tracing, so we can't lean on the
+/// parsed `Environment` enum here — we read the same env vars
+/// (`RUST_ENV`, fallback `NODE_ENV`) that the config layer does.
 fn init_tracing() {
-    tracing_subscriber::registry()
-        .with(
-            tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-                // Default log levels for different modules
-                "loyalty_backend=info,tower_http=info,axum=info,sqlx=warn".into()
-            }),
-        )
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_target(true)
-                .with_thread_ids(false)
-                .with_file(false)
-                .with_line_number(false),
-        )
-        .init();
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        // Default log levels for different modules
+        "loyalty_backend=info,tower_http=info,axum=info,sqlx=warn".into()
+    });
+
+    let registry = tracing_subscriber::registry().with(env_filter);
+
+    if is_development_env() {
+        // Pretty / human-readable for dev.
+        registry
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_target(true)
+                    .with_thread_ids(false)
+                    .with_file(false)
+                    .with_line_number(false),
+            )
+            .init();
+    } else {
+        // JSON-line output for staging / production. `with_current_span` +
+        // `with_span_list` carry the http_request span and any nested
+        // spans onto every log line so a single request's logs are easy
+        // to correlate even before request IDs land.
+        registry
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_current_span(true)
+                    .with_span_list(true)
+                    .with_target(true)
+                    .with_thread_ids(false)
+                    .with_file(false)
+                    .with_line_number(false),
+            )
+            .init();
+    }
+}
+
+/// Read `RUST_ENV` (falling back to `NODE_ENV`) and report whether we're
+/// in development. Matches `Settings::new()`'s parsing rule so logging
+/// and config agree about which environment they're in.
+fn is_development_env() -> bool {
+    let env_str = std::env::var("RUST_ENV")
+        .or_else(|_| std::env::var("NODE_ENV"))
+        .unwrap_or_else(|_| "development".to_string());
+    matches!(
+        env_str.to_lowercase().as_str(),
+        "development" | "dev" | "local"
+    )
 }
 
 /// Log startup information about configured features

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,10 +6,31 @@
 # GitHub Actions workflow sets environment variables in .env file
 # This file does NOT hardcode any secrets - all loaded from .env at runtime
 
+#
+# Resource limits (see Operational HIGH-2):
+#
+# `docker compose` (non-swarm) honours the top-level `mem_limit:` and
+# `cpus:` keys, NOT `deploy.resources.limits` (which is swarm-only and
+# silently ignored here). The starting numbers below are conservative
+# anchors for a single-host evergreen deploy — tune from `docker stats`
+# under real traffic once production has a few weeks of usage.
+#
+# Floor reasoning:
+# - backend:  1 CPU / 512 MiB   — Rust binary, small steady state; spikes
+#                                 on multipart slip uploads.
+# - frontend: 0.5 CPU / 128 MiB — nginx serving static SPA bundle.
+# - postgres: 2 CPU / 2 GiB     — primary memory pressure source under
+#                                 audit-log growth; largest allocation.
+# - redis:    0.5 CPU / 256 MiB — small cache, currently single-instance.
+# - nginx:    0.25 CPU / 64 MiB — reverse proxy, no heavy lifting.
+#
+
 services:
   postgres:
     container_name: loyalty_postgres_production
     restart: unless-stopped
+    cpus: 2.0
+    mem_limit: 2g
     ports:
       # Bind to localhost only — backend reaches postgres via the docker network.
       # Host port mapping exists for ad-hoc DBA access from the host (via SSH tunnel).
@@ -18,12 +39,16 @@ services:
   redis:
     container_name: loyalty_redis_production
     restart: unless-stopped
+    cpus: 0.5
+    mem_limit: 256m
     ports:
       # Bind to localhost only — backend reaches redis via the docker network.
       - "127.0.0.1:6379:6379"  # Production Redis port
 
   backend:
     container_name: loyalty_backend_production
+    cpus: 1.0
+    mem_limit: 512m
     build:
       target: runner  # Use production-optimized runner stage with Rust binary
     environment:
@@ -89,6 +114,8 @@ services:
     # NOTE: VITE_API_URL is build-time only (baked into the image during docker build).
     # NODE_ENV is not consumed by the alpine nginx serving the built SPA.
     # Neither belongs in runtime env for the GHCR frontend image.
+    cpus: 0.5
+    mem_limit: 128m
     volumes:
       # GHCR frontend uses nginx:alpine with logs at /var/log/nginx
       - frontend_logs:/var/log/nginx
@@ -99,6 +126,8 @@ services:
   nginx:
     container_name: loyalty_nginx_production
     restart: unless-stopped
+    cpus: 0.25
+    mem_limit: 64m
     ports:
       - "4001:80"  # Production Nginx port
     volumes:

--- a/docs/cloudflare-tunnel-runbook.md
+++ b/docs/cloudflare-tunnel-runbook.md
@@ -1,0 +1,151 @@
+# Cloudflare Tunnel Runbook
+
+The evergreen host has no direct public-internet ingress. Both
+production user traffic and the GitHub Actions deploy SSH path flow
+through a `cloudflared` tunnel daemon on the host. This runbook covers
+restart, health check, and Cloudflare-incident contingency.
+
+> See also: `docs/rollback-runbook.md`, `docs/restore-runbook.md`.
+
+## What the tunnel carries
+
+```
+                    ┌───────────────────────────────┐
+                    │   Cloudflare global network   │
+                    └─────────────┬─────────────────┘
+       loyalty.saichon.com (prod) │
+       loyalty-dev.saichon.com    │
+       cloudflared access ssh ────┤
+                                  ▼
+                  ┌──────────────────────────────────┐
+                  │  cloudflared daemon on evergreen │
+                  │  (systemd unit, single process)  │
+                  └─────────────┬────────────────────┘
+                                ▼
+                  ┌──────────────────────────────────┐
+                  │  Local services on evergreen     │
+                  │  - nginx :4001  (prod ingress)   │
+                  │  - nginx :4101  (staging ingress)│
+                  │  - sshd  :22    (deploy access)  │
+                  └──────────────────────────────────┘
+```
+
+A single tunnel daemon serves all of:
+
+- `https://loyalty.saichon.com` → production nginx → production backend
+- `https://loyalty-dev.saichon.com` → staging nginx → staging backend
+- `ssh` via `cloudflared access ssh` → deploy SSH user → host shell
+
+When the daemon dies, **all three go dark simultaneously**.
+
+## Tunnel identity
+
+The Cloudflare account that owns this tunnel: **thehfhotel**.
+
+| Field           | Value / How to find                                   |
+| --------------- | ----------------------------------------------------- |
+| Tunnel name     | `loyalty-app-evergreen` (verify via Cloudflare UI)    |
+| Tunnel UUID     | `cat /etc/cloudflared/config.yml` on evergreen        |
+| Systemd unit    | `cloudflared.service`                                 |
+| Config file     | `/etc/cloudflared/config.yml`                         |
+| Credentials     | `/etc/cloudflared/*.json` (tunnel-secret, 0600 root)  |
+| Log destination | `journalctl -u cloudflared`                           |
+
+If you don't have shell on evergreen, the tunnel is also visible in the
+Cloudflare dashboard at **Zero Trust → Networks → Tunnels**.
+
+## Restart procedure
+
+```bash
+# 1. SSH in (this itself goes through the tunnel — see "If the tunnel is
+#    already down" below if SSH fails).
+ssh -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
+  deploy@evergreen.thehfhotel.org
+
+# 2. Confirm the daemon's state.
+sudo systemctl status cloudflared
+
+# 3. Restart cleanly.
+sudo systemctl restart cloudflared
+
+# 4. Watch logs for a fresh "Registered tunnel connection" line.
+sudo journalctl -u cloudflared -f
+```
+
+A healthy restart logs four lines of the form:
+
+```
+INF Registered tunnel connection connIndex=0 ...
+INF Registered tunnel connection connIndex=1 ...
+INF Registered tunnel connection connIndex=2 ...
+INF Registered tunnel connection connIndex=3 ...
+```
+
+(One per Cloudflare edge data center.) Anything fewer than 2 connections
+means a partial Cloudflare-side issue; anything zero means the daemon
+is broken locally.
+
+## Health verification
+
+```bash
+# From any internet-connected machine — no Cloudflare credentials needed:
+curl -fsS https://loyalty.saichon.com/api/health
+curl -fsS https://loyalty-dev.saichon.com/api/health
+
+# From evergreen itself (validates the tunnel's outbound):
+cloudflared tunnel info <tunnel-uuid>
+```
+
+`tunnel info` shows the per-connection state and the last heartbeat
+timestamp.
+
+## If the tunnel is already down (and SSH-through-tunnel won't work)
+
+The deploy SSH path uses the same tunnel as user traffic — so the very
+SSH connection you'd use to restart cloudflared depends on cloudflared
+being alive. Recovery requires out-of-band access to evergreen:
+
+- **Direct SSH** (if evergreen has a public IP or a separate management
+  network): use that path to `sudo systemctl restart cloudflared`.
+- **Cloud provider serial console** (if evergreen is hosted at a cloud
+  provider that offers one): get a shell that way.
+- **Physical access** (if evergreen is on-premise).
+
+There is no second tunnel today — see "Single point of failure" below.
+
+## During a Cloudflare incident
+
+A regional Cloudflare outage (Cloudflare's `https://www.cloudflarestatus.com`
+is the source of truth) blocks both user traffic and deploys.
+
+There is no automatic fallback. The contingency is:
+
+1. Post on the status / support email channel that the app is down due
+   to an upstream Cloudflare incident.
+2. Wait. Trying to "fix" the tunnel during an upstream Cloudflare
+   incident usually just adds noise; the daemon side is fine.
+3. When Cloudflare recovers, verify the tunnel re-registered
+   automatically (`systemctl status cloudflared` on evergreen, or check
+   the Cloudflare dashboard). If it stuck in a half-state, restart it.
+
+## Cloudflare-side health notifications
+
+Enable on the Cloudflare account: **Zero Trust → Networks → Tunnels →
+<tunnel> → Configure → Notifications → Tunnel state alerts → email me
+on `Inactive`**.
+
+This is the cheapest available paging signal for the tunnel itself —
+it fires within a few minutes of the daemon losing all of its
+connections.
+
+## Single point of failure
+
+The tunnel is currently a SPOF. Mitigation options for after public
+launch:
+
+- Run a second cloudflared daemon on a second host with the same
+  credentials; Cloudflare load-balances across both automatically.
+- Add a Cloudflare Workers-side static fallback page for total outage.
+
+Both are out of scope for the current ops bundle. Tracked in the
+operational audit (HIGH-6 follow-up).

--- a/docs/migration-rewrite-runbook.md
+++ b/docs/migration-rewrite-runbook.md
@@ -1,0 +1,186 @@
+# Migration Rewrite Runbook
+
+When (and how) to legitimately edit an already-applied migration file.
+
+> Quick links:
+> [`backend-rust/src/db/migrations.rs`](../backend-rust/src/db/migrations.rs)
+> · [`backend-rust/migrations/`](../backend-rust/migrations/)
+> · [`docs/restore-runbook.md`](./restore-runbook.md)
+
+## TL;DR
+
+```
+1. Confirm the rewrite is schema-equivalent (no behavior change).
+2. Diff the schema before and after on a copy of prod.
+3. Add the version to `REBRIDGED_MIGRATIONS` in
+   `backend-rust/src/db/migrations.rs` with a `reason` string.
+4. Get both pieces (the SQL file and the rebridge entry) reviewed
+   together by a second pair of eyes.
+5. Verify on staging before merging to main.
+```
+
+## Background
+
+`sqlx::migrate!` stores a SHA-384 checksum of every applied migration in
+`_sqlx_migrations.checksum`. On the next startup it verifies that the
+embedded migration source matches what was applied; if the source has
+changed it refuses to proceed with:
+
+```
+migration <version> was previously applied but has been modified
+```
+
+The `bridge_modified_migration_checksums` function in
+`backend-rust/src/db/migrations.rs` is the escape hatch: when an entry
+is added to the `REBRIDGED_MIGRATIONS` array, the recorded checksum is
+silently updated to match the current source on the next boot, without
+re-running the SQL. This is dangerous if misused — the rewrite must be
+genuinely schema-equivalent.
+
+## When a rewrite is legitimate
+
+- **Canonical reconciliation**. Two long-running environments
+  (production and staging) diverged because someone hand-applied a
+  partial schema change; you're now rewriting the file to be the single
+  truth that produces the same end-state on both.
+- **Idempotence refactor**. Replacing `ADD COLUMN` with
+  `ADD COLUMN IF NOT EXISTS` so a failed deploy can retry. The
+  end-state schema is identical.
+- **Comment / whitespace cleanup**. Same SQL, prettier.
+
+## When a rewrite is **not** legitimate (do not rebridge)
+
+- Adding a new column / table / index → write a **new migration** with
+  a new timestamp.
+- Dropping or renaming a column / table → write a new migration; never
+  retroactively edit history.
+- Changing a column type → write a new migration that does the
+  conversion.
+- "Fixing" a bug in stored-procedure logic → write a new migration that
+  `CREATE OR REPLACE`s the function.
+
+If you find yourself wondering "is this safe to rebridge?", the answer
+is almost certainly no. Write a new migration.
+
+## Procedure
+
+### 1. Verify schema-equivalence on a copy of prod
+
+```bash
+# Pull a recent backup (docs/restore-runbook.md § "Pick the dump").
+# Restore into a throwaway local DB.
+psql -c 'CREATE DATABASE before_rewrite;' postgres
+psql -d before_rewrite -f /tmp/restore.sql
+
+# Capture the pre-rewrite schema.
+pg_dump --schema-only --no-owner --no-acl -d before_rewrite > /tmp/before.sql
+
+# Apply your rewritten migration to a fresh DB initialised from the
+# CURRENT migrations directory.
+createdb after_rewrite
+for f in backend-rust/migrations/*.sql; do
+  psql -d after_rewrite -v ON_ERROR_STOP=1 -f "$f"
+done
+pg_dump --schema-only --no-owner --no-acl -d after_rewrite > /tmp/after.sql
+
+# Diff. Acceptable noise: comment changes, ordering of independent
+# items, whitespace. Anything structural is a STOP.
+diff -u /tmp/before.sql /tmp/after.sql | less
+```
+
+If the diff shows any column / index / type / constraint change, your
+rewrite is **not** schema-equivalent and rebridging is unsafe.
+
+### 2. Add the rebridge entry
+
+Edit `backend-rust/src/db/migrations.rs`:
+
+```rust
+const REBRIDGED_MIGRATIONS: &[(i64, &str)] = &[
+    (
+        20260511000000,
+        "PR #215 canonical booking_slips reconciliation",
+    ),
+    // Add yours below with a one-line reason for future operators.
+    (
+        20260601120000,
+        "PR #999 idempotence refactor of booking_admin_fields",
+    ),
+];
+```
+
+The `reason` string is what shows up in staging / production startup
+logs:
+
+```
+Rebridging modified migration checksum (schema unchanged, source edited)
+  version=20260601120000  reason="PR #999 ..."
+```
+
+### 3. Regenerate the sqlx offline cache
+
+The rewritten SQL is parsed at compile time. If the rewrite changes any
+query shape, regenerate:
+
+```bash
+backend-rust/scripts/regen-sqlx-cache.sh
+git add backend-rust/.sqlx/
+```
+
+CI verifies the cache with `cargo sqlx prepare --check` — skipping this
+will fail the build.
+
+### 4. Two-piece code review
+
+The PR must include **both**:
+- the rewritten migration SQL file, and
+- the entry in `REBRIDGED_MIGRATIONS`.
+
+A reviewer cannot evaluate one without the other. PR description must
+link to the schema diff from step 1.
+
+### 5. Verify on staging before merging
+
+Push to a feature branch, open the PR, and wait for the staging deploy
+to succeed. Specifically watch for the
+`Rebridging modified migration checksum` info log in
+`Verify Staging → backend.log` (the post-merge log capture from
+`ci-build-e2e.yml`).
+
+If staging boots clean and `/api/health` returns 200, the rebridge
+worked. If staging refuses to boot with
+`migration X was previously applied but has been modified`, either:
+- the rebridge entry has a typo in the version number, or
+- staging's `_sqlx_migrations` row has a checksum that matches neither
+  the old nor new source (manual prior intervention) — investigate by
+  hand; do not "fix forward" by adding another rebridge entry.
+
+### 6. Document in the PR description and CHANGELOG
+
+```
+- migration N rewrite: <one-line reason>
+- rebridge entry added with the same `reason` string
+- schema diff (no structural changes): <link to gist / artifact>
+- staging boot log line confirming rebridge: <link>
+```
+
+## What if rebridging breaks staging
+
+`docs/rollback-runbook.md` § "Steps — code + DB rollback" is the path.
+Staging refuses to boot is a clear signal; production is gated behind a
+manual approval that should not be clicked.
+
+If you somehow merged a broken rebridge to `main` and production tried
+to apply it:
+
+1. Production startup fails before the new image takes traffic.
+2. The previous (good) image keeps running because docker compose's
+   `restart: unless-stopped` policy doesn't tear it down until the new
+   one is healthy.
+3. Roll back as in the rollback runbook, then revert the bad PR.
+
+## History
+
+| When        | Rebridged version    | Reason                                                |
+| ----------- | -------------------- | ----------------------------------------------------- |
+| 2026-05-11  | `20260511000000`     | PR #215 canonical booking_slips reconciliation        |

--- a/docs/restore-runbook.md
+++ b/docs/restore-runbook.md
@@ -1,0 +1,193 @@
+# Database Restore Runbook
+
+This document covers how to restore a production Postgres backup created
+by `.github/workflows/backup-production.yml`. The on-call operator should
+be able to follow this end-to-end without prior context.
+
+> See also: `docs/secrets-runbook.md`, `docs/rollback-runbook.md`.
+
+## What gets backed up
+
+Daily at 01:00 ICT (18:00 UTC) the `Backup Production Database` workflow:
+
+1. Streams `pg_dump` of the production loyalty DB through the same
+   cloudflared tunnel `deploy.yml` uses.
+2. Pipes the dump through `gzip -9`.
+3. Encrypts with `age` against `BACKUP_AGE_RECIPIENT` (a public key).
+4. Uploads to `s3://${BACKUP_S3_BUCKET}/daily/loyalty_pg_<ts>.sql.gz.age`.
+
+The dump uses `--no-owner --no-acl` so it can be restored into a DB
+owned by any role (matches the way `deploy.yml` provisions Postgres).
+
+## Required secrets and one-time setup
+
+Until these are configured, the workflow runs only via
+`workflow_dispatch` (the `if:` guard in `backup-production.yml` is the
+on/off switch) and the scheduled trigger is inert.
+
+| Secret                          | What it is                                       |
+| ------------------------------- | ------------------------------------------------ |
+| `BACKUP_AGE_RECIPIENT`          | Single-line `age1...` public key                 |
+| `BACKUP_S3_BUCKET`              | Bucket name                                      |
+| `BACKUP_S3_ENDPOINT`            | S3-compatible endpoint URL (empty for AWS S3)    |
+| `BACKUP_S3_REGION`              | Region (`auto` for R2, `us-east-005` for B2, …)  |
+| `BACKUP_S3_ACCESS_KEY_ID`       | Access key                                       |
+| `BACKUP_S3_SECRET_ACCESS_KEY`   | Secret key                                       |
+
+The age private key for decryption stays on the operator's machine and
+is **not** stored in GitHub. Keep it in a password manager.
+
+### 30-day retention
+
+Server-side lifecycle policy on the bucket — recommended over deleting
+inside the workflow because the workflow's IAM credentials don't need
+`DeleteObject`.
+
+- **R2**: bucket settings → Lifecycle rules → expire after 30 days
+  under `daily/`.
+- **AWS S3**: bucket → Management → Lifecycle rule → `daily/` prefix →
+  Expire current versions after 30 days.
+- **Backblaze B2**: bucket → Lifecycle settings → `daily/` → hide after
+  30 days.
+
+## Restoring from backup
+
+### 1. Pick the dump
+
+```bash
+aws --endpoint-url "$BACKUP_S3_ENDPOINT" s3 ls "s3://$BACKUP_S3_BUCKET/daily/"
+# loyalty_pg_20260513T180001Z.sql.gz.age
+```
+
+Download a specific dump:
+
+```bash
+aws --endpoint-url "$BACKUP_S3_ENDPOINT" s3 cp \
+  "s3://$BACKUP_S3_BUCKET/daily/loyalty_pg_20260513T180001Z.sql.gz.age" \
+  /tmp/restore.sql.gz.age
+```
+
+### 2. Decrypt and decompress locally
+
+```bash
+age --decrypt --identity ~/.age/loyalty-backup.key \
+  /tmp/restore.sql.gz.age > /tmp/restore.sql.gz
+gunzip /tmp/restore.sql.gz
+# /tmp/restore.sql is now plain SQL — handle as sensitive data.
+```
+
+### 3. Stop the backend (drains in-flight writes)
+
+Graceful shutdown (PR adding this runbook) ensures in-flight requests
+complete before the container exits.
+
+```bash
+ssh -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
+  deploy@evergreen.thehfhotel.org \
+  'docker stop loyalty_backend_production'
+```
+
+### 4. Restore the dump
+
+Drop and recreate the DB inside the Postgres container, then `psql` the
+dump in.
+
+```bash
+ssh -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
+  deploy@evergreen.thehfhotel.org bash -s <<'REMOTE'
+  set -euo pipefail
+  docker exec -i loyalty_postgres_production psql -U "$POSTGRES_USER" -d postgres <<SQL
+    DROP DATABASE IF EXISTS "${POSTGRES_DB}_restore";
+    CREATE DATABASE "${POSTGRES_DB}_restore";
+SQL
+REMOTE
+
+# Pipe the local SQL file into the remote postgres container
+ssh -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
+  deploy@evergreen.thehfhotel.org \
+  "docker exec -i loyalty_postgres_production psql -U \"\$POSTGRES_USER\" -d \"\${POSTGRES_DB}_restore\"" \
+  < /tmp/restore.sql
+```
+
+### 5. Verify the restored data
+
+```bash
+ssh ... 'docker exec loyalty_postgres_production psql -U "$POSTGRES_USER" \
+  -d "${POSTGRES_DB}_restore" -c "SELECT COUNT(*) FROM users;"'
+```
+
+Spot-check a few tables (`users`, `bookings`, `points_transactions`,
+`booking_audit_log`) match the row counts you expect for the backup date.
+
+### 6. Promote the restored DB
+
+Only after verification. This is irreversible without another restore.
+
+```sql
+-- inside `docker exec -it loyalty_postgres_production psql -U "$POSTGRES_USER" -d postgres`
+ALTER DATABASE "${POSTGRES_DB}"          RENAME TO "${POSTGRES_DB}_pre_restore";
+ALTER DATABASE "${POSTGRES_DB}_restore"  RENAME TO "${POSTGRES_DB}";
+```
+
+### 7. Bring the backend back up
+
+```bash
+ssh ... 'docker start loyalty_backend_production'
+
+# Wait for the embedded healthcheck binary to report healthy
+curl -fsS https://loyalty.saichon.com/api/health
+```
+
+### 8. Clean up
+
+After ~24 hours of healthy production, drop the safety copy:
+
+```sql
+DROP DATABASE "${POSTGRES_DB}_pre_restore";
+```
+
+## Combining restore with a code rollback
+
+The current `sqlx::migrate!` design is forward-only — no
+down-migrations. If you also need to roll back code past the last
+applied migration, **restore the DB first**, then deploy the prior
+image SHA. See `docs/rollback-runbook.md` for the code rollback path.
+
+## Restore drill log
+
+Document each restore drill here so the next operator can see when this
+was last exercised.
+
+| Date       | Operator | Backup restored                          | Notes                |
+| ---------- | -------- | ---------------------------------------- | -------------------- |
+| _pending_  | _name_   | _e.g. loyalty_pg_20260513T180001Z._      | First drill required |
+
+> **Pre-launch action**: perform one full end-to-end restore drill into
+> a throwaway database before flipping the public switch. Record the
+> result in this table.
+
+## Troubleshooting
+
+### `age: failed to decrypt: no identity matched any of the recipients`
+
+The `BACKUP_AGE_RECIPIENT` used at backup time doesn't match the
+identity you passed to `age --decrypt`. Confirm the public key in the
+GitHub secret matches the private key you have.
+
+### `aws: command not found`
+
+```bash
+brew install awscli            # macOS
+sudo apt-get install awscli    # Debian/Ubuntu
+```
+
+### `psql: error: connection to server ... password authentication failed`
+
+`POSTGRES_USER` / `POSTGRES_PASSWORD` env vars on the remote shell
+don't match what's currently in the running container's `.env`. SSH in
+and `cat /srv/.../.env | grep POSTGRES`.
+
+### Dump is empty / `0 bytes`
+
+The backup workflow includes a `< 1024 bytes` sanity check. If a dump
+gets that small in production, investigate before relying on it.

--- a/docs/rollback-runbook.md
+++ b/docs/rollback-runbook.md
@@ -1,0 +1,200 @@
+# Rollback Runbook
+
+How to roll the production deploy back to a previous image when something
+is wrong and the next push to `main` won't fix it fast enough.
+
+> See also: `docs/restore-runbook.md` (DB restore),
+> `docs/cloudflare-tunnel-runbook.md` (tunnel-side recovery),
+> `docs/secrets-runbook.md` (env-injection details).
+
+## Overview
+
+`.github/workflows/deploy.yml` ships GHCR images tagged with the commit
+SHA (`ghcr.io/thehfhotel/loyalty-app/backend:<sha>`). A rollback is
+"redeploy a previous `<sha>` image to evergreen using the same SSH-to-
+evergreen path the deploy workflow already takes."
+
+**Critical constraint**: `sqlx::migrate!` is forward-only. There are no
+down-migrations. If you roll the code back past the last applied
+migration, the older code will hit columns/tables/types it doesn't
+understand and will misbehave or crash. The decision tree below is the
+guard.
+
+## Decision tree
+
+```
+Did the bad commit add or alter a schema element
+(new column, new table, dropped column, type change)?
+│
+├── YES → Code rollback alone is unsafe.
+│         Roll BOTH the DB (docs/restore-runbook.md) and the code.
+│
+└── NO  → Code rollback is safe.
+          Proceed to "Steps" below.
+```
+
+Migrations are listed under `backend-rust/migrations/`. The bad commit
+either:
+- changed nothing under `migrations/` → safe to roll back code only.
+- added a new file under `migrations/` → roll back both (code + DB).
+- modified an applied migration → see `docs/migration-rewrite-runbook.md`;
+  this is a separate path and rollback requires DB restore.
+
+## Steps — code-only rollback
+
+### 1. Identify the last-known-good SHA
+
+```bash
+# Recent CI builds against main, with conclusion + commit SHA:
+gh run list -R thehfhotel/loyalty-app \
+  --workflow=ci-build-e2e.yml --branch=main \
+  --json conclusion,headSha,createdAt,displayTitle --limit 20
+
+# Pick the most recent "success" row whose displayTitle predates the
+# regression. Note its headSha (full 40 chars).
+```
+
+Sanity-check that the chosen SHA also has a green `ci-test.yml` for
+the same commit (frontend lint + unit tests):
+
+```bash
+gh run list -R thehfhotel/loyalty-app \
+  --workflow=ci-test.yml --branch=main --commit=<sha> \
+  --json conclusion
+```
+
+### 2. Confirm the GHCR images exist for that SHA
+
+```bash
+gh api repos/thehfhotel/loyalty-app/packages/container/loyalty-app%2Fbackend/versions \
+  --jq '.[] | select(.metadata.container.tags | index("<sha>"))'
+
+gh api repos/thehfhotel/loyalty-app/packages/container/loyalty-app%2Ffrontend/versions \
+  --jq '.[] | select(.metadata.container.tags | index("<sha>"))'
+```
+
+Both should return a non-empty result. If the image was garbage-collected
+by GHCR retention, use a more recent green SHA.
+
+### 3. Trigger redeploy
+
+Two options.
+
+**Option A — re-run the previous green deploy**: the simplest path. Find
+the previous green production `Deploy` run, click "Re-run jobs". GitHub
+will redeploy the same SHA without rebuilding.
+
+```bash
+gh run list -R thehfhotel/loyalty-app --workflow=deploy.yml \
+  --json status,conclusion,headSha,databaseId --limit 10
+gh run rerun <database_id> -R thehfhotel/loyalty-app
+```
+
+**Option B — manual SSH redeploy** (when re-run isn't available): mirror
+the `deploy.yml` env-injection block by hand. You need the `DATABASE_URL`,
+JWT/Session/Postgres secrets in your shell. See `docs/secrets-runbook.md`
+section "Manual production deployment (recovery only)" for the secret
+list and the `docker compose -f ... up -d` invocation. Set
+`IMAGE_TAG=<previous-sha>` (override in the `.env`) before bringing the
+stack up so it pulls the prior image instead of `:latest`.
+
+### 4. Approve the production environment
+
+The `deploy-production` job is gated by the `production` GitHub
+environment, which requires a human approver. The approver should:
+
+- Confirm the SHA matches the last-known-good identified above.
+- Confirm there were no migrations added between the bad and good SHAs.
+- Click **Review deployments → Approve and deploy**.
+
+### 5. Verify
+
+```bash
+curl -fsS https://loyalty.saichon.com/api/health
+# Expect HTTP 200 with a JSON body that mentions postgres + redis healthy.
+```
+
+Spot-check the obvious user paths: `/`, login, recent booking page,
+admin dashboard. The post-deploy `Verify Staging` workflow does **not**
+re-run for a manual redeploy — health-check production manually here.
+
+### 6. Open a follow-up issue for the bad commit
+
+Document what regressed so the on-call who took the call has a written
+record, and to prevent re-introduction:
+
+```bash
+gh issue create -R thehfhotel/loyalty-app \
+  --title "regression: rolled back <bad-sha>" \
+  --body "Symptoms / impact / rolled-back-from <bad-sha> / rolled-back-to <good-sha>"
+```
+
+## Steps — code + DB rollback
+
+Use this when the bad commit added or altered a schema element.
+
+1. **Stop the backend** to drain in-flight writes:
+   ```bash
+   ssh ... 'docker stop loyalty_backend_production'
+   ```
+2. **Restore the DB** to a snapshot from before the bad migration was
+   applied (`docs/restore-runbook.md` § "Restoring from backup",
+   steps 1–6, choose a dump whose timestamp predates the bad deploy).
+3. **Redeploy the prior image** as in "code-only rollback" steps 1–4
+   above.
+4. **Verify** as in step 5 above.
+
+> **Caveat**: any application data written between the bad-deploy moment
+> and the rollback is lost. That tradeoff is usually correct vs. running
+> on a corrupt schema, but document the cutoff timestamp in the
+> follow-up issue.
+
+## Who can approve production when the primary approver is unreachable
+
+The `production` GitHub environment defines the required reviewer list
+in repository settings (Settings → Environments → production →
+Deployment branches and tags / Required reviewers). Backup approvers
+must be listed there ahead of time — there is no "break-glass" override
+in the GitHub UI.
+
+If the listed approvers are all unreachable:
+
+1. A repo admin can temporarily add themselves to the required reviewer
+   list at Settings → Environments → production → Required reviewers.
+2. Approve the deploy.
+3. Restore the original reviewer list immediately afterward.
+4. Document the override in the post-incident issue.
+
+## Manual SSH-to-evergreen recovery (last resort)
+
+If GitHub Actions itself is down, you can still redeploy by hand. The
+flow `deploy.yml` runs over SSH is:
+
+```bash
+# On your workstation (the cloudflared binary must be installed):
+ssh -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
+  deploy@evergreen.thehfhotel.org
+
+# Then on evergreen, inside the deploy directory, edit .env to set
+# COMMIT_SHA / IMAGE_TAG to the previous-green SHA, then:
+docker compose -f docker-compose.yml -f docker-compose.ghcr.yml \
+  -f docker-compose.prod.yml pull backend frontend
+docker compose -f docker-compose.yml -f docker-compose.ghcr.yml \
+  -f docker-compose.prod.yml up -d
+```
+
+The exact deploy directory and `.env` path are not committed (they live
+on the host). Look at `/srv/run-deploy-loyalty-app-prod.sh` on evergreen
+for the canonical invocation.
+
+## Dry-run
+
+Before relying on this runbook in an incident, perform one dry-run
+rollback against staging:
+
+1. Identify the previous-green staging deploy SHA.
+2. Trigger `Re-run jobs` on it.
+3. Confirm `loyalty-dev.saichon.com` serves traffic correctly afterward.
+4. Note the date in `docs/restore-runbook.md` § "Restore drill log".
+
+Last dry-run: _pending — perform before public launch_.

--- a/docs/secrets-runbook.md
+++ b/docs/secrets-runbook.md
@@ -28,6 +28,22 @@ The following GitHub Actions secrets are expected to be configured under
 
 > Translation services are currently disabled. Azure translator secrets are not required unless that feature is re-enabled.
 
+### Backup secrets (workflow: `.github/workflows/backup-production.yml`)
+
+These are required to enable the daily Postgres backup workflow. Until
+they are wired, the scheduled trigger is inert (guarded by an `if:`
+condition in the workflow). See [`restore-runbook.md`](./restore-runbook.md)
+for end-to-end setup, retention policy, and the restore drill.
+
+| Secret                          | Description                                          |
+| ------------------------------- | ---------------------------------------------------- |
+| `BACKUP_AGE_RECIPIENT`          | `age1...` public key for dump encryption             |
+| `BACKUP_S3_BUCKET`              | S3-compatible bucket name                            |
+| `BACKUP_S3_ENDPOINT`            | Endpoint URL (empty for AWS S3, set for R2 / B2)     |
+| `BACKUP_S3_REGION`              | Region string (`auto` for R2, `us-east-005` for B2)  |
+| `BACKUP_S3_ACCESS_KEY_ID`       | Access key with `PutObject` on the bucket            |
+| `BACKUP_S3_SECRET_ACCESS_KEY`   | Secret access key                                    |
+
 ### Inspecting and updating secrets
 
 ```bash

--- a/scripts/backup-production.sh
+++ b/scripts/backup-production.sh
@@ -22,6 +22,13 @@ BACKUP_TYPE="full"
 COMPRESS_BACKUP=false
 BACKUP_DIR="$PROJECT_ROOT/backups"
 
+# Database credentials — read from env vars so this script works against
+# either the legacy `loyalty:loyalty_db` defaults or the current GHCR
+# deploy (which uses POSTGRES_USER/POSTGRES_DB injected from GitHub
+# secrets). Fail loudly if neither is set in a production-like environment.
+PG_USER="${POSTGRES_USER:-${PGUSER:-loyalty}}"
+PG_DB="${POSTGRES_DB:-${PGDATABASE:-loyalty_db}}"
+
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -116,7 +123,7 @@ DB_BACKUP_FILE="$BACKUP_PATH/database_${TIMESTAMP}.sql"
 
 if docker compose ps postgres | grep -q "Up"; then
     # Database is running - use pg_dump
-    if docker compose exec -T postgres pg_dump -U loyalty loyalty_db > "$DB_BACKUP_FILE"; then
+    if docker compose exec -T postgres pg_dump -U "$PG_USER" "$PG_DB" > "$DB_BACKUP_FILE"; then
         success "✅ Database backup created: $(basename "$DB_BACKUP_FILE")"
         
         # Get database stats
@@ -276,7 +283,8 @@ echo "   Total backups in directory: $BACKUP_COUNT"
 echo "   Backup directory: $BACKUP_DIR"
 echo
 echo "🔄 Restore Instructions:"
-echo "   Database: docker compose exec -T postgres psql -U loyalty -d loyalty_db < database_*.sql"
+echo "   Database: docker compose exec -T postgres psql -U \"\$PG_USER\" -d \"\$PG_DB\" < database_*.sql"
+echo "             (set POSTGRES_USER and POSTGRES_DB env vars to match the deploy)"
 if [[ "$COMPRESS_BACKUP" == "true" ]]; then
     echo "   Extract: tar xzf ${BACKUP_NAME}.tar.gz"
 fi


### PR DESCRIPTION
Bundles the OPS INFRA fixes from the 2026-05-13 operational audit (plus the correctness HIGH on startup-error anyhow chains). Nine commits, each shippable on its own.

Findings addressed:
- **Operational CRIT-1, CRIT-2, CRIT-3** (backups, alerting, graceful shutdown)
- **Operational HIGH-1, HIGH-2, HIGH-3, HIGH-6** (verify-staging log capture, container resource limits, rollback runbook, tunnel runbook)
- **Operational MED-2, MED-3, MED-4** (JSON logs, request IDs, migration-rewrite runbook)
- **Correctness HIGH** — startup error logs drop the anyhow cause chain (six call sites)

Findings deliberately deferred (not in this bundle):
- **HIGH-4** runtime metrics / Prometheus — multi-day project, separate bundle.
- **HIGH-5** booking_audit_log retention — schema agent's bundle.
- **MED-1** healthcheck binary endpoint — verify-once, no code change needed in this bundle.
- **MED-5, MED-6, LOW-1/2/3** — out of scope per task spec.

## Commits

### 1. `feat(server): graceful shutdown on SIGTERM/SIGINT`
Wires `axum::serve(...).with_graceful_shutdown(...)` to a `tokio::select!` race between `tokio::signal::ctrl_c()` and the Unix `SIGTERM` so in-flight requests (slip uploads, SSE long-polls, password hashing) finish before the runtime exits. Adds `signal` to the `tokio` feature list. Closes the db pool with a 25s bound after the serve future resolves. **(CRIT-3)**

### 2. `fix(startup): surface anyhow cause chain in startup error logs`
Six startup error sites (`main.rs:52,67,85,104,112,125` per the audit) now use `error!("...: {:#}", e)` instead of `{}`, exposing the underlying sqlx / dotenvy / io error chain. PR #228 fixed `run_migrations` only; this completes the pattern. **(Correctness HIGH)**

### 3. `feat(ops): daily encrypted Postgres backups to S3-compatible storage`
New `.github/workflows/backup-production.yml`: SSHes through the existing cloudflared tunnel, streams `pg_dump | gzip -9` to the runner, encrypts with `age`, uploads to S3-compatible storage (S3 / R2 / Backblaze B2). Daily at 18:00 UTC + manual dispatch. `scripts/backup-production.sh` now reads `POSTGRES_USER` / `POSTGRES_DB` from env. New `docs/restore-runbook.md` covers the download → decrypt → restore → promote flow plus a drill log. **(CRIT-1)**

> **Caveat**: requires `BACKUP_S3_*` and `BACKUP_AGE_RECIPIENT` secrets. The schedule trigger is guarded with `if: github.event_name == 'workflow_dispatch'` until those land. Secret list documented in `docs/secrets-runbook.md` and `docs/restore-runbook.md`.

### 4. `feat(ci): file GitHub issues on cargo-audit, verify-staging, and prod-deploy failure`
Three `if: failure()` notify jobs that file (or comment on) a GitHub issue when the workflows go red. The cargo-audit workflow already had `issues: write` per a TODO comment. No external secrets required to ship — Slack / email channels can be layered in later via a single step that consumes a webhook secret. **(CRIT-2)**

### 5. `feat(ci): capture staging backend logs on Verify Staging failure`
On failure of the `verify-staging` health poll, the job now SSHes back through cloudflared to evergreen and captures `docker ps` + `docker logs` for `loyalty_backend_dev`, postgres, nginx. Uploaded as a 14-day-retention artifact. Each remote command is `|| true`-guarded. **(HIGH-1)**

### 6. `feat(compose): conservative resource limits on production containers`
Adds `cpus:` and `mem_limit:` keys (non-swarm syntax, not `deploy.resources.limits` which is silently ignored for compose). Starting numbers: backend 1c/512m, frontend 0.5c/128m, postgres 2c/2g, redis 0.5c/256m, nginx 0.25c/64m. **(HIGH-2)**

### 7. `docs(ops): rollback, cloudflare tunnel, and migration-rewrite runbooks`
Three new runbooks plus a CLAUDE.md cross-link to migration-rewrite. Rollback runbook includes the migration-aware decision tree, last-known-good SHA identification, manual SSH recovery, and approver-fallback procedure. **(HIGH-3, HIGH-6, MED-4)**

### 8. `feat(logging): JSON-line output in non-development environments`
`init_tracing()` reads `RUST_ENV` / `NODE_ENV` directly (it runs before `Settings::new()`) and emits `.json()` formatted log lines in staging / production. Dev terminal output is unchanged. **(MED-2)**

### 9. `feat(observability): propagate x-request-id and include it in trace spans`
`SetRequestIdLayer` (v4 UUID) + `PropagateRequestIdLayer` + a custom `make_span_with` that threads the request ID onto every `http_request` span. Inbound `x-request-id` headers are passed through; otherwise one is generated and echoed back. Enables `tower-http` features `request-id` and `util`. Layer-ordering rationale documented inline. **(MED-3)**

## Test plan

Runtime changes (commits 1, 2, 8, 9):
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --lib --bins` → 397 + 12 tests pass
- [x] `cargo sqlx prepare --check` clean
- [x] `cargo build --bin loyalty-backend` produces a binary

Workflow changes (commits 3, 4, 5):
- [x] All YAML parses cleanly (`python3 -c 'yaml.safe_load(...)'`)
- [ ] **Dry-run by a maintainer**: trigger `Backup Production Database` via `workflow_dispatch` to validate the secret-missing failure path is clear (since `BACKUP_*` are not yet wired, the validation step at the top of the job will fail cleanly).
- [ ] **Dry-run**: trigger any workflow with `gh workflow run` and confirm the notify-on-failure job stays inert when the parent succeeds.

Compose change (commit 6):
- [x] `docker compose ... config` would parse the file (yaml validated; couldn't run `docker compose` on the dev box without docker)
- [ ] **After merge / staging deploy**: confirm `docker stats` on evergreen shows the new caps applied.

Docs (commit 7):
- [x] Markdown reads cleanly; cross-links between runbooks point to existing files.

## Caveats / follow-ups

- **Backup workflow needs secrets before the schedule fires.** Until `BACKUP_*` are configured, the schedule trigger is inert by the `if:` guard. Secret list lives in `docs/secrets-runbook.md` and `docs/restore-runbook.md`.
- **Slack / email notification** is not wired — the notify-on-failure jobs file GitHub issues only. Adding a Slack step is a one-line drop-in once `OPS_ALERT_SLACK_WEBHOOK` secret lands.
- **Auto-rollback on verify-staging failure** is not in this PR — too much surface for one bundle. The captured artifact (commit 5) gives the operator what they need to call the rollback manually.
- **Restore drill** still pending — the runbook documents the procedure; perform it once before public launch and note the date in the runbook's drill-log table.
- **HIGH-4 (runtime metrics)** is a multi-day project deliberately out of scope. Flag for a future bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)