### PR TITLE
fix(security): bump frontend nginx:alpine digest to clear Alpine CVEs

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -52,7 +52,7 @@ RUN test -f dist/index.html && \
 # =============================================================================
 # STAGE 3: Production runtime (nginx - minimal)
 # =============================================================================
-FROM nginx:alpine@sha256:c083c3799197cfff91fe5c3c558db3d2eea65ccbbfd419fa42a64d2c39a24027 AS production
+FROM nginx:alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a AS production
 
 # Update packages to fix CVEs (e.g., CVE-2025-62408 in c-ares)
 RUN apk upgrade --no-cache


### PR DESCRIPTION
Trivy's post-build image scan started firing after the `trivy.yml` workflow_run trigger was fixed in #259, and surfaced fixable Alpine package CVEs in the frontend (`nginx:alpine`) image — previously never scanned:

- **HIGH** CVE-2026-6732 — `libxml2` 2.13.9-r0 → **2.13.9-r1**
- MEDIUM/LOW CVE-2025-14017 / 14524 / 14819, CVE-2026-1965 / 3783 / 3784 / 3805 — `curl`/`libcurl` 8.17.0-r1 → **8.19.0-r0**
- MEDIUM CVE-2026-40930 — `libpng` 1.6.57-r0 → **1.6.58-r1**

All have fixed versions in newer Alpine packages; bumping the pinned `nginx:alpine` digest (`c083…` → `8b1e…`) pulls the patched packages. The backend distroless base-OS CVEs (libc6/gcc/libssl3) have no upstream fix and were dismissed as won't-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)