### PR TITLE
docs: fix stale async-imap references after dep removal

### DIFF
--- a/backend-rust/src/routes/admin_email.rs
+++ b/backend-rust/src/routes/admin_email.rs
@@ -17,12 +17,12 @@
 //!   EHLO/STARTTLS/AUTH handshake via `lettre::AsyncSmtpTransport::test_connection`
 //!   and tears down. Reflects authentication and TLS state, not just config.
 //! - **IMAP** — **only a configured-state check**. There is no IMAP client
-//!   wired into this backend yet. The `async-imap` crate is listed in
-//!   `Cargo.toml` but never imported; shipping a "probe" would mean
-//!   building an `ImapService` trait + impl from scratch (parallel to
-//!   `EmailService`), which deserves its own PR. The response field is
-//!   reported as `imapConnected: true` if `IMAP_HOST/USER/PASS` are all
-//!   set and `false` otherwise. The status object also returns
+//!   wired into this backend yet; shipping a "probe" would mean building an
+//!   `ImapService` trait + impl from scratch (parallel to `EmailService`)
+//!   and re-adding an IMAP client crate, which deserves its own PR. The
+//!   response field is reported as `imapConnected: true` if
+//!   `IMAP_HOST/USER/PASS` are all set and `false` otherwise. The status
+//!   object also returns
 //!   `imapProbed: false` so the frontend (and an operator reading the
 //!   JSON) knows this is a declarative check, not a live probe.
 //! - **End-to-end SMTP→IMAP loopback test** — explicitly NOT implemented.

--- a/docs/admin-backend-gaps.md
+++ b/docs/admin-backend-gaps.md
@@ -174,11 +174,10 @@ Used by `EmailServicePage.tsx` (Settings → Email Service).
 
 ### Skipped in misc batch
 
-- **IMAP live probe** for `GET /email/status` — the `async-imap` crate
-  is already in `Cargo.toml` but unused; building a probe needs a new
-  `ImapService` trait + impl (parallel to `EmailService`) and live
-  IMAP test infrastructure to exercise it. Kept out of this PR to
-  bound scope. The endpoint reports `imapConnected` based on whether
+- **IMAP live probe** for `GET /email/status` — building a probe needs a
+  new `ImapService` trait + impl (parallel to `EmailService`), a re-added
+  IMAP client crate, and live IMAP test infrastructure to exercise it.
+  Kept out of scope. The endpoint reports `imapConnected` based on whether
   `IMAP_HOST/USER/PASS` are set, and exposes `imapProbed: false` so
   the frontend can distinguish "configured-but-unprobed" from
   "probed-and-healthy".


### PR DESCRIPTION
Follow-up to #261. That PR removed the unused `async-imap` crate, but two docs still referenced it as "listed in Cargo.toml":
- `backend-rust/src/routes/admin_email.rs` module doc
- `docs/admin-backend-gaps.md`

Updated both to say a future IMAP probe would *re-add* an IMAP client crate. No behavior change. The `IMAP_*` env / `ImapConfig::is_configured()` check remains live (it backs the admin email-status endpoint's `imapConnected` field), so the IMAP env injection in the deploy workflows is **not** dead and was left intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)