### PR TITLE
chore: launch-readiness hardening (backups, prod gate, metrics)

### DIFF
--- a/.github/workflows/backup-production.yml
+++ b/.github/workflows/backup-production.yml
@@ -30,10 +30,11 @@ name: Backup Production Database
 #   - BACKUP_S3_ACCESS_KEY_ID     (new)
 #   - BACKUP_S3_SECRET_ACCESS_KEY (new)
 #
-# Until BACKUP_* secrets are wired, the schedule trigger is disabled and
-# only manual `workflow_dispatch` runs (which fail at the upload step with
-# a clear error). See docs/restore-runbook.md for the secret-wiring
-# follow-up checklist.
+# The daily schedule is always enabled. Until the BACKUP_* secrets are wired
+# the `backup` job is cleanly SKIPPED (a green no-op with a notice) by the
+# `check-config` gate below — no nightly failures — and it starts running
+# automatically the moment the secrets land. See docs/restore-runbook.md for
+# the secret-wiring follow-up checklist.
 
 on:
   schedule:
@@ -51,33 +52,38 @@ permissions:
   actions: read
 
 jobs:
-  backup:
-    name: "Backup Production DB"
+  # Gate the backup on whether the BACKUP_* secrets exist. This lets the daily
+  # schedule stay enabled: until the secrets are wired the backup job is
+  # skipped (a green no-op with a notice) instead of failing every night, and
+  # the moment the secrets land the daily backup starts running on its own.
+  check-config:
+    name: "Check backup config"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    # Disable the schedule trigger until BACKUP_* secrets are wired. Manual
-    # workflow_dispatch runs are still allowed so the operator who wires
-    # secrets can sanity-check the path immediately.
-    #
-    # TODO: flip this guard to a `BACKUP_S3_BUCKET != ''` check once
-    # secrets land.
-    if: github.event_name == 'workflow_dispatch'
-
+    timeout-minutes: 5
+    outputs:
+      configured: ${{ steps.check.outputs.configured }}
     steps:
-      - name: Validate required secrets are configured
+      - name: Detect backup secrets
+        id: check
         env:
           BACKUP_S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET }}
           BACKUP_AGE_RECIPIENT: ${{ secrets.BACKUP_AGE_RECIPIENT }}
         run: |
-          set -euo pipefail
-          missing=()
-          [ -z "${BACKUP_S3_BUCKET:-}" ] && missing+=("BACKUP_S3_BUCKET")
-          [ -z "${BACKUP_AGE_RECIPIENT:-}" ] && missing+=("BACKUP_AGE_RECIPIENT")
-          if [ ${#missing[@]} -gt 0 ]; then
-            echo "::error::Missing required secrets: ${missing[*]}. See docs/restore-runbook.md."
-            exit 1
+          if [ -n "${BACKUP_S3_BUCKET:-}" ] && [ -n "${BACKUP_AGE_RECIPIENT:-}" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Backup secrets not configured yet — skipping backup. Wire BACKUP_* secrets (see docs/restore-runbook.md) to enable daily backups."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
           fi
 
+  backup:
+    name: "Backup Production DB"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: [check-config]
+    if: needs.check-config.outputs.configured == 'true'
+
+    steps:
       - name: Install age (encryption) and AWS CLI v2
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project are tracked here. Format roughly follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions are dated
 because the project ships from `main` without semver tags.
 
+## 2026-06-07 — launch-readiness hardening
+
+### `chore`: backup auto-activation, prod approval gate, Prometheus metrics
+
+In-repo follow-ups from the public-launch readiness review:
+
+- **Backups now self-activate** — `backup-production.yml`'s daily schedule is
+  always enabled; a `check-config` gate makes the backup job cleanly skip (a
+  green no-op with a notice) until the `BACKUP_*` secrets are wired, then it
+  starts running on its own the moment they land. No more nightly failures
+  while secrets are pending, and no code change needed at wiring time.
+- **Production approval gate** — the `production` GitHub environment now has a
+  required reviewer, so `deploy.yml` pauses for manual approval before each
+  prod deploy (previously it auto-deployed on green CI).
+- **Runtime metrics** — added `axum-prometheus`; the backend now exposes
+  request-rate / latency-histogram / in-flight metrics at top-level
+  `GET /metrics`. It's internal-only by construction (nginx proxies only
+  `/api` + `/storage`, so `/metrics` is reachable on the Docker network for a
+  Prometheus scrape but never publicly) and is excluded from the rate limiter
+  and from its own measurement. Wiring an actual Prometheus/Grafana (or a
+  hosted agent) against it remains an ops step.
+
 ## 2026-06-07 — dead-code cleanup
 
 ### `chore`: remove dead code across backend, frontend, and tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,11 +135,11 @@ Workflows fire on push to `main`:
 
 Production deploys live in `deploy.yml`, `workflow_run`-triggered after
 CI Build & Deploy + CI Tests succeed for the commit, and gated by the
-`production` GitHub environment. To require manual sign-off, add required
-reviewers to that environment (see
-[`docs/production-approval-checklist.md`](docs/production-approval-checklist.md));
-with no reviewers configured the deploy proceeds automatically once both
-CI workflows are green.
+`production` GitHub environment, which has a **required reviewer** — the
+deploy pauses for manual approval before it runs (walk
+[`docs/production-approval-checklist.md`](docs/production-approval-checklist.md)
+before approving). Manage the approver list in Settings → Environments →
+`production`.
 
 Public-launch readiness — the state of every audit follow-up tied to
 flipping the public switch — is tracked in

--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -242,6 +242,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-prometheus"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739e2585f5376f5bdd129324ded72d3261fdd5b7c411a645920328fb5dc875d4"
+dependencies = [
+ "axum",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "matchit",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "once_cell",
+ "pin-project",
+ "tokio",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1860,6 +1890,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
+ "axum-prometheus",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -1941,6 +1972,51 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "metrics"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3045b4193fbdc5b5681f32f11070da9be3609f189a79f3390706d42587f46bb5"
+dependencies = [
+ "ahash 0.8.12",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -2419,6 +2495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2647,21 @@ name = "qrcode"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
 
 [[package]]
 name = "quick-error"
@@ -2717,6 +2814,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -3329,6 +3435,12 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
@@ -4547,6 +4659,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4554,6 +4682,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -87,6 +87,7 @@ once_cell = "1"
 # OpenAPI documentation
 utoipa = { version = "4", features = ["axum_extras", "uuid", "chrono", "yaml"] }
 utoipa-swagger-ui = { version = "6", features = ["axum"] }
+axum-prometheus = "0.7"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/backend-rust/src/routes/mod.rs
+++ b/backend-rust/src/routes/mod.rs
@@ -141,7 +141,24 @@ pub fn create_router(state: AppState) -> Router {
         None => app,
     };
 
+    // Prometheus metrics. The layer measures every API request defined above
+    // (request count, in-flight, and latency histograms by path/method/status).
+    // The `/metrics` endpoint is added AFTER the layer so it is neither
+    // measured nor rate-limited, and it lives at the top level — nginx only
+    // proxies `/api` and `/storage` to the backend, so `/metrics` is reachable
+    // only inside the Docker network (e.g. a Prometheus sidecar scraping
+    // `backend:4001/metrics`), never from the public internet.
+    let (prometheus_layer, metric_handle) = axum_prometheus::PrometheusMetricLayer::pair();
+
     app.layer(Extension(jwt_secret))
+        .layer(prometheus_layer)
+        .route(
+            "/metrics",
+            axum::routing::get(move || {
+                let handle = metric_handle.clone();
+                async move { handle.render() }
+            }),
+        )
 }
 
 #[cfg(test)]

--- a/docs/public-launch-readiness.md
+++ b/docs/public-launch-readiness.md
@@ -8,6 +8,7 @@ next one is due ~90 days after the first public traffic).
 
 Legend:
 - `[x]` — landed and verified in repo / live
+- `[~]` — partially landed (repo half done; an out-of-repo step remains)
 - `[ ]` — open, with the audit finding ID it closes when ticked
 
 ## Operational baseline
@@ -83,7 +84,10 @@ Legend:
   `BACKUP_S3_BUCKET`, `BACKUP_S3_ENDPOINT`, `BACKUP_S3_REGION`,
   `BACKUP_S3_ACCESS_KEY_ID`, `BACKUP_S3_SECRET_ACCESS_KEY` (see
   [`docs/secrets-runbook.md`](secrets-runbook.md#backup-secrets-workflow-githubworkflowsbackup-productionyml)).
-  Without these the daily backup workflow is inert.
+  The daily schedule is now always enabled and the backup job auto-skips
+  (a green no-op) until these secrets exist, then starts running on its
+  own the moment they land — so this row needs only the secret wiring, no
+  further code change.
 - [ ] **Restore drill performed once** (CRIT-1 closure) — follow
   [`docs/restore-runbook.md`](restore-runbook.md) against staging.
   Document the date and the restored DB size in the runbook so the
@@ -130,12 +134,15 @@ Legend:
 
 ## After the first 30 days
 
-- [ ] **Runtime metrics / dashboard** (HIGH-4) — currently no
-  request rate / error rate / p99 visibility outside `tracing` logs.
-  `axum-prometheus` + a small Prometheus on evergreen + a static
-  Grafana dashboard is the cheapest baseline; a hosted alternative
-  (Better Stack, Honeycomb) is the lower-effort path. Decide based
-  on actual traffic and budget.
+- [~] **Runtime metrics / dashboard** (HIGH-4) — backend half **done**:
+  `axum-prometheus` exposes request-rate / latency-histogram / in-flight
+  metrics at `GET /metrics` (top-level, internal-only — nginx proxies
+  only `/api` + `/storage`, so the endpoint is reachable on the Docker
+  network for a scrape but never publicly). **Still open**: run a
+  Prometheus on evergreen (scrape `backend:4001/metrics`) + a static
+  Grafana dashboard, or point a hosted agent (Better Stack, Honeycomb)
+  at it. There's no request-rate/error-rate/p99 *dashboard* until that
+  scraper is wired.
 - [ ] **`booking_audit_log` retention partitioning** (HIGH-5) —
   if disk pressure emerges, range-partition by `occurred_at` (year)
   so old partitions can be detached cheaply.


### PR DESCRIPTION
In-repo follow-ups from the "ready for real users?" review (capacity is fine for ~50 concurrent; these close operational gaps).

### 1. Backups self-activate
`backup-production.yml`'s daily schedule is now **always enabled**. A new `check-config` job detects whether the `BACKUP_*` secrets exist:
- **not wired** → backup job is cleanly **skipped** (green no-op + a `::notice::`), so no nightly failure spam while secrets are pending.
- **wired** → the daily backup runs automatically, no code change needed.

(Wiring the `BACKUP_*` secrets + running one restore drill remain your tasks — see `docs/restore-runbook.md`.)

### 2. Production approval gate
The `production` GitHub environment now has a **required reviewer** (`jwinut`, self-review allowed so a solo operator isn't locked out), configured via the API. `deploy.yml` will now **pause for manual approval** before each prod deploy instead of auto-deploying on green CI. CLAUDE.md updated to match.

### 3. Runtime metrics (`/metrics`)
Added `axum-prometheus` (0.7, matches axum 0.7). The backend now exposes request-rate, latency-histogram, and in-flight metrics at top-level **`GET /metrics`**:
- **Internal-only by construction** — nginx proxies only `/api` and `/storage` to the backend, so `/metrics` is reachable on the Docker network (for a Prometheus scrape of `backend:4001/metrics`) but returns 404 publicly.
- Excluded from the rate limiter and from its own measurement (route added after those layers).
- Standing up a Prometheus + Grafana (or a hosted agent) against it is the remaining ops step.

Verified: `cargo build` + `cargo clippy --all-targets -D warnings` green; backup workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)