### PR TITLE
fix: CouponAssignmentsModal flake + clear Trivy base-image CVEs

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@
 # On code-only changes, only layers 3+ rebuild (fast)
 # On dependency changes, layers 1+ rebuild (slow but necessary)
 
-FROM node:26-alpine@sha256:7c6af15abe4e3de859690e7db171d0d711bf37d27528eddfe625b2fe89e097f8 AS base
+FROM node:26-alpine@sha256:725aeba2364a9b16beae49e180d83bd597dbd0b15c47f1f28875c290bfd255b9 AS base
 WORKDIR /app
 
 # =============================================================================
@@ -52,9 +52,13 @@ RUN test -f dist/index.html && \
 # =============================================================================
 # STAGE 3: Production runtime (nginx - minimal)
 # =============================================================================
-FROM nginx:alpine@sha256:8b1e78743a03dbb2c95171cc58639fef29abc8816598e27fb910ed2e621e589a AS production
+FROM nginx:alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa AS production
 
-# Update packages to fix CVEs (e.g., CVE-2025-62408 in c-ares)
+# Refreshed base digest + apk upgrade to pull patched Alpine packages. Bumping
+# the FROM digest is what makes the upgrade effective: it invalidates the cached
+# upgrade layer so the rebuild fetches the latest libssl3/libcrypto3/libexpat
+# (resolving the OpenSSL + expat CVE cluster Trivy was flagging at 3.5.6-r0 /
+# 2.7.5-r0).
 RUN apk upgrade --no-cache
 
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/frontend/src/components/admin/CouponAssignmentsModal.tsx
+++ b/frontend/src/components/admin/CouponAssignmentsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { couponService } from '../../services/couponService';
 import { Coupon } from '../../types/coupon';
@@ -52,12 +52,26 @@ const CouponAssignmentsModal: React.FC<CouponAssignmentsModalProps> = ({
   const [userToRemove, setUserToRemove] = useState<CouponAssignment | null>(null);
   const limit = 10;
 
+  // Track mount status so the async handlers below never call setState after
+  // the modal has unmounted (e.g. closed mid-request). A late setState into a
+  // torn-down React root throws, and because the handlers are wired as
+  // fire-and-forget onClick callbacks that throw would surface as an unhandled
+  // promise rejection.
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
   const loadAssignments = useCallback(async (pageNum: number = 1) => {
     try {
       setLoading(true);
       setError(null);
       const result = await couponService.getCouponAssignments(coupon.id, pageNum, limit);
-      
+      if (!isMountedRef.current) {return;}
+
       setAssignments(result.assignments);
       setSummary(result.summary);
       setPage(result.page);
@@ -65,12 +79,15 @@ const CouponAssignmentsModal: React.FC<CouponAssignmentsModalProps> = ({
       setTotal(result.total);
     } catch (err: unknown) {
       logger.error('Error loading coupon assignments:', err);
+      if (!isMountedRef.current) {return;}
       const errorMessage = err instanceof Error && 'response' in err
         ? (err as { response?: { data?: { message?: string } } }).response?.data?.message
         : undefined;
       setError(errorMessage ?? t('errors.failedToLoadAssignments', 'Failed to load assignments'));
     } finally {
-      setLoading(false);
+      if (isMountedRef.current) {
+        setLoading(false);
+      }
     }
   }, [coupon.id, limit, t]);
 
@@ -122,16 +139,19 @@ const CouponAssignmentsModal: React.FC<CouponAssignmentsModalProps> = ({
       // Reload assignments to reflect changes
       await loadAssignments(page);
 
-
+      if (!isMountedRef.current) {return;}
       setUserToRemove(null);
     } catch (err: unknown) {
       logger.error('Error removing user coupons:', err);
+      if (!isMountedRef.current) {return;}
       const errorMessage = err instanceof Error && 'response' in err
         ? (err as { response?: { data?: { message?: string } } }).response?.data?.message
         : undefined;
       setError(errorMessage ?? t('errors.failedToRemoveCoupons', 'Failed to remove user coupons'));
     } finally {
-      setRemovingUserId(null);
+      if (isMountedRef.current) {
+        setRemovingUserId(null);
+      }
     }
   };
 


### PR DESCRIPTION
**1. Frontend test flake** — `CouponAssignmentsModal` async handlers called `setState` after their awaits; if the modal unmounted mid-request the late update hit a torn-down React root and threw, surfacing as an intermittent unhandled rejection (all assertions passed). Guarded with a mount ref. Verified 10/10 clean + full suite (1959).

**2. Trivy base-image CVEs (32 frontend)** — the `nginx:alpine` production base was pinned to a stale digest, so the cached `apk upgrade` kept shipping libssl3/libcrypto3 3.5.6-r0 + libexpat 2.7.5-r0. Bumped both base digests; the rebuild fetches patched 3.5.7-r0 / 2.8.1-r0, which closes the 32 frontend alerts on the next image scan. The 1 backend Debian libssl3 alert (no upstream fix) was dismissed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)