### PR TITLE
feat: LINE OA integration + PMS booking channel (big-bang launch implementation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,30 @@ LINE_CHANNEL_SECRET=your_line_channel_secret
 LINE_CALLBACK_URL=http://localhost:5001/api/oauth/line/callback
 
 # ===========================================
+# LINE OA INTEGRATION (docs/launch-plan.md)
+# ===========================================
+# Messaging API channels — one per property OA. All channels MUST live
+# under the same LINE provider as the Login channel (ADR-0002).
+LINE_MESSAGING_HF_ACCESS_TOKEN=
+LINE_MESSAGING_HF_CHANNEL_SECRET=
+LINE_MESSAGING_HFVILLE_ACCESS_TOKEN=
+LINE_MESSAGING_HFVILLE_CHANNEL_SECRET=
+
+# ===========================================
+# PMS BOOKING CHANNEL + STAY ACCRUAL (ADR-0003)
+# ===========================================
+# Outbound: loyalty -> PMS channel API (availability / create-booking).
+PMS_BASE_URL=
+PMS_CHANNEL_TOKEN=
+# Inbound: PMS checkout hook -> POST /api/loyalty/stays (shared secret).
+LOYALTY_SERVICE_TOKEN=
+
+# Per-property PromptPay receiving accounts (13-digit IDs). Falls back to
+# PROMPTPAY_TAX_ID when a per-property ID is unset.
+PROMPTPAY_HF_ID=
+PROMPTPAY_HFVILLE_ID=
+
+# ===========================================
 # ADMIN USER (DEVELOPMENT)
 # ===========================================
 LOYALTY_USERNAME=admin@localhost

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,8 @@ cd backend-rust
 cargo build              # debug
 cargo build --release    # release
 cargo test               # all tests
+cargo test <name>        # single test by name filter
+cargo test --test lib integration::coupon_test  # one integration module (harness: tests/lib.rs)
 cargo clippy --all-targets --all-features -- -D warnings
 cargo fmt --all -- --check
 cargo sqlx prepare --check
@@ -98,7 +100,31 @@ catch (error) {
 ```bash
 cd frontend
 npm run lint && npm run typecheck && npm run test
+npx vitest run src/path/to/File.test.tsx   # single test file
 ```
+
+## Root scripts & E2E
+
+The root `package.json` orchestrates both halves:
+
+```bash
+npm run quality:check    # lint + typecheck + test-integrity + backend tests (what pre-push runs)
+npm run dev              # backend (cargo run) + frontend (vite) concurrently
+npm run test:e2e         # Playwright with the local E2E_* port env vars pre-set
+```
+
+Playwright is configured at the root (`playwright.config.ts`, tests in
+`tests/`) with two projects: `api` (`*.api.spec.ts`, request-context only,
+sequential) and `browser` (`*.browser.spec.ts`, Desktop Chrome). Run one
+file locally:
+
+```bash
+npx playwright test tests/health.api.spec.ts --project=api
+```
+
+`BACKEND_URL` / `FRONTEND_URL` env vars override the target. The suite
+assumes CI manages the Docker containers — locally, point it at an
+already-running stack.
 
 ## API routes
 
@@ -107,6 +133,10 @@ Before wiring a new frontend call:
 2. Check its mount path in `backend-rust/src/routes/mod.rs`.
 3. Construct `/api/{mount}/{route}`.
 4. Hit it with `curl` first to confirm shape.
+5. Regenerate the typed client instead of hand-writing fetch calls:
+   `cd frontend && npm run generate:api` pulls `/api/openapi.json`
+   (defined in `backend-rust/src/openapi.rs`) into
+   `frontend/src/api/generated/`.
 
 ## CI/CD
 
@@ -172,3 +202,17 @@ gh pr create --base main
 # ...human reviews...
 gh pr merge <PR> --squash --delete-branch   # only after explicit approval
 ```
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues (thehfhotel/loyalty-app) via the `gh` CLI; external PRs are NOT a triage/request surface. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`), created on first use. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: one root `CONTEXT.md` (lazy-created by /grill-with-docs) + `docs/adr/`. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,69 @@
+# HF Loyalty
+
+The loyalty program for the HF hotel group. One program, one membership,
+spanning every property the group operates.
+
+## Language
+
+**Program**:
+The single loyalty scheme covering all properties. There is exactly one;
+membership, points, and tiers are program-wide, never per-property.
+
+**Property**:
+A physical hotel a stay happens at. Currently two: HF (The Harbour Front
+Hotel) and HF Ville. A property is an attribute of a stay or redemption,
+not a boundary of the program.
+_Avoid_: location, branch, hotel (ambiguous between the group and one building)
+
+**Member**:
+A person enrolled in the Program. One member has one membership regardless
+of how many properties they stay at.
+_Avoid_: customer, account
+
+**Stay**:
+A completed, checked-out occupancy at one property, as recorded by the PMS.
+The source event for Nights and points; every stay belongs to exactly one
+property.
+
+**Night**:
+One night of a Stay at any property. The unit that drives tier progression,
+summed across all properties.
+
+**Tier**:
+A member's level (Bronze / Silver / Gold / Platinum), computed from total
+nights across all properties — never from points, never per-property.
+
+**Coupon**:
+A redeemable benefit issued to a Member. Program-wide by default; may be
+restricted to a single property at creation, enforced at redemption.
+
+**Deposit**:
+The payment that confirms an in-app booking: 50% of the booking total, or
+the full amount if the guest chooses. Paid by PromptPay transfer into the
+booked property's own receiving account; the balance is due at the desk.
+
+**OA (Official Account)**:
+A property's LINE presence. Each property has exactly one OA. An OA is a
+door into the Program — never a program boundary.
+_Avoid_: LINE account, bot
+
+**Guest Profile**:
+The PMS's record of a real-world guest (name, phone, documents), built from
+bookings and check-ins. Lives in the PMS — the Program never duplicates it.
+_Avoid_: CRM record, customer record
+
+**Link**:
+The association between a Member and a Guest Profile. Created by staff
+scanning the member's QR at the desk, or by phone-number search when the QR
+moment was missed. A member is linked at most once; once linked, their stays
+can be attributed to their membership.
+
+**Member QR**:
+The scannable code in the member's app that identifies their membership to
+staff. The physical handshake that creates a Link.
+
+**Friendship**:
+A member's opt-in to receive LINE messages from one specific OA. Tracked
+per OA; a member can hold zero, one, or two friendships. Messages about an
+event at a property are sent by that property's OA (property-affinity),
+falling back to whichever OA the member has friended.

--- a/backend-rust/.sqlx/query-0583933d13f2cdf4419b46e1d922dffccb8a35afea4e39fd6c42d55280d02bbc.json
+++ b/backend-rust/.sqlx/query-0583933d13f2cdf4419b46e1d922dffccb8a35afea4e39fd6c42d55280d02bbc.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO stays (pms_stay_id, user_id, property, check_in, check_out, nights)\n        VALUES ($1, $2, $3, $4, $5, $6)\n        ON CONFLICT (pms_stay_id) DO NOTHING\n        RETURNING id\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Uuid",
+        "Varchar",
+        "Date",
+        "Date",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "0583933d13f2cdf4419b46e1d922dffccb8a35afea4e39fd6c42d55280d02bbc"
+}

--- a/backend-rust/.sqlx/query-21da249e2f764e825cf9c26f74907b34876fdfacb1093fe1ae833ebccfe89960.json
+++ b/backend-rust/.sqlx/query-21da249e2f764e825cf9c26f74907b34876fdfacb1093fe1ae833ebccfe89960.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    INSERT INTO line_friendships (line_user_id, property, is_friend, followed_at, updated_at)\n                    VALUES ($1, $2, TRUE, NOW(), NOW())\n                    ON CONFLICT (line_user_id, property)\n                    DO UPDATE SET is_friend = TRUE, followed_at = NOW(), updated_at = NOW()\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "21da249e2f764e825cf9c26f74907b34876fdfacb1093fe1ae833ebccfe89960"
+}

--- a/backend-rust/.sqlx/query-2a022ce467ae2e55e89ea507a49e0ac23e64100158177756d456a71cabc083ab.json
+++ b/backend-rust/.sqlx/query-2a022ce467ae2e55e89ea507a49e0ac23e64100158177756d456a71cabc083ab.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            id,\n            code,\n            name,\n            description,\n            terms_and_conditions,\n            type::text as \"coupon_type!\",\n            value,\n            currency,\n            minimum_spend,\n            maximum_discount,\n            valid_from,\n            valid_until,\n            usage_limit,\n            usage_limit_per_user,\n            used_count,\n            status::text as \"status\",\n            created_at\n        FROM coupons\n        WHERE id = $1\n        ",
+  "query": "\n        SELECT\n            id,\n            code,\n            name,\n            description,\n            terms_and_conditions,\n            type::text as \"coupon_type!\",\n            value,\n            currency,\n            minimum_spend,\n            maximum_discount,\n            valid_from,\n            valid_until,\n            usage_limit,\n            usage_limit_per_user,\n            used_count,\n            status::text as \"status\",\n            created_at,\n            property\n        FROM coupons\n        WHERE id = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -87,6 +87,11 @@
         "ordinal": 16,
         "name": "created_at",
         "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "property",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
@@ -111,8 +116,9 @@
       true,
       true,
       null,
+      true,
       true
     ]
   },
-  "hash": "212e5fd8adb2ebc45254eea22e36186bec3a14394e99d680fe27c365a46b1320"
+  "hash": "2a022ce467ae2e55e89ea507a49e0ac23e64100158177756d456a71cabc083ab"
 }

--- a/backend-rust/.sqlx/query-321e04cf2955484da9bd9cae61719f3c50fcf07bbcaadcbde8dc0a37d47881ea.json
+++ b/backend-rust/.sqlx/query-321e04cf2955484da9bd9cae61719f3c50fcf07bbcaadcbde8dc0a37d47881ea.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT oauth_provider_id FROM users WHERE id = $1 AND oauth_provider = 'line'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "oauth_provider_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "321e04cf2955484da9bd9cae61719f3c50fcf07bbcaadcbde8dc0a37d47881ea"
+}

--- a/backend-rust/.sqlx/query-32732f2b07a8717f0a66a89f981687019114906f325f0327ac09ae4f15775ae5.json
+++ b/backend-rust/.sqlx/query-32732f2b07a8717f0a66a89f981687019114906f325f0327ac09ae4f15775ae5.json
@@ -63,7 +63,7 @@
       false,
       false,
       false,
-      false,
+      true,
       true,
       true,
       false,

--- a/backend-rust/.sqlx/query-3933a65c76ace6f8f158b94fcdffa6e5856768917b05c508c63f9cb77881208d.json
+++ b/backend-rust/.sqlx/query-3933a65c76ace6f8f158b94fcdffa6e5856768917b05c508c63f9cb77881208d.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT pms_booking_id AS \"pms_booking_id!\",\n               COALESCE(amount_due_now, total_price) AS \"amount_received!\"\n        FROM bookings WHERE id = $1 AND pms_booking_id IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "pms_booking_id!",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "amount_received!",
+        "type_info": "Numeric"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      true,
+      null
+    ]
+  },
+  "hash": "3933a65c76ace6f8f158b94fcdffa6e5856768917b05c508c63f9cb77881208d"
+}

--- a/backend-rust/.sqlx/query-3d9a9567ac24a925e30bd0927164746de2c46ebdc693dac7a131c4322af30bfb.json
+++ b/backend-rust/.sqlx/query-3d9a9567ac24a925e30bd0927164746de2c46ebdc693dac7a131c4322af30bfb.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT membership_id FROM user_profiles WHERE user_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "membership_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "3d9a9567ac24a925e30bd0927164746de2c46ebdc693dac7a131c4322af30bfb"
+}

--- a/backend-rust/.sqlx/query-49ec8372aa6380f69e79d08142702296ca102b5c83aca2a5731f4b53f47aab00.json
+++ b/backend-rust/.sqlx/query-49ec8372aa6380f69e79d08142702296ca102b5c83aca2a5731f4b53f47aab00.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n                    INSERT INTO line_friendships (line_user_id, property, is_friend, followed_at, updated_at)\n                    VALUES ($1, $2, FALSE, NOW(), NOW())\n                    ON CONFLICT (line_user_id, property)\n                    DO UPDATE SET is_friend = FALSE, updated_at = NOW()\n                    ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "49ec8372aa6380f69e79d08142702296ca102b5c83aca2a5731f4b53f47aab00"
+}

--- a/backend-rust/.sqlx/query-5bb4c40af70303a807f8fef4482ea997a5149d2ba2c774e12f63b8ea73320506.json
+++ b/backend-rust/.sqlx/query-5bb4c40af70303a807f8fef4482ea997a5149d2ba2c774e12f63b8ea73320506.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            UPDATE bookings\n            SET status = 'cancelled', cancelled_at = NOW(),\n                cancellation_reason = 'Payment window expired', updated_at = NOW()\n            WHERE id = $1 AND status = 'pending'\n            ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "5bb4c40af70303a807f8fef4482ea997a5149d2ba2c774e12f63b8ea73320506"
+}

--- a/backend-rust/.sqlx/query-5d53f642cd7d4f15fda3f17d23e536f13afb9436681c3531cfd861ab6ee04f10.json
+++ b/backend-rust/.sqlx/query-5d53f642cd7d4f15fda3f17d23e536f13afb9436681c3531cfd861ab6ee04f10.json
@@ -172,7 +172,7 @@
     "nullable": [
       false,
       false,
-      false,
+      true,
       false,
       false,
       false,

--- a/backend-rust/.sqlx/query-6832b870441eb469b6daf961371d9ef0b9e3cc5810500b12b14555af985a9023.json
+++ b/backend-rust/.sqlx/query-6832b870441eb469b6daf961371d9ef0b9e3cc5810500b12b14555af985a9023.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO bookings (\n            id, user_id, check_in_date, check_out_date, num_guests,\n            total_price, status, property, pms_booking_id, pms_room_type_id,\n            guest_name, guest_phone, payment_option, amount_due_now,\n            balance_due, hold_expires_at\n        )\n        VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7, $8, $9, $10, $11, $12, $13, $14, $15)\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Date",
+        "Date",
+        "Int4",
+        "Numeric",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Varchar",
+        "Numeric",
+        "Numeric",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6832b870441eb469b6daf961371d9ef0b9e3cc5810500b12b14555af985a9023"
+}

--- a/backend-rust/.sqlx/query-78855b7f9cec5bd6c8d5a9476f5da2468cf14f2d71d64905c35b5a62d99143ea.json
+++ b/backend-rust/.sqlx/query-78855b7f9cec5bd6c8d5a9476f5da2468cf14f2d71d64905c35b5a62d99143ea.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT id, pms_booking_id\n        FROM bookings\n        WHERE status = 'pending'\n          AND pms_booking_id IS NOT NULL\n          AND hold_expires_at IS NOT NULL\n          AND hold_expires_at < NOW()\n        LIMIT 50\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "pms_booking_id",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "78855b7f9cec5bd6c8d5a9476f5da2468cf14f2d71d64905c35b5a62d99143ea"
+}

--- a/backend-rust/.sqlx/query-8d0d977eb7b688e846ede582b87fc7a010deb422fe1dc8ad48aba0eeb216017f.json
+++ b/backend-rust/.sqlx/query-8d0d977eb7b688e846ede582b87fc7a010deb422fe1dc8ad48aba0eeb216017f.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE bookings SET status = 'confirmed', updated_at = NOW()\n               WHERE id = $1 AND status = 'pending'",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "8d0d977eb7b688e846ede582b87fc7a010deb422fe1dc8ad48aba0eeb216017f"
+}

--- a/backend-rust/.sqlx/query-9b3ea92f20df84217f5852dbec6820d3979ae5aa54d220ba32b4417451f38a8a.json
+++ b/backend-rust/.sqlx/query-9b3ea92f20df84217f5852dbec6820d3979ae5aa54d220ba32b4417451f38a8a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            uc.id,\n            uc.user_id,\n            uc.status::text as \"status!\",\n            uc.expires_at,\n            c.type::text as \"coupon_type!\",\n            c.value,\n            c.minimum_spend,\n            c.maximum_discount,\n            c.currency\n        FROM user_coupons uc\n        JOIN coupons c ON uc.coupon_id = c.id\n        WHERE uc.qr_code = $1\n        ",
+  "query": "\n        SELECT\n            uc.id,\n            uc.user_id,\n            uc.status::text as \"status!\",\n            uc.expires_at,\n            c.type::text as \"coupon_type!\",\n            c.value,\n            c.minimum_spend,\n            c.maximum_discount,\n            c.currency,\n            c.property\n        FROM user_coupons uc\n        JOIN coupons c ON uc.coupon_id = c.id\n        WHERE uc.qr_code = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -47,6 +47,11 @@
         "ordinal": 8,
         "name": "currency",
         "type_info": "Varchar"
+      },
+      {
+        "ordinal": 9,
+        "name": "property",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
@@ -63,8 +68,9 @@
       true,
       true,
       true,
+      true,
       true
     ]
   },
-  "hash": "d51b619988c8a3bb7c50de9dedd708aa125f49569dc967b6e986f43e33e2be90"
+  "hash": "9b3ea92f20df84217f5852dbec6820d3979ae5aa54d220ba32b4417451f38a8a"
 }

--- a/backend-rust/.sqlx/query-9ccc6767f0a71fb22d43600e83b66e775da09972499a437053e25f31052b91a8.json
+++ b/backend-rust/.sqlx/query-9ccc6767f0a71fb22d43600e83b66e775da09972499a437053e25f31052b91a8.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT property FROM stays WHERE user_id = $1 ORDER BY created_at DESC LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "property",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9ccc6767f0a71fb22d43600e83b66e775da09972499a437053e25f31052b91a8"
+}

--- a/backend-rust/.sqlx/query-9e50560943b08e0313dd6b180a516d3d008c4574f89515686f7f33dac9400dd2.json
+++ b/backend-rust/.sqlx/query-9e50560943b08e0313dd6b180a516d3d008c4574f89515686f7f33dac9400dd2.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT property FROM line_friendships WHERE line_user_id = $1 AND is_friend",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "property",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9e50560943b08e0313dd6b180a516d3d008c4574f89515686f7f33dac9400dd2"
+}

--- a/backend-rust/.sqlx/query-9ff2698e09fdb83b6611f3968c2c0669e593cd786f2ad4b41573e3839aa7f00b.json
+++ b/backend-rust/.sqlx/query-9ff2698e09fdb83b6611f3968c2c0669e593cd786f2ad4b41573e3839aa7f00b.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT award_points($1, $2, 'earned_stay'::varchar, $3, $4, NULL, NULL, $5) AS \"result!\"\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "result!",
+        "type_info": "Jsonb"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int4",
+        "Text",
+        "Varchar",
+        "Int4"
+      ]
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "9ff2698e09fdb83b6611f3968c2c0669e593cd786f2ad4b41573e3839aa7f00b"
+}

--- a/backend-rust/.sqlx/query-a95dd1bbc4f36e20bb5bad7651462a44277056bbea922f04c56ddadacad1442d.json
+++ b/backend-rust/.sqlx/query-a95dd1bbc4f36e20bb5bad7651462a44277056bbea922f04c56ddadacad1442d.json
@@ -1,0 +1,15 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE points_transactions SET property = $1 WHERE id = $2",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a95dd1bbc4f36e20bb5bad7651462a44277056bbea922f04c56ddadacad1442d"
+}

--- a/backend-rust/.sqlx/query-aa3e4b9ec442b7611344b7b24903af574fbcef46f6b66b095870c76e15219878.json
+++ b/backend-rust/.sqlx/query-aa3e4b9ec442b7611344b7b24903af574fbcef46f6b66b095870c76e15219878.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT t.name AS \"name?\"\n        FROM user_loyalty ul\n        LEFT JOIN tiers t ON ul.tier_id = t.id\n        WHERE ul.user_id = $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "name?",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "aa3e4b9ec442b7611344b7b24903af574fbcef46f6b66b095870c76e15219878"
+}

--- a/backend-rust/.sqlx/query-b3fb12072c8690db0da3ff31ac8ec09b35ae9483151e32bf10b7e9cb54488dad.json
+++ b/backend-rust/.sqlx/query-b3fb12072c8690db0da3ff31ac8ec09b35ae9483151e32bf10b7e9cb54488dad.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE stays SET points_awarded = $1, points_transaction_id = $2 WHERE id = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int4",
+        "Uuid",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b3fb12072c8690db0da3ff31ac8ec09b35ae9483151e32bf10b7e9cb54488dad"
+}

--- a/backend-rust/.sqlx/query-b97f2119aa51c81df7980a9030d07b4859a237de3e2e4077ae6a93476322a50a.json
+++ b/backend-rust/.sqlx/query-b97f2119aa51c81df7980a9030d07b4859a237de3e2e4077ae6a93476322a50a.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT user_id FROM user_profiles WHERE membership_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "user_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "b97f2119aa51c81df7980a9030d07b4859a237de3e2e4077ae6a93476322a50a"
+}

--- a/backend-rust/.sqlx/query-ccb28f5b055a8d388f6321d40fbfa85d4bfbd3f7d5d9222cec34f465cb196706.json
+++ b/backend-rust/.sqlx/query-ccb28f5b055a8d388f6321d40fbfa85d4bfbd3f7d5d9222cec34f465cb196706.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT points_per_unit\n        FROM points_earning_rules\n        WHERE unit_type = 'night'\n          AND is_active = TRUE\n          AND (valid_from IS NULL OR valid_from <= NOW())\n          AND (valid_until IS NULL OR valid_until >= NOW())\n        ORDER BY created_at DESC\n        LIMIT 1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "points_per_unit",
+        "type_info": "Numeric"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "ccb28f5b055a8d388f6321d40fbfa85d4bfbd3f7d5d9222cec34f465cb196706"
+}

--- a/backend-rust/.sqlx/query-cd3750d2bc90e72e723193dceaeefeb16fecd271376b9d0c38fe69f4f136acc2.json
+++ b/backend-rust/.sqlx/query-cd3750d2bc90e72e723193dceaeefeb16fecd271376b9d0c38fe69f4f136acc2.json
@@ -1,0 +1,46 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n            SELECT id, user_id, property, nights, points_awarded\n            FROM stays WHERE pms_stay_id = $1\n            ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "user_id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 2,
+        "name": "property",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 3,
+        "name": "nights",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 4,
+        "name": "points_awarded",
+        "type_info": "Int4"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "cd3750d2bc90e72e723193dceaeefeb16fecd271376b9d0c38fe69f4f136acc2"
+}

--- a/backend-rust/.sqlx/query-d0811a2fdab89f7ef6da1147bf163862f079a237083868baafad255f23c9e251.json
+++ b/backend-rust/.sqlx/query-d0811a2fdab89f7ef6da1147bf163862f079a237083868baafad255f23c9e251.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                id,\n                code,\n                name,\n                description,\n                terms_and_conditions,\n                type::text as \"coupon_type!\",\n                value,\n                currency,\n                minimum_spend,\n                maximum_discount,\n                valid_from,\n                valid_until,\n                usage_limit,\n                usage_limit_per_user,\n                used_count,\n                status::text as \"status\",\n                created_at\n            FROM coupons\n            WHERE\n                ($1::text IS NULL OR status::text = $1)\n                AND ($2::text IS NULL OR type::text = $2)\n                AND ($3::text IS NULL OR (code ILIKE $3 OR name ILIKE $3))\n            ORDER BY created_at DESC\n            LIMIT $4 OFFSET $5\n            ",
+  "query": "\n            SELECT\n                id,\n                code,\n                name,\n                description,\n                terms_and_conditions,\n                type::text as \"coupon_type!\",\n                value,\n                currency,\n                minimum_spend,\n                maximum_discount,\n                valid_from,\n                valid_until,\n                usage_limit,\n                usage_limit_per_user,\n                used_count,\n                status::text as \"status\",\n                created_at,\n                property\n            FROM coupons\n            WHERE status = 'active'\n                AND ($1::text IS NULL OR type::text = $1)\n                AND ($2::text IS NULL OR (code ILIKE $2 OR name ILIKE $2))\n                AND (valid_from IS NULL OR valid_from <= NOW())\n                AND (valid_until IS NULL OR valid_until > NOW())\n            ORDER BY created_at DESC\n            LIMIT $3 OFFSET $4\n            ",
   "describe": {
     "columns": [
       {
@@ -87,11 +87,15 @@
         "ordinal": 16,
         "name": "created_at",
         "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "property",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
         "Text",
         "Text",
         "Int8",
@@ -115,8 +119,9 @@
       true,
       true,
       null,
+      true,
       true
     ]
   },
-  "hash": "8819cdbb8d629a6664c05a2d02efbf0f514e48a47bdbb5dc8d0618dd340f6c0e"
+  "hash": "d0811a2fdab89f7ef6da1147bf163862f079a237083868baafad255f23c9e251"
 }

--- a/backend-rust/.sqlx/query-e3759fd9ace7c998001f3d4769eb87ce4be1e0f5c261ae72880e3f6240e9d1c5.json
+++ b/backend-rust/.sqlx/query-e3759fd9ace7c998001f3d4769eb87ce4be1e0f5c261ae72880e3f6240e9d1c5.json
@@ -167,7 +167,7 @@
     "nullable": [
       false,
       false,
-      false,
+      true,
       false,
       false,
       false,

--- a/backend-rust/.sqlx/query-ee36cdc1f990fc99897903ef0f579abc88385cea8361717d703a43c83508402d.json
+++ b/backend-rust/.sqlx/query-ee36cdc1f990fc99897903ef0f579abc88385cea8361717d703a43c83508402d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                id,\n                code,\n                name,\n                description,\n                terms_and_conditions,\n                type::text as \"coupon_type!\",\n                value,\n                currency,\n                minimum_spend,\n                maximum_discount,\n                valid_from,\n                valid_until,\n                usage_limit,\n                usage_limit_per_user,\n                used_count,\n                status::text as \"status\",\n                created_at\n            FROM coupons\n            WHERE status = 'active'\n                AND ($1::text IS NULL OR type::text = $1)\n                AND ($2::text IS NULL OR (code ILIKE $2 OR name ILIKE $2))\n                AND (valid_from IS NULL OR valid_from <= NOW())\n                AND (valid_until IS NULL OR valid_until > NOW())\n            ORDER BY created_at DESC\n            LIMIT $3 OFFSET $4\n            ",
+  "query": "\n            SELECT\n                id,\n                code,\n                name,\n                description,\n                terms_and_conditions,\n                type::text as \"coupon_type!\",\n                value,\n                currency,\n                minimum_spend,\n                maximum_discount,\n                valid_from,\n                valid_until,\n                usage_limit,\n                usage_limit_per_user,\n                used_count,\n                status::text as \"status\",\n                created_at,\n                property\n            FROM coupons\n            WHERE\n                ($1::text IS NULL OR status::text = $1)\n                AND ($2::text IS NULL OR type::text = $2)\n                AND ($3::text IS NULL OR (code ILIKE $3 OR name ILIKE $3))\n            ORDER BY created_at DESC\n            LIMIT $4 OFFSET $5\n            ",
   "describe": {
     "columns": [
       {
@@ -87,10 +87,16 @@
         "ordinal": 16,
         "name": "created_at",
         "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 17,
+        "name": "property",
+        "type_info": "Varchar"
       }
     ],
     "parameters": {
       "Left": [
+        "Text",
         "Text",
         "Text",
         "Int8",
@@ -114,8 +120,9 @@
       true,
       true,
       null,
+      true,
       true
     ]
   },
-  "hash": "2bdf094d2135213bfcd98390c0f50a615969868b68f26b33f71597fed6799664"
+  "hash": "ee36cdc1f990fc99897903ef0f579abc88385cea8361717d703a43c83508402d"
 }

--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -1888,6 +1888,7 @@ dependencies = [
  "fake",
  "futures",
  "hex",
+ "hmac",
  "http-body-util",
  "image",
  "jsonwebtoken",

--- a/backend-rust/Cargo.toml
+++ b/backend-rust/Cargo.toml
@@ -79,6 +79,9 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 
 # PromptPay QR code generation (Thai EMVCo payment standard)
 promptpay-rs = "0.5"
+
+# HMAC for LINE webhook signature verification
+hmac = "0.12"
 qrcode = { version = "0.14", default-features = false, features = ["svg"] }
 
 # Lazy initialization

--- a/backend-rust/migrations/20260710000000_property_line_channel.sql
+++ b/backend-rust/migrations/20260710000000_property_line_channel.sql
@@ -1,0 +1,150 @@
+-- Property dimension + LINE OA integration + PMS booking channel foundation
+-- (docs/launch-plan.md, ADR-0001/0002/0003)
+--
+-- Idempotent by convention: ADD COLUMN IF NOT EXISTS, DO-block constraint
+-- guards, CREATE TABLE/INDEX IF NOT EXISTS.
+
+-- =====================================================
+-- Property dimension (ADR-0001: property is an attribute, not a partition)
+-- Values: 'hf' (The Harbour Front Hotel) | 'hfville' (HF Ville)
+-- =====================================================
+
+ALTER TABLE "public"."points_transactions"
+    ADD COLUMN IF NOT EXISTS "property" VARCHAR(10);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_points_transactions_property'
+    ) THEN
+        ALTER TABLE "public"."points_transactions"
+            ADD CONSTRAINT "chk_points_transactions_property"
+            CHECK ("property" IS NULL OR "property" IN ('hf', 'hfville'));
+    END IF;
+END $$;
+
+-- Coupons: NULL property = program-wide (default); non-NULL = redeemable
+-- only at that property (checked at redemption time in the API layer).
+ALTER TABLE "public"."coupons"
+    ADD COLUMN IF NOT EXISTS "property" VARCHAR(10);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_coupons_property'
+    ) THEN
+        ALTER TABLE "public"."coupons"
+            ADD CONSTRAINT "chk_coupons_property"
+            CHECK ("property" IS NULL OR "property" IN ('hf', 'hfville'));
+    END IF;
+END $$;
+
+-- Room-type catalog: local rows may map to a PMS room type per property
+-- (ADR-0003: local tables are a display catalog, not inventory).
+ALTER TABLE "public"."room_types"
+    ADD COLUMN IF NOT EXISTS "property" VARCHAR(10);
+ALTER TABLE "public"."room_types"
+    ADD COLUMN IF NOT EXISTS "pms_room_type_id" VARCHAR(100);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_room_types_property'
+    ) THEN
+        ALTER TABLE "public"."room_types"
+            ADD CONSTRAINT "chk_room_types_property"
+            CHECK ("property" IS NULL OR "property" IN ('hf', 'hfville'));
+    END IF;
+END $$;
+
+-- =====================================================
+-- Booking channel records (ADR-0003)
+-- Channel bookings live in the PMS; the local row is a channel record.
+-- room_id / room_type_id become nullable: the PMS assigns physical rooms.
+-- =====================================================
+
+ALTER TABLE "public"."bookings" ALTER COLUMN "room_id" DROP NOT NULL;
+ALTER TABLE "public"."bookings" ALTER COLUMN "room_type_id" DROP NOT NULL;
+
+ALTER TABLE "public"."bookings"
+    ADD COLUMN IF NOT EXISTS "property" VARCHAR(10),
+    ADD COLUMN IF NOT EXISTS "pms_booking_id" VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS "pms_room_type_id" VARCHAR(100),
+    ADD COLUMN IF NOT EXISTS "guest_name" VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS "guest_phone" VARCHAR(32),
+    ADD COLUMN IF NOT EXISTS "payment_option" VARCHAR(10),
+    ADD COLUMN IF NOT EXISTS "amount_due_now" DECIMAL(10,2),
+    ADD COLUMN IF NOT EXISTS "balance_due" DECIMAL(10,2),
+    ADD COLUMN IF NOT EXISTS "hold_expires_at" TIMESTAMPTZ(6);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_bookings_property'
+    ) THEN
+        ALTER TABLE "public"."bookings"
+            ADD CONSTRAINT "chk_bookings_property"
+            CHECK ("property" IS NULL OR "property" IN ('hf', 'hfville'));
+    END IF;
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_bookings_payment_option'
+    ) THEN
+        ALTER TABLE "public"."bookings"
+            ADD CONSTRAINT "chk_bookings_payment_option"
+            CHECK ("payment_option" IS NULL OR "payment_option" IN ('deposit50', 'full'));
+    END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_bookings_pms_booking_id"
+    ON "public"."bookings"("pms_booking_id") WHERE "pms_booking_id" IS NOT NULL;
+CREATE INDEX IF NOT EXISTS "idx_bookings_hold_expires"
+    ON "public"."bookings"("hold_expires_at")
+    WHERE "status" = 'pending' AND "hold_expires_at" IS NOT NULL;
+
+-- =====================================================
+-- Stays: accrual records from PMS checkouts (idempotent by pms_stay_id)
+-- =====================================================
+
+CREATE TABLE IF NOT EXISTS "public"."stays" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "pms_stay_id" VARCHAR(100) NOT NULL,
+    "user_id" UUID NOT NULL,
+    "property" VARCHAR(10) NOT NULL,
+    "check_in" DATE NOT NULL,
+    "check_out" DATE NOT NULL,
+    "nights" INTEGER NOT NULL,
+    "points_awarded" INTEGER NOT NULL DEFAULT 0,
+    "points_transaction_id" UUID,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT "stays_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "stays_pms_stay_id_key" UNIQUE ("pms_stay_id"),
+    CONSTRAINT "chk_stays_property" CHECK ("property" IN ('hf', 'hfville')),
+    CONSTRAINT "chk_stays_nights" CHECK ("nights" > 0),
+    CONSTRAINT "chk_stays_dates" CHECK ("check_out" > "check_in"),
+    CONSTRAINT "stays_user_id_fkey" FOREIGN KEY ("user_id")
+        REFERENCES "public"."users"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+CREATE INDEX IF NOT EXISTS "idx_stays_user_id" ON "public"."stays"("user_id");
+CREATE INDEX IF NOT EXISTS "idx_stays_property" ON "public"."stays"("property");
+
+-- =====================================================
+-- LINE friendships: per-OA follow state (property-affinity push routing).
+-- Keyed by LINE userId (shared across channels — ADR-0002); a row may
+-- exist before the LINE user is ever a member.
+-- =====================================================
+
+CREATE TABLE IF NOT EXISTS "public"."line_friendships" (
+    "line_user_id" VARCHAR(64) NOT NULL,
+    "property" VARCHAR(10) NOT NULL,
+    "is_friend" BOOLEAN NOT NULL DEFAULT TRUE,
+    "followed_at" TIMESTAMPTZ(6) NOT NULL DEFAULT NOW(),
+    "updated_at" TIMESTAMPTZ(6) NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT "line_friendships_pkey" PRIMARY KEY ("line_user_id", "property"),
+    CONSTRAINT "chk_line_friendships_property" CHECK ("property" IN ('hf', 'hfville'))
+);
+
+CREATE INDEX IF NOT EXISTS "idx_line_friendships_property_friend"
+    ON "public"."line_friendships"("property") WHERE "is_friend";

--- a/backend-rust/src/config/mod.rs
+++ b/backend-rust/src/config/mod.rs
@@ -341,13 +341,93 @@ impl SlipokConfig {
 pub struct PromptPayConfig {
     /// 13-digit Tax ID (or 10-digit phone number) for PromptPay payments.
     /// Sourced from the `PROMPTPAY_TAX_ID` environment variable.
+    /// Legacy single-account fallback when per-property IDs are unset.
     pub tax_id: Option<String>,
+
+    /// Receiving PromptPay ID for HF (`PROMPTPAY_HF_ID`).
+    pub hf_id: Option<String>,
+
+    /// Receiving PromptPay ID for HF Ville (`PROMPTPAY_HFVILLE_ID`).
+    pub hfville_id: Option<String>,
 }
 
 impl PromptPayConfig {
     pub fn is_configured(&self) -> bool {
         self.tax_id.is_some()
     }
+
+    /// Receiving PromptPay ID for a property ("hf" | "hfville"), falling
+    /// back to the legacy single `tax_id` when no per-property ID is set.
+    /// Each property has its own receiving account (docs/launch-plan.md).
+    pub fn id_for_property(&self, property: &str) -> Option<&String> {
+        let per_property = match property {
+            "hf" => self.hf_id.as_ref(),
+            "hfville" => self.hfville_id.as_ref(),
+            _ => None,
+        };
+        per_property.or(self.tax_id.as_ref())
+    }
+}
+
+/// One LINE Messaging API channel (a property's OA).
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LineMessagingChannelConfig {
+    /// Long-lived channel access token for push messages.
+    pub access_token: Option<String>,
+    /// Channel secret for webhook signature verification.
+    pub channel_secret: Option<String>,
+}
+
+impl LineMessagingChannelConfig {
+    pub fn is_configured(&self) -> bool {
+        self.access_token.is_some() && self.channel_secret.is_some()
+    }
+}
+
+/// LINE Messaging API configuration — one channel per property OA
+/// (ADR-0002: all channels live under the same LINE provider, so userIds
+/// are shared with the LINE Login channel).
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LineMessagingConfig {
+    #[serde(default)]
+    pub hf: LineMessagingChannelConfig,
+    #[serde(default)]
+    pub hfville: LineMessagingChannelConfig,
+}
+
+impl LineMessagingConfig {
+    /// Channel credentials for a property ("hf" | "hfville").
+    pub fn channel(&self, property: &str) -> Option<&LineMessagingChannelConfig> {
+        match property {
+            "hf" => Some(&self.hf),
+            "hfville" => Some(&self.hfville),
+            _ => None,
+        }
+    }
+}
+
+/// PMS booking-channel client configuration (ADR-0003: the loyalty app is
+/// a booking channel into the PMS; availability and booking creation live
+/// there).
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct PmsConfig {
+    /// Base URL of the PMS channel API (e.g. https://pms.internal).
+    pub base_url: Option<String>,
+    /// Bearer token for outbound calls to the PMS channel API.
+    pub channel_token: Option<String>,
+}
+
+impl PmsConfig {
+    pub fn is_configured(&self) -> bool {
+        self.base_url.is_some() && self.channel_token.is_some()
+    }
+}
+
+/// Inbound service-token configuration for machine-to-machine callers
+/// (the PMS checkout hook posting to /api/loyalty/stays).
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct LoyaltyServiceConfig {
+    pub token: Option<String>,
 }
 
 /// Server configuration
@@ -545,6 +625,18 @@ pub struct Settings {
     /// Cloudflare Access configuration (admin auto-login exchange)
     #[serde(default)]
     pub cf_access: CfAccessConfig,
+
+    /// LINE Messaging API channels (one per property OA)
+    #[serde(default)]
+    pub line_messaging: LineMessagingConfig,
+
+    /// PMS booking-channel client (ADR-0003)
+    #[serde(default)]
+    pub pms: PmsConfig,
+
+    /// Inbound service token (PMS → loyalty accrual calls)
+    #[serde(default)]
+    pub loyalty_service: LoyaltyServiceConfig,
 }
 
 impl Settings {
@@ -633,6 +725,33 @@ impl Settings {
             .set_override_option("slipok.branch_id", env::var("SLIPOK_BRANCH_ID").ok())?
             .set_override_option("slipok.api_key", env::var("SLIPOK_API_KEY").ok())?
             .set_override_option("promptpay.tax_id", env::var("PROMPTPAY_TAX_ID").ok())?
+            .set_override_option("promptpay.hf_id", env::var("PROMPTPAY_HF_ID").ok())?
+            .set_override_option(
+                "promptpay.hfville_id",
+                env::var("PROMPTPAY_HFVILLE_ID").ok(),
+            )?
+            .set_override_option(
+                "line_messaging.hf.access_token",
+                env::var("LINE_MESSAGING_HF_ACCESS_TOKEN").ok(),
+            )?
+            .set_override_option(
+                "line_messaging.hf.channel_secret",
+                env::var("LINE_MESSAGING_HF_CHANNEL_SECRET").ok(),
+            )?
+            .set_override_option(
+                "line_messaging.hfville.access_token",
+                env::var("LINE_MESSAGING_HFVILLE_ACCESS_TOKEN").ok(),
+            )?
+            .set_override_option(
+                "line_messaging.hfville.channel_secret",
+                env::var("LINE_MESSAGING_HFVILLE_CHANNEL_SECRET").ok(),
+            )?
+            .set_override_option("pms.base_url", env::var("PMS_BASE_URL").ok())?
+            .set_override_option("pms.channel_token", env::var("PMS_CHANNEL_TOKEN").ok())?
+            .set_override_option(
+                "loyalty_service.token",
+                env::var("LOYALTY_SERVICE_TOKEN").ok(),
+            )?
             .set_override_option("security.max_file_size", env::var("MAX_FILE_SIZE").ok())?
             .set_override_option(
                 "security.rate_limit_window_ms",

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -154,6 +154,26 @@ async fn main() -> anyhow::Result<()> {
     // Create application state
     let state = AppState::new(db.pool().clone(), redis.connection.clone(), config.clone());
 
+    // Belt-and-braces sweep for channel-booking payment windows (ADR-0003):
+    // releases PMS holds whose deposit never arrived and cancels the local
+    // channel rows. The PMS runs its own expiry sweep too; both sides are
+    // idempotent, so double-release is harmless.
+    {
+        let sweep_state = state.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(300));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                interval.tick().await;
+                loyalty_backend::services::pms_channel::release_expired_holds(
+                    sweep_state.db(),
+                    sweep_state.config(),
+                )
+                .await;
+            }
+        });
+    }
+
     // Build the application router with all routes and middleware
     let app = create_app(state, &config);
 

--- a/backend-rust/src/models/coupon.rs
+++ b/backend-rust/src/models/coupon.rs
@@ -71,6 +71,9 @@ pub struct Coupon {
     pub available_languages: Option<serde_json::Value>,
     pub last_translated: Option<DateTime<Utc>>,
     pub translation_status: Option<String>,
+    /// Optional property restriction ("hf" | "hfville"); None = program-wide.
+    #[sqlx(default)]
+    pub property: Option<String>,
 }
 
 /// User coupon assignment database entity
@@ -111,6 +114,9 @@ pub struct CreateCouponRequest {
     pub tier_restrictions: Option<serde_json::Value>,
     pub customer_segment: Option<serde_json::Value>,
     pub status: Option<CouponStatus>,
+    /// Optional property restriction ("hf" | "hfville"); None = program-wide
+    /// (ADR-0001: coupons are program-wide by default).
+    pub property: Option<String>,
 }
 
 /// Update coupon request DTO
@@ -130,6 +136,9 @@ pub struct UpdateCouponRequest {
     pub tier_restrictions: Option<serde_json::Value>,
     pub customer_segment: Option<serde_json::Value>,
     pub status: Option<CouponStatus>,
+    /// Optional property restriction ("hf" | "hfville"); None leaves the
+    /// current value unchanged (use the dedicated clear flag if ever needed).
+    pub property: Option<String>,
 }
 
 /// Coupon response DTO
@@ -152,6 +161,11 @@ pub struct CouponResponse {
     pub used_count: Option<i32>,
     pub status: Option<CouponStatus>,
     pub created_at: Option<DateTime<Utc>>,
+    /// Optional property restriction ("hf" | "hfville"); None = program-wide.
+    /// `sqlx(default)` keeps SELECTs that don't project this column working.
+    #[serde(default)]
+    #[sqlx(default)]
+    pub property: Option<String>,
 }
 
 /// User coupon response DTO
@@ -187,6 +201,7 @@ impl From<Coupon> for CouponResponse {
             used_count: coupon.used_count,
             status: coupon.status,
             created_at: coupon.created_at,
+            property: coupon.property,
         }
     }
 }

--- a/backend-rust/src/routes/admin_slips.rs
+++ b/backend-rust/src/routes/admin_slips.rs
@@ -227,6 +227,42 @@ async fn verify_slip(
         "Admin verified slip"
     );
 
+    // PMS booking channel (ADR-0003): a verified slip IS the payment event
+    // for a channel booking. Confirm the PMS booking first — if the PMS is
+    // unreachable this returns an error so the admin retries the verify
+    // action (idempotent on both sides) rather than leaving money received
+    // against a hold that would silently expire.
+    let channel_row = sqlx::query!(
+        r#"
+        SELECT pms_booking_id AS "pms_booking_id!",
+               COALESCE(amount_due_now, total_price) AS "amount_received!"
+        FROM bookings WHERE id = $1 AND pms_booking_id IS NOT NULL
+        "#,
+        row.booking_id
+    )
+    .fetch_optional(state.db())
+    .await?;
+    if let Some(channel) = channel_row {
+        let pms_booking_id = channel.pms_booking_id;
+        let pms = crate::services::pms_channel::PmsChannelClient::from_settings(state.config())?;
+        // The PMS needs the received amount — it doesn't persist the
+        // guest's deposit50/full choice.
+        pms.payment_verified(&pms_booking_id, channel.amount_received)
+            .await?;
+        sqlx::query!(
+            r#"UPDATE bookings SET status = 'confirmed', updated_at = NOW()
+               WHERE id = $1 AND status = 'pending'"#,
+            row.booking_id
+        )
+        .execute(state.db())
+        .await?;
+        tracing::info!(
+            booking_id = %row.booking_id,
+            pms_booking_id = %pms_booking_id,
+            "channel booking confirmed after slip verification"
+        );
+    }
+
     Ok(Json(AdminSlipResponse {
         id: row.id,
         booking_id: row.booking_id,

--- a/backend-rust/src/routes/auth.rs
+++ b/backend-rust/src/routes/auth.rs
@@ -687,6 +687,106 @@ async fn login(
     ))
 }
 
+/// LIFF login request (POST /api/auth/liff)
+#[derive(Debug, Deserialize)]
+pub struct LiffLoginRequest {
+    #[serde(rename = "idToken")]
+    pub id_token: String,
+}
+
+/// POST /api/auth/liff - Silent login from inside LINE (LIFF).
+///
+/// Verifies the LIFF ID token with LINE, finds-or-creates the member from
+/// the LINE identity (silent enrollment — docs/launch-plan.md), and issues
+/// the exact same access-token + HttpOnly-refresh-cookie contract as
+/// /api/auth/login. The LIFF app is attached to the LINE Login channel, so
+/// the userId matches web "Sign in with LINE" accounts (ADR-0002).
+async fn liff_login(
+    State(state): State<AppState>,
+    jar: CookieJar,
+    Json(payload): Json<LiffLoginRequest>,
+) -> Result<(CookieJar, Json<AuthResponse>), AppError> {
+    if payload.id_token.trim().is_empty() {
+        return Err(AppError::Validation("idToken is required".to_string()));
+    }
+
+    let config = state.config();
+    let client_id = config
+        .oauth
+        .line
+        .client_id
+        .clone()
+        .ok_or_else(|| AppError::Configuration("LINE login is not configured".to_string()))?;
+
+    // 1. Verify the ID token with LINE.
+    let claims = crate::services::line::verify_liff_id_token(&payload.id_token, &client_id).await?;
+
+    // 2. Silent enrollment: find-or-create the member by LINE userId.
+    let profile = super::oauth::LineProfile {
+        user_id: claims.sub,
+        display_name: claims.name.unwrap_or_else(|| "LINE Member".to_string()),
+        picture_url: claims.picture,
+        status_message: None,
+    };
+    let (oauth_user, is_new_user) = super::oauth::upsert_line_user(&state, &profile).await?;
+    let user_id: Uuid = oauth_user
+        .id
+        .parse()
+        .map_err(|_| AppError::Internal("Invalid user id from enrollment".to_string()))?;
+
+    // 3. Same token + cookie contract as login().
+    let access_token = generate_access_token(
+        &user_id,
+        oauth_user.email.as_deref(),
+        &oauth_user.role,
+        &config.auth.jwt_secret,
+        config.auth.access_token_expiry_secs as i64,
+    )?;
+
+    let refresh_token = generate_refresh_token_string();
+    let refresh_expires_at = Utc::now() + Duration::days(7);
+
+    sqlx::query(
+        r#"
+        INSERT INTO refresh_tokens (user_id, token, expires_at)
+        VALUES ($1, $2, $3)
+        "#,
+    )
+    .bind(user_id)
+    .bind(&refresh_token)
+    .bind(refresh_expires_at)
+    .execute(state.db())
+    .await
+    .map_err(|e| AppError::DatabaseQuery(e.to_string()))?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO user_audit_log (user_id, action, details)
+        VALUES ($1, 'login', $2)
+        "#,
+    )
+    .bind(user_id)
+    .bind(serde_json::json!({ "method": "liff", "isNewUser": is_new_user }))
+    .execute(state.db())
+    .await
+    .map_err(|e| AppError::DatabaseQuery(e.to_string()))?;
+
+    let user_response = get_user_profile(state.db(), &user_id).await?;
+
+    tracing::info!(user_id = %user_id, is_new_user, "LIFF login");
+
+    let refresh_max_age_secs = (refresh_expires_at - Utc::now()).num_seconds().max(0);
+    let jar = jar.add(build_refresh_cookie(refresh_token, refresh_max_age_secs));
+
+    Ok((
+        jar,
+        Json(AuthResponse {
+            user: user_response,
+            tokens: AuthTokens { access_token },
+        }),
+    ))
+}
+
 /// Map a Cloudflare Access verification failure onto the app's error type.
 ///
 /// `FetchFailed` (JWKS unreachable) is a transient infrastructure problem,
@@ -1242,6 +1342,7 @@ pub fn routes() -> Router<AppState> {
     // Public routes (no authentication required)
     let public_routes = Router::<AppState>::new()
         .route("/login", post(login))
+        .route("/liff", post(liff_login))
         .route("/register", post(register))
         .route("/refresh", post(refresh))
         .route("/reset-password/request", post(forgot_password))
@@ -1269,6 +1370,7 @@ pub fn routes_with_state(state: AppState) -> Router {
     // Public routes (no authentication required)
     let public_routes = Router::<AppState>::new()
         .route("/auth/login", post(login))
+        .route("/auth/liff", post(liff_login))
         .route("/auth/register", post(register))
         .route("/auth/refresh", post(refresh))
         .route("/auth/reset-password/request", post(forgot_password))

--- a/backend-rust/src/routes/bookings.rs
+++ b/backend-rust/src/routes/bookings.rs
@@ -20,7 +20,10 @@ use validator::Validate;
 use crate::error::{AppError, AppResult};
 use crate::middleware::auth::{auth_middleware, has_role, AuthUser};
 use crate::models::booking::{BookingResponse, BookingStatus, RoomType};
+use crate::services::pms_channel::{PmsChannelClient, PmsCreateBookingRequest, PmsGuest};
+use crate::services::promptpay::PromptPayService;
 use crate::state::AppState;
+use crate::types::Property;
 
 // ==================== REQUEST/RESPONSE TYPES ====================
 
@@ -50,15 +53,6 @@ fn default_page() -> i32 {
 
 fn default_limit() -> i32 {
     20
-}
-
-/// Availability check query parameters
-#[derive(Debug, Deserialize, Validate)]
-#[serde(rename_all = "camelCase")]
-pub struct AvailabilityQuery {
-    pub check_in: NaiveDate,
-    pub check_out: NaiveDate,
-    pub room_type: Option<String>,
 }
 
 /// Create booking request
@@ -143,19 +137,6 @@ pub struct BookingListResponse {
     pub page: i32,
     pub limit: i32,
     pub total_pages: i32,
-}
-
-/// Room availability response
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AvailabilityResponse {
-    pub available: bool,
-    pub room_type: Option<String>,
-    pub check_in: NaiveDate,
-    pub check_out: NaiveDate,
-    pub available_rooms: i32,
-    pub price_per_night: Option<Decimal>,
-    pub total_price: Option<Decimal>,
 }
 
 /// Success response for operations
@@ -694,36 +675,9 @@ async fn delete_booking_slip(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// GET /api/bookings/availability - Check room availability
-///
-/// Query parameters:
-/// - checkIn: Check-in date (YYYY-MM-DD)
-/// - checkOut: Check-out date (YYYY-MM-DD)
-/// - roomType: Optional room type filter
-async fn check_availability(
-    State(state): State<AppState>,
-    Query(params): Query<AvailabilityQuery>,
-) -> AppResult<Json<AvailabilityResponse>> {
-    // Validate date range
-    if params.check_out <= params.check_in {
-        return Err(AppError::Validation(
-            "Check-out date must be after check-in date".to_string(),
-        ));
-    }
-
-    // Parse room type if provided
-    let room_type = params
-        .room_type
-        .as_deref()
-        .map(parse_room_type)
-        .transpose()?;
-
-    // Check availability in database
-    let availability =
-        check_room_availability(state.db(), params.check_in, params.check_out, room_type).await?;
-
-    Ok(Json(availability))
-}
+// Legacy local-inventory availability (check_availability /
+// check_room_availability) was removed with ADR-0003: availability truth
+// lives in the PMS; see channel_availability below.
 
 // ==================== DATABASE ROW TYPES ====================
 
@@ -733,8 +687,10 @@ async fn check_availability(
 struct BookingRow {
     pub id: Uuid,
     pub user_id: Uuid,
-    pub room_id: Uuid,
-    pub room_type_id: Uuid,
+    // Nullable since the PMS booking channel (ADR-0003): channel bookings
+    // carry no local room — the PMS assigns physical rooms.
+    pub room_id: Option<Uuid>,
+    pub room_type_id: Option<Uuid>,
     pub check_in_date: NaiveDate,
     pub check_out_date: NaiveDate,
     pub num_guests: i32,
@@ -798,11 +754,10 @@ impl BookingRow {
     }
 }
 
-/// Room type row for availability check
+/// Room type row for legacy booking creation (price lookup)
 #[derive(Debug, FromRow)]
 struct RoomTypeRow {
     pub id: Uuid,
-    pub name: String,
     pub price_per_night: Decimal,
 }
 
@@ -1000,7 +955,7 @@ async fn insert_booking(
     // Find the room type (read-only, safe to do outside the transaction)
     let room_type_row: RoomTypeRow = sqlx::query_as(
         r#"
-        SELECT id, name, price_per_night
+        SELECT id, price_per_night
         FROM room_types
         WHERE LOWER(name) = LOWER($1) AND is_active = true
         "#,
@@ -1027,10 +982,13 @@ async fn insert_booking(
         WHERE r.room_type_id = $1
           AND r.is_active = true
           AND r.id NOT IN (
-            -- Exclude rooms with existing bookings that overlap
+            -- Exclude rooms with existing bookings that overlap.
+            -- room_id IS NOT NULL guards the NOT-IN-with-NULL trap:
+            -- channel bookings (ADR-0003) have no local room.
             SELECT DISTINCT b.room_id
             FROM bookings b
-            WHERE b.status NOT IN ('cancelled', 'no_show')
+            WHERE b.room_id IS NOT NULL
+              AND b.status NOT IN ('cancelled', 'no_show')
               AND b.check_in_date < $3
               AND b.check_out_date > $2
           )
@@ -1129,7 +1087,7 @@ async fn update_booking_in_db(
 
         let room_type_row: RoomTypeRow = sqlx::query_as(
             r#"
-            SELECT id, name, price_per_night
+            SELECT id, price_per_night
             FROM room_types
             WHERE LOWER(name) = LOWER($1) AND is_active = true
             "#,
@@ -1147,9 +1105,12 @@ async fn update_booking_in_db(
             WHERE r.room_type_id = $1
               AND r.is_active = true
               AND r.id NOT IN (
+                -- room_id IS NOT NULL guards the NOT-IN-with-NULL trap:
+                -- channel bookings (ADR-0003) have no local room.
                 SELECT DISTINCT b.room_id
                 FROM bookings b
-                WHERE b.status NOT IN ('cancelled')
+                WHERE b.room_id IS NOT NULL
+                  AND b.status NOT IN ('cancelled')
                   AND b.id != $4
                   AND b.check_in_date < $3
                   AND b.check_out_date > $2
@@ -1253,125 +1214,7 @@ async fn complete_booking_in_db(db: &PgPool, booking_id: Uuid) -> AppResult<Book
     query_booking_by_id(db, booking_id).await
 }
 
-async fn check_room_availability(
-    db: &PgPool,
-    check_in: NaiveDate,
-    check_out: NaiveDate,
-    room_type: Option<RoomType>,
-) -> AppResult<AvailabilityResponse> {
-    let nights = (check_out - check_in).num_days() as i32;
-
-    if let Some(rt) = room_type {
-        let room_type_name = format!("{:?}", rt);
-
-        // Get room type info
-        let room_type_info: Option<RoomTypeRow> = sqlx::query_as(
-            r#"
-            SELECT id, name, price_per_night
-            FROM room_types
-            WHERE LOWER(name) = LOWER($1) AND is_active = true
-            "#,
-        )
-        .bind(&room_type_name)
-        .fetch_optional(db)
-        .await?;
-
-        if let Some(rt_info) = room_type_info {
-            // Count available rooms
-            let available_count: (i64,) = sqlx::query_as(
-                r#"
-                SELECT COUNT(*)
-                FROM rooms r
-                WHERE r.room_type_id = $1
-                  AND r.is_active = true
-                  AND r.id NOT IN (
-                    SELECT DISTINCT b.room_id
-                    FROM bookings b
-                    WHERE b.status NOT IN ('cancelled')
-                      AND b.check_in_date < $3
-                      AND b.check_out_date > $2
-                  )
-                  AND r.id NOT IN (
-                    SELECT DISTINCT rbd.room_id
-                    FROM room_blocked_dates rbd
-                    WHERE rbd.blocked_date >= $2 AND rbd.blocked_date < $3
-                  )
-                "#,
-            )
-            .bind(rt_info.id)
-            .bind(check_in)
-            .bind(check_out)
-            .fetch_one(db)
-            .await?;
-
-            let total_price = rt_info.price_per_night * Decimal::from(nights);
-
-            Ok(AvailabilityResponse {
-                available: available_count.0 > 0,
-                room_type: Some(rt_info.name.to_lowercase()),
-                check_in,
-                check_out,
-                available_rooms: available_count.0 as i32,
-                price_per_night: Some(rt_info.price_per_night),
-                total_price: Some(total_price),
-            })
-        } else {
-            Ok(AvailabilityResponse {
-                available: false,
-                room_type: Some(room_type_name.to_lowercase()),
-                check_in,
-                check_out,
-                available_rooms: 0,
-                price_per_night: None,
-                total_price: None,
-            })
-        }
-    } else {
-        // Check all room types
-        let total_available: (i64,) = sqlx::query_as(
-            r#"
-            SELECT COUNT(*)
-            FROM rooms r
-            WHERE r.is_active = true
-              AND r.id NOT IN (
-                SELECT DISTINCT b.room_id
-                FROM bookings b
-                WHERE b.status NOT IN ('cancelled')
-                  AND b.check_in_date < $2
-                  AND b.check_out_date > $1
-              )
-              AND r.id NOT IN (
-                SELECT DISTINCT rbd.room_id
-                FROM room_blocked_dates rbd
-                WHERE rbd.blocked_date >= $1 AND rbd.blocked_date < $2
-              )
-            "#,
-        )
-        .bind(check_in)
-        .bind(check_out)
-        .fetch_one(db)
-        .await?;
-
-        // Get cheapest room type for price reference
-        let cheapest: Option<(Decimal,)> =
-            sqlx::query_as("SELECT MIN(price_per_night) FROM room_types WHERE is_active = true")
-                .fetch_optional(db)
-                .await?;
-
-        let price_per_night = cheapest.map(|c| c.0);
-        let total_price = price_per_night.map(|p| p * Decimal::from(nights));
-
-        Ok(AvailabilityResponse {
-            available: total_available.0 > 0,
-            room_type: None,
-            check_in,
-            check_out,
-            available_rooms: total_available.0 as i32,
-            price_per_night,
-            total_price,
-        })
-    }
-}
+// check_room_availability was removed with ADR-0003 (see note above).
 
 async fn award_loyalty_points(
     db: &PgPool,
@@ -1560,6 +1403,266 @@ fn parse_room_type(room_type: &str) -> AppResult<RoomType> {
 ///
 /// All routes require authentication.
 /// Admin-only routes are protected with role checks within handlers.
+// ==================== PMS BOOKING CHANNEL (ADR-0003) ====================
+// Locked contract: docs/launch-plan.md. The app holds no inventory —
+// availability comes live from the PMS and confirmed bookings are created
+// there; the local row is a channel record for history/slips/payment.
+
+#[derive(Debug, Deserialize)]
+pub struct ChannelAvailabilityQuery {
+    pub property: Property,
+    pub check_in: NaiveDate,
+    pub check_out: NaiveDate,
+    pub guests: i32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChannelRoomTypeResponse {
+    pub room_type_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    /// Reserved for catalog enrichment; the PMS carries no photos yet.
+    pub photo_url: Option<String>,
+    pub nightly_price: f64,
+    pub available_count: i32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChannelAvailabilityResponse {
+    pub property: Property,
+    pub check_in: NaiveDate,
+    pub check_out: NaiveDate,
+    pub room_types: Vec<ChannelRoomTypeResponse>,
+}
+
+fn validate_channel_dates(check_in: NaiveDate, check_out: NaiveDate) -> AppResult<()> {
+    if check_out <= check_in {
+        return Err(AppError::Validation(
+            "check_out must be after check_in".to_string(),
+        ));
+    }
+    if check_in < Utc::now().date_naive() {
+        return Err(AppError::Validation(
+            "check_in cannot be in the past".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// GET /api/bookings/availability — live availability from the PMS.
+async fn channel_availability(
+    State(state): State<AppState>,
+    Extension(_user): Extension<AuthUser>,
+    Query(query): Query<ChannelAvailabilityQuery>,
+) -> AppResult<Json<ChannelAvailabilityResponse>> {
+    use rust_decimal::prelude::ToPrimitive;
+
+    validate_channel_dates(query.check_in, query.check_out)?;
+    if !(1..=10).contains(&query.guests) {
+        return Err(AppError::Validation(
+            "guests must be between 1 and 10".to_string(),
+        ));
+    }
+
+    let pms = PmsChannelClient::from_settings(state.config())?;
+    let availability = pms
+        .availability(
+            query.property,
+            query.check_in,
+            query.check_out,
+            query.guests,
+        )
+        .await?;
+
+    let room_types = availability
+        .room_types
+        .into_iter()
+        .map(|rt| ChannelRoomTypeResponse {
+            room_type_id: rt.room_type_id,
+            name: rt.name,
+            description: rt.description,
+            photo_url: None,
+            nightly_price: rt.nightly_price.to_f64().unwrap_or(0.0),
+            available_count: rt.available_count,
+        })
+        .collect();
+
+    Ok(Json(ChannelAvailabilityResponse {
+        property: query.property,
+        check_in: query.check_in,
+        check_out: query.check_out,
+        room_types,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateChannelBookingRequest {
+    pub property: Property,
+    pub room_type_id: String,
+    pub check_in: NaiveDate,
+    pub check_out: NaiveDate,
+    pub guests: i32,
+    pub guest_name: String,
+    pub guest_phone: String,
+    /// "deposit50" | "full" — 50% deposit or pay in full (guest's choice).
+    pub payment_option: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChannelBookingResponse {
+    pub booking_id: Uuid,
+    pub pms_booking_id: String,
+    pub total_amount: f64,
+    pub amount_due_now: f64,
+    pub balance_due_at_checkin: f64,
+    /// Raw EMVCo PromptPay payload — the frontend renders it as a QR.
+    pub promptpay_qr_payload: String,
+    pub hold_expires_at: DateTime<Utc>,
+}
+
+/// POST /api/bookings/channel — create a held booking in the PMS, generate
+/// the property-specific PromptPay payload, and record the channel row.
+async fn create_channel_booking(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthUser>,
+    Json(payload): Json<CreateChannelBookingRequest>,
+) -> AppResult<(StatusCode, Json<ChannelBookingResponse>)> {
+    use rust_decimal::prelude::ToPrimitive;
+
+    validate_channel_dates(payload.check_in, payload.check_out)?;
+    if !(1..=10).contains(&payload.guests) {
+        return Err(AppError::Validation(
+            "guests must be between 1 and 10".to_string(),
+        ));
+    }
+    if !matches!(payload.payment_option.as_str(), "deposit50" | "full") {
+        return Err(AppError::Validation(
+            "payment_option must be deposit50 or full".to_string(),
+        ));
+    }
+    let guest_name = payload.guest_name.trim();
+    let guest_phone = payload.guest_phone.trim();
+    if guest_name.is_empty() || guest_phone.is_empty() {
+        return Err(AppError::Validation(
+            "guest_name and guest_phone are required".to_string(),
+        ));
+    }
+
+    let user_uuid = Uuid::parse_str(&user.id)
+        .map_err(|_| AppError::InvalidInput("Invalid user ID format".to_string()))?;
+
+    // PromptPay must be configured for this property BEFORE we create the
+    // PMS hold — fail fast rather than holding a room we can't charge for.
+    let promptpay_id = state
+        .config()
+        .promptpay
+        .id_for_property(payload.property.as_str())
+        .cloned()
+        .ok_or_else(|| {
+            AppError::Configuration(format!(
+                "PromptPay account for {} is not configured",
+                payload.property
+            ))
+        })?;
+    let promptpay = PromptPayService::new(promptpay_id)?;
+
+    // Pass the membership through so the PMS links the guest profile —
+    // the Link is what makes checkout accrual work (docs/launch-plan.md).
+    let membership_id: Option<String> = sqlx::query_scalar!(
+        r#"SELECT membership_id FROM user_profiles WHERE user_id = $1"#,
+        user_uuid
+    )
+    .fetch_optional(state.db())
+    .await?;
+
+    let pms = PmsChannelClient::from_settings(state.config())?;
+    let created = pms
+        .create_booking(&PmsCreateBookingRequest {
+            property: payload.property,
+            room_type_id: payload.room_type_id.clone(),
+            check_in: payload.check_in,
+            check_out: payload.check_out,
+            guests: payload.guests,
+            guest: PmsGuest {
+                name: guest_name.to_string(),
+                phone: guest_phone.to_string(),
+            },
+            membership_id,
+            payment: payload.payment_option.clone(),
+        })
+        .await?;
+
+    let balance_due = created.total - created.amount_due_now;
+    let amount_due_now_f64 = created
+        .amount_due_now
+        .to_f64()
+        .ok_or_else(|| AppError::Internal("PMS returned a non-representable amount".to_string()))?;
+    let qr_payload = promptpay.generate_payload(amount_due_now_f64)?;
+
+    // Record the channel row. If this fails, release the PMS hold so we
+    // never strand inventory behind a booking the guest can't see.
+    let booking_id = Uuid::new_v4();
+    let inserted = sqlx::query!(
+        r#"
+        INSERT INTO bookings (
+            id, user_id, check_in_date, check_out_date, num_guests,
+            total_price, status, property, pms_booking_id, pms_room_type_id,
+            guest_name, guest_phone, payment_option, amount_due_now,
+            balance_due, hold_expires_at
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, 'pending', $7, $8, $9, $10, $11, $12, $13, $14, $15)
+        "#,
+        booking_id,
+        user_uuid,
+        payload.check_in,
+        payload.check_out,
+        payload.guests,
+        created.total,
+        payload.property.as_str(),
+        created.pms_booking_id,
+        payload.room_type_id,
+        guest_name,
+        guest_phone,
+        payload.payment_option,
+        created.amount_due_now,
+        balance_due,
+        created.hold_expires_at,
+    )
+    .execute(state.db())
+    .await;
+
+    if let Err(e) = inserted {
+        tracing::error!(error = %e, pms_booking_id = %created.pms_booking_id,
+            "channel record insert failed; releasing PMS hold");
+        if let Err(release_err) = pms.release(&created.pms_booking_id).await {
+            tracing::error!(error = %release_err, pms_booking_id = %created.pms_booking_id,
+                "failed to release PMS hold after insert failure");
+        }
+        return Err(e.into());
+    }
+
+    tracing::info!(
+        booking_id = %booking_id,
+        pms_booking_id = %created.pms_booking_id,
+        property = %payload.property,
+        payment_option = %payload.payment_option,
+        "channel booking held"
+    );
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ChannelBookingResponse {
+            booking_id,
+            pms_booking_id: created.pms_booking_id,
+            total_amount: created.total.to_f64().unwrap_or(0.0),
+            amount_due_now: amount_due_now_f64,
+            balance_due_at_checkin: balance_due.to_f64().unwrap_or(0.0),
+            promptpay_qr_payload: qr_payload,
+            hold_expires_at: created.hold_expires_at,
+        }),
+    ))
+}
+
 pub fn routes() -> Router<AppState> {
     router()
 }
@@ -1581,8 +1684,11 @@ pub fn routes() -> Router<AppState> {
 /// Admin-only operations are protected with role checks within handlers.
 pub fn router() -> Router<AppState> {
     Router::new()
-        // Public availability check (but still requires auth for rate limiting)
-        .route("/availability", get(check_availability))
+        // Live availability from the PMS (ADR-0003). Replaces the old
+        // local-inventory availability check.
+        .route("/availability", get(channel_availability))
+        // Create a held booking in the PMS + local channel record.
+        .route("/channel", post(create_channel_booking))
         // User booking routes
         .route("/", get(list_bookings))
         .route("/", post(create_booking))
@@ -1612,7 +1718,6 @@ pub fn routes_without_auth() -> Router<AppState> {
 #[cfg(test)]
 pub fn router_without_auth() -> Router<AppState> {
     Router::new()
-        .route("/availability", get(check_availability))
         .route("/", get(list_bookings))
         .route("/", post(create_booking))
         .route("/:id", get(get_booking))

--- a/backend-rust/src/routes/coupons.rs
+++ b/backend-rust/src/routes/coupons.rs
@@ -145,6 +145,9 @@ pub struct RedeemCouponRequest {
     pub transaction_reference: Option<String>,
     /// Location of redemption
     pub location: Option<String>,
+    /// Property where the redemption happens ("hf" | "hfville").
+    /// Required when the coupon carries a property restriction.
+    pub property: Option<crate::types::Property>,
     /// Additional metadata
     pub metadata: Option<serde_json::Value>,
 }
@@ -333,7 +336,8 @@ async fn list_coupons(
                 usage_limit_per_user,
                 used_count,
                 status::text as "status",
-                created_at
+                created_at,
+                property
             FROM coupons
             WHERE
                 ($1::text IS NULL OR status::text = $1)
@@ -360,6 +364,7 @@ async fn list_coupons(
                 description: r.description,
                 terms_and_conditions: r.terms_and_conditions,
                 coupon_type: parse_coupon_type(&r.coupon_type),
+                property: r.property,
                 value: r.value,
                 currency: r.currency,
                 minimum_spend: r.minimum_spend,
@@ -415,7 +420,8 @@ async fn list_coupons(
                 usage_limit_per_user,
                 used_count,
                 status::text as "status",
-                created_at
+                created_at,
+                property
             FROM coupons
             WHERE status = 'active'
                 AND ($1::text IS NULL OR type::text = $1)
@@ -442,6 +448,7 @@ async fn list_coupons(
                 description: r.description,
                 terms_and_conditions: r.terms_and_conditions,
                 coupon_type: parse_coupon_type(&r.coupon_type),
+                property: r.property,
                 value: r.value,
                 currency: r.currency,
                 minimum_spend: r.minimum_spend,
@@ -625,7 +632,8 @@ async fn get_coupon(
             usage_limit_per_user,
             used_count,
             status::text as "status",
-            created_at
+            created_at,
+            property
         FROM coupons
         WHERE id = $1
         "#,
@@ -642,6 +650,7 @@ async fn get_coupon(
         description: row.description,
         terms_and_conditions: row.terms_and_conditions,
         coupon_type: parse_coupon_type(&row.coupon_type),
+        property: row.property,
         value: row.value,
         currency: row.currency,
         minimum_spend: row.minimum_spend,
@@ -721,6 +730,13 @@ async fn create_coupon(
         }
     }
 
+    // Optional property restriction must name a real property.
+    if let Some(p) = request.property.as_deref() {
+        p.parse::<crate::types::Property>().map_err(|_| {
+            AppError::Validation("property must be one of: hf, hfville".to_string())
+        })?;
+    }
+
     let user_uuid = Uuid::parse_str(&user.id)
         .map_err(|_| AppError::InvalidInput("Invalid user ID format".to_string()))?;
 
@@ -740,11 +756,11 @@ async fn create_coupon(
             type, value, currency, minimum_spend, maximum_discount,
             valid_from, valid_until, usage_limit, usage_limit_per_user,
             tier_restrictions, customer_segment, status, created_by,
-            created_at, updated_at
+            property, created_at, updated_at
         )
         VALUES (
             $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
-            $11, $12, $13, $14, $15, $16, $17, $18, NOW(), NOW()
+            $11, $12, $13, $14, $15, $16, $17, $18, $19, NOW(), NOW()
         )
         RETURNING
             id,
@@ -763,7 +779,8 @@ async fn create_coupon(
             usage_limit_per_user,
             used_count,
             status,
-            created_at
+            created_at,
+            property
         "#,
     )
     .bind(coupon_id)
@@ -784,6 +801,7 @@ async fn create_coupon(
     .bind(&request.customer_segment)
     .bind(&status)
     .bind(user_uuid)
+    .bind(&request.property)
     .fetch_one(state.db())
     .await
     .map_err(|e: sqlx::Error| {
@@ -812,6 +830,13 @@ async fn update_coupon(
     Path(coupon_id): Path<Uuid>,
     Json(request): Json<UpdateCouponRequest>,
 ) -> AppResult<Json<SuccessResponse<CouponResponse>>> {
+    // Optional property restriction must name a real property.
+    if let Some(p) = request.property.as_deref() {
+        p.parse::<crate::types::Property>().map_err(|_| {
+            AppError::Validation("property must be one of: hf, hfville".to_string())
+        })?;
+    }
+
     // Validate percentage value if updating
     if let Some(value) = request.value {
         if value > Decimal::from(100) {
@@ -852,6 +877,7 @@ async fn update_coupon(
             tier_restrictions = COALESCE($13, tier_restrictions),
             customer_segment = COALESCE($14, customer_segment),
             status = COALESCE($15, status),
+            property = COALESCE($16, property),
             updated_at = NOW()
         WHERE id = $1
         RETURNING
@@ -871,7 +897,8 @@ async fn update_coupon(
             usage_limit_per_user,
             used_count,
             status,
-            created_at
+            created_at,
+            property
         "#,
     )
     .bind(coupon_id)
@@ -889,6 +916,7 @@ async fn update_coupon(
     .bind(&request.tier_restrictions)
     .bind(&request.customer_segment)
     .bind(&request.status)
+    .bind(&request.property)
     .fetch_optional(state.db())
     .await?
     .ok_or_else(|| AppError::NotFound("Coupon".to_string()))?;
@@ -1059,7 +1087,8 @@ async fn redeem_coupon(
             c.value,
             c.minimum_spend,
             c.maximum_discount,
-            c.currency
+            c.currency,
+            c.property
         FROM user_coupons uc
         JOIN coupons c ON uc.coupon_id = c.id
         WHERE uc.qr_code = $1
@@ -1082,6 +1111,20 @@ async fn redeem_coupon(
     if let Some(expires_at) = user_coupon.expires_at {
         if expires_at < Utc::now() {
             return Err(AppError::Validation("Coupon has expired".to_string()));
+        }
+    }
+
+    // Property restriction (ADR-0001): a property-scoped coupon redeems
+    // only at that property; the redeeming staff must say where they are.
+    if let Some(required) = user_coupon.property.as_deref() {
+        let required_property: crate::types::Property = required
+            .parse()
+            .map_err(|_| AppError::Internal(format!("Coupon has invalid property {required}")))?;
+        if request.property != Some(required_property) {
+            return Err(AppError::Validation(format!(
+                "This coupon can only be redeemed at {}",
+                required_property.display_name()
+            )));
         }
     }
 
@@ -1121,6 +1164,7 @@ async fn redeem_coupon(
         "finalAmount": final_amount,
         "transactionReference": request.transaction_reference,
         "location": request.location,
+        "property": request.property,
         "metadata": request.metadata
     });
 

--- a/backend-rust/src/routes/line_webhook.rs
+++ b/backend-rust/src/routes/line_webhook.rs
@@ -1,0 +1,123 @@
+//! LINE Messaging API webhooks — one endpoint per property OA.
+//!
+//! POST /api/line/webhook/{property} receives events from that property's
+//! OA channel. Signature verification (X-Line-Signature, HMAC-SHA256 with
+//! the channel secret) is the authentication; there is no JWT on this
+//! route. Only follow/unfollow events are consumed — they maintain the
+//! `line_friendships` table that drives property-affinity push routing.
+
+use axum::{
+    body::Bytes,
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    routing::post,
+    Router,
+};
+use serde::Deserialize;
+
+use crate::error::{AppError, AppResult};
+use crate::services::line::verify_line_signature;
+use crate::state::AppState;
+use crate::types::Property;
+
+#[derive(Debug, Deserialize)]
+struct WebhookPayload {
+    #[serde(default)]
+    events: Vec<WebhookEvent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WebhookEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    source: Option<WebhookSource>,
+}
+
+#[derive(Debug, Deserialize)]
+struct WebhookSource {
+    #[serde(rename = "userId")]
+    user_id: Option<String>,
+}
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/webhook/:property", post(line_webhook))
+}
+
+async fn line_webhook(
+    State(state): State<AppState>,
+    Path(property): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> AppResult<StatusCode> {
+    let property: Property = property
+        .parse()
+        .map_err(|_| AppError::NotFound("Unknown property".to_string()))?;
+
+    let channel = state
+        .config()
+        .line_messaging
+        .channel(property.as_str())
+        .ok_or_else(|| AppError::NotFound("Unknown property".to_string()))?;
+    let Some(secret) = channel.channel_secret.as_ref() else {
+        // Channel not wired yet — don't accept unverifiable traffic.
+        return Err(AppError::Configuration(format!(
+            "LINE messaging channel for {property} is not configured"
+        )));
+    };
+
+    let signature = headers
+        .get("x-line-signature")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    if !verify_line_signature(secret, &body, signature) {
+        tracing::warn!(property = %property, "LINE webhook signature verification failed");
+        return Err(AppError::Unauthorized("Invalid signature".to_string()));
+    }
+
+    let payload: WebhookPayload = serde_json::from_slice(&body)
+        .map_err(|e| AppError::BadRequest(format!("Malformed webhook payload: {e}")))?;
+
+    for event in payload.events {
+        let Some(line_user_id) = event.source.as_ref().and_then(|s| s.user_id.as_deref()) else {
+            continue;
+        };
+        match event.event_type.as_str() {
+            "follow" => {
+                sqlx::query!(
+                    r#"
+                    INSERT INTO line_friendships (line_user_id, property, is_friend, followed_at, updated_at)
+                    VALUES ($1, $2, TRUE, NOW(), NOW())
+                    ON CONFLICT (line_user_id, property)
+                    DO UPDATE SET is_friend = TRUE, followed_at = NOW(), updated_at = NOW()
+                    "#,
+                    line_user_id,
+                    property.as_str(),
+                )
+                .execute(state.db())
+                .await?;
+                tracing::info!(property = %property, "LINE follow recorded");
+            },
+            "unfollow" => {
+                sqlx::query!(
+                    r#"
+                    INSERT INTO line_friendships (line_user_id, property, is_friend, followed_at, updated_at)
+                    VALUES ($1, $2, FALSE, NOW(), NOW())
+                    ON CONFLICT (line_user_id, property)
+                    DO UPDATE SET is_friend = FALSE, updated_at = NOW()
+                    "#,
+                    line_user_id,
+                    property.as_str(),
+                )
+                .execute(state.db())
+                .await?;
+                tracing::info!(property = %property, "LINE unfollow recorded");
+            },
+            // Other event types (message, postback, …) are acknowledged
+            // and ignored — in-chat replies are explicitly out of scope.
+            _ => {},
+        }
+    }
+
+    Ok(StatusCode::OK)
+}

--- a/backend-rust/src/routes/loyalty.rs
+++ b/backend-rust/src/routes/loyalty.rs
@@ -572,7 +572,277 @@ pub fn routes() -> Router<AppState> {
         .route("/admin/deduct-nights", post(admin_deduct_nights))
         .layer(middleware::from_fn(auth_middleware));
 
-    public_routes.merge(auth_routes).merge(admin_routes)
+    // Machine-to-machine routes: the PMS checkout hook. Authenticated by
+    // service token inside the handler (no JWT/auth_middleware).
+    let service_routes = Router::new().route("/stays", post(record_stay));
+
+    public_routes
+        .merge(auth_routes)
+        .merge(admin_routes)
+        .merge(service_routes)
+}
+
+// ============================================================================
+// PMS stay accrual (service-token; docs/launch-plan.md locked contract)
+// ============================================================================
+
+/// Stay accrual request posted by the PMS checkout hook at guest checkout.
+#[derive(Debug, Deserialize)]
+pub struct StayAccrualRequest {
+    pub pms_stay_id: String,
+    pub membership_id: String,
+    pub property: crate::types::Property,
+    pub check_in: chrono::NaiveDate,
+    pub check_out: chrono::NaiveDate,
+    pub nights: i32,
+}
+
+#[derive(Debug, Serialize)]
+pub struct StayAccrualResponse {
+    pub stay_id: Uuid,
+    pub user_id: Uuid,
+    pub property: crate::types::Property,
+    pub nights: i32,
+    pub points_awarded: i32,
+    pub already_processed: bool,
+}
+
+/// Service-token check for machine callers. Compares SHA-256 digests so the
+/// comparison time doesn't depend on the matching prefix length.
+fn verify_service_token(state: &AppState, headers: &axum::http::HeaderMap) -> Result<(), AppError> {
+    use sha2::{Digest, Sha256};
+
+    let expected = state
+        .config()
+        .loyalty_service
+        .token
+        .as_deref()
+        .ok_or_else(|| {
+            AppError::Configuration("LOYALTY_SERVICE_TOKEN is not configured".to_string())
+        })?;
+    let given = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .unwrap_or("");
+    if given.is_empty() || Sha256::digest(given.as_bytes()) != Sha256::digest(expected.as_bytes()) {
+        return Err(AppError::Unauthorized("Invalid service token".to_string()));
+    }
+    Ok(())
+}
+
+/// Current tier name for a user (None when unranked).
+async fn tier_name(db: &PgPool, user_id: Uuid) -> Result<Option<String>, AppError> {
+    let name: Option<Option<String>> = sqlx::query_scalar!(
+        r#"
+        SELECT t.name AS "name?"
+        FROM user_loyalty ul
+        LEFT JOIN tiers t ON ul.tier_id = t.id
+        WHERE ul.user_id = $1
+        "#,
+        user_id
+    )
+    .fetch_optional(db)
+    .await?;
+    Ok(name.flatten())
+}
+
+/// POST /api/loyalty/stays — record a completed stay from the PMS.
+///
+/// Idempotent by `pms_stay_id`: replays return 200 with the recorded result
+/// and `already_processed: true`; first processing returns 201. Awards
+/// nights (tier-driving) plus points from the active per-night earning rule
+/// via the `award_points` stored procedure, stamps the property on the
+/// points transaction, and sends the property-affinity LINE push.
+async fn record_stay(
+    State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
+    Json(payload): Json<StayAccrualRequest>,
+) -> Result<(StatusCode, Json<StayAccrualResponse>), AppError> {
+    verify_service_token(&state, &headers)?;
+
+    if payload.nights <= 0 {
+        return Err(AppError::Validation("nights must be positive".to_string()));
+    }
+    if payload.check_out <= payload.check_in {
+        return Err(AppError::Validation(
+            "check_out must be after check_in".to_string(),
+        ));
+    }
+    if payload.pms_stay_id.trim().is_empty() || payload.pms_stay_id.len() > 100 {
+        return Err(AppError::Validation("invalid pms_stay_id".to_string()));
+    }
+
+    let db = state.db();
+
+    // Resolve the member through the Link's membership ID.
+    let user_id: Option<Uuid> = sqlx::query_scalar!(
+        r#"SELECT user_id FROM user_profiles WHERE membership_id = $1"#,
+        payload.membership_id
+    )
+    .fetch_optional(db)
+    .await?;
+    let user_id = user_id.ok_or_else(|| {
+        AppError::NotFound(format!(
+            "No member with membership_id {}",
+            payload.membership_id
+        ))
+    })?;
+
+    // Idempotency gate: first writer wins the pms_stay_id.
+    let inserted: Option<Uuid> = sqlx::query_scalar!(
+        r#"
+        INSERT INTO stays (pms_stay_id, user_id, property, check_in, check_out, nights)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT (pms_stay_id) DO NOTHING
+        RETURNING id
+        "#,
+        payload.pms_stay_id,
+        user_id,
+        payload.property.as_str(),
+        payload.check_in,
+        payload.check_out,
+        payload.nights
+    )
+    .fetch_optional(db)
+    .await?;
+
+    let Some(stay_id) = inserted else {
+        let existing = sqlx::query!(
+            r#"
+            SELECT id, user_id, property, nights, points_awarded
+            FROM stays WHERE pms_stay_id = $1
+            "#,
+            payload.pms_stay_id
+        )
+        .fetch_one(db)
+        .await?;
+        return Ok((
+            StatusCode::OK,
+            Json(StayAccrualResponse {
+                stay_id: existing.id,
+                user_id: existing.user_id,
+                property: existing.property.parse().unwrap_or(payload.property),
+                nights: existing.nights,
+                points_awarded: existing.points_awarded,
+                already_processed: true,
+            }),
+        ));
+    };
+
+    // Points: nights × the active per-night earning rule; no rule → nights only.
+    let points_per_night: Option<rust_decimal::Decimal> = sqlx::query_scalar!(
+        r#"
+        SELECT points_per_unit
+        FROM points_earning_rules
+        WHERE unit_type = 'night'
+          AND is_active = TRUE
+          AND (valid_from IS NULL OR valid_from <= NOW())
+          AND (valid_until IS NULL OR valid_until >= NOW())
+        ORDER BY created_at DESC
+        LIMIT 1
+        "#
+    )
+    .fetch_optional(db)
+    .await?;
+    let points: i32 = {
+        use rust_decimal::prelude::ToPrimitive;
+        points_per_night
+            .map(|rate| rate * rust_decimal::Decimal::from(payload.nights))
+            .and_then(|total| total.round().to_i32())
+            .unwrap_or(0)
+    };
+
+    let tier_before = tier_name(db, user_id).await?;
+
+    // Nights + points + tier recalculation, all inside the stored procedure.
+    let description = format!(
+        "Stay at {} ({} nights)",
+        payload.property.display_name(),
+        payload.nights
+    );
+    let award: JsonValue = sqlx::query_scalar!(
+        r#"
+        SELECT award_points($1, $2, 'earned_stay'::varchar, $3, $4, NULL, NULL, $5) AS "result!"
+        "#,
+        user_id,
+        points,
+        description,
+        payload.pms_stay_id,
+        payload.nights
+    )
+    .fetch_one(db)
+    .await?;
+
+    let tx_id = award
+        .get("transaction_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| Uuid::parse_str(s).ok());
+
+    // Property attribution (ADR-0001) + accrual bookkeeping on the stay row.
+    if let Some(tx_id) = tx_id {
+        sqlx::query!(
+            r#"UPDATE points_transactions SET property = $1 WHERE id = $2"#,
+            payload.property.as_str(),
+            tx_id
+        )
+        .execute(db)
+        .await?;
+    }
+    sqlx::query!(
+        r#"UPDATE stays SET points_awarded = $1, points_transaction_id = $2 WHERE id = $3"#,
+        points,
+        tx_id,
+        stay_id
+    )
+    .execute(db)
+    .await?;
+
+    // Property-affinity push — best-effort by design; accrual never fails
+    // because LINE is down.
+    let tier_after = tier_name(db, user_id).await?;
+    let mut message = format!(
+        "ขอบคุณที่เข้าพักที่ {} ค่ะ 🙏\nคุณได้รับ {} คืน และ {} คะแนน",
+        payload.property.display_name(),
+        payload.nights,
+        points
+    );
+    if tier_after != tier_before {
+        if let Some(new_tier) = &tier_after {
+            message.push_str(&format!("\nยินดีด้วย! คุณเลื่อนระดับเป็น {new_tier} 🎉"));
+        }
+    }
+    if let Err(e) = crate::services::line::push_to_member(
+        db,
+        state.config(),
+        user_id,
+        Some(payload.property),
+        &message,
+    )
+    .await
+    {
+        tracing::warn!(error = %e, user_id = %user_id, "stay accrual push failed");
+    }
+
+    tracing::info!(
+        user_id = %user_id,
+        property = %payload.property,
+        nights = payload.nights,
+        points,
+        "stay recorded"
+    );
+
+    Ok((
+        StatusCode::CREATED,
+        Json(StayAccrualResponse {
+            stay_id,
+            user_id,
+            property: payload.property,
+            nights: payload.nights,
+            points_awarded: points,
+            already_processed: false,
+        }),
+    ))
 }
 
 // ============================================================================

--- a/backend-rust/src/routes/mod.rs
+++ b/backend-rust/src/routes/mod.rs
@@ -13,6 +13,7 @@ pub mod auth;
 pub mod bookings;
 pub mod coupons;
 pub mod health;
+pub mod line_webhook;
 pub mod loyalty;
 pub mod membership;
 pub mod notifications;
@@ -125,6 +126,9 @@ pub fn create_router(state: AppState) -> Router {
         .nest("/api/slips", slips::routes())
         .nest("/api/analytics", analytics::routes())
         .nest("/api/translation", translation::routes())
+        // LINE Messaging API webhooks (per-property OA). Public by design —
+        // authenticated by X-Line-Signature inside the handler.
+        .nest("/api/line", line_webhook::routes())
         // OpenAPI documentation routes
         .merge(SwaggerUi::new("/api/docs").url("/api/openapi.json", ApiDoc::openapi()))
         .with_state(state)

--- a/backend-rust/src/routes/oauth.rs
+++ b/backend-rust/src/routes/oauth.rs
@@ -134,17 +134,18 @@ struct GoogleUserInfo {
     picture: Option<String>,
 }
 
-/// LINE profile response
+/// LINE profile response. Also constructed from LIFF ID-token claims by
+/// the /api/auth/liff handler (same userId space — ADR-0002).
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
-struct LineProfile {
-    user_id: String,
-    display_name: String,
+pub(crate) struct LineProfile {
+    pub(crate) user_id: String,
+    pub(crate) display_name: String,
     #[serde(default)]
-    picture_url: Option<String>,
+    pub(crate) picture_url: Option<String>,
     #[serde(default)]
-    status_message: Option<String>,
+    pub(crate) status_message: Option<String>,
 }
 
 /// Authentication result after OAuth processing
@@ -158,12 +159,12 @@ pub struct OAuthResult {
 /// User response for OAuth result
 #[derive(Debug, Serialize, Deserialize)]
 pub struct UserResponse {
-    id: String,
-    email: Option<String>,
-    role: String,
-    is_active: bool,
-    email_verified: bool,
-    oauth_provider: Option<String>,
+    pub id: String,
+    pub email: Option<String>,
+    pub role: String,
+    pub is_active: bool,
+    pub email_verified: bool,
+    pub oauth_provider: Option<String>,
 }
 
 /// Token response for OAuth result
@@ -1201,6 +1202,27 @@ async fn get_line_profile(access_token: &str) -> AppResult<LineProfile> {
 
 /// Process LINE authentication and create/update user
 async fn process_line_auth(state: &AppState, profile: LineProfile) -> AppResult<OAuthResult> {
+    let (user, is_new_user) = upsert_line_user(state, &profile).await?;
+
+    // Generate JWT tokens
+    let tokens = generate_tokens(state, &user.id, user.email.as_deref(), &user.role).await?;
+
+    Ok(OAuthResult {
+        user,
+        tokens,
+        is_new_user,
+    })
+}
+
+/// Find-or-create a member from a LINE identity (silent enrollment).
+///
+/// Shared by the web LINE OAuth callback and the LIFF login endpoint
+/// (/api/auth/liff): both surfaces yield the same LINE userId because all
+/// channels live under one provider (ADR-0002).
+pub(crate) async fn upsert_line_user(
+    state: &AppState,
+    profile: &LineProfile,
+) -> AppResult<(UserResponse, bool)> {
     let line_id = &profile.user_id;
 
     tracing::debug!(
@@ -1344,14 +1366,7 @@ async fn process_line_auth(state: &AppState, profile: LineProfile) -> AppResult<
         .await
         .map_err(AppError::Database)?;
 
-    // Generate JWT tokens
-    let tokens = generate_tokens(state, &user.id, user.email.as_deref(), &user.role).await?;
-
-    Ok(OAuthResult {
-        user,
-        tokens,
-        is_new_user,
-    })
+    Ok((user, is_new_user))
 }
 
 // =============================================================================

--- a/backend-rust/src/services/line.rs
+++ b/backend-rust/src/services/line.rs
@@ -1,0 +1,208 @@
+//! LINE Platform integration for the two property OAs.
+//!
+//! Covers the three LINE surfaces introduced by the OA integration
+//! (docs/launch-plan.md):
+//! - LIFF ID-token verification (silent enrollment login)
+//! - Messaging API webhook signature verification (follow/unfollow)
+//! - Messaging API push with property-affinity routing (ADR-0001/0002)
+
+use base64::Engine;
+use hmac::{Hmac, Mac};
+use serde::Deserialize;
+use sha2::Sha256;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use crate::config::Settings;
+use crate::error::{AppError, AppResult};
+use crate::types::Property;
+
+const LINE_VERIFY_URL: &str = "https://api.line.me/oauth2/v2.1/verify";
+const LINE_PUSH_URL: &str = "https://api.line.me/v2/bot/message/push";
+
+/// Claims returned by LINE's ID-token verify endpoint.
+#[derive(Debug, Deserialize)]
+pub struct LineIdTokenClaims {
+    /// LINE userId — shared across all channels under our provider
+    /// (ADR-0002), so it matches `users.oauth_provider_id` for members
+    /// who signed in with LINE Login.
+    pub sub: String,
+    pub name: Option<String>,
+    pub picture: Option<String>,
+    pub email: Option<String>,
+}
+
+/// Verify a LIFF ID token with LINE. `client_id` is the LINE Login channel
+/// ID (the LIFF app is attached to that channel).
+pub async fn verify_liff_id_token(id_token: &str, client_id: &str) -> AppResult<LineIdTokenClaims> {
+    let client = reqwest::Client::new();
+    let response = client
+        .post(LINE_VERIFY_URL)
+        .form(&[("id_token", id_token), ("client_id", client_id)])
+        .send()
+        .await
+        .map_err(|e| AppError::OAuth(format!("LINE ID-token verify request failed: {e}")))?;
+
+    if !response.status().is_success() {
+        // Never log the token itself; the status is enough for diagnosis.
+        tracing::warn!(status = %response.status(), "LIFF ID-token rejected by LINE");
+        return Err(AppError::Unauthorized("Invalid LIFF ID token".to_string()));
+    }
+
+    response
+        .json::<LineIdTokenClaims>()
+        .await
+        .map_err(|e| AppError::OAuth(format!("LINE ID-token verify response malformed: {e}")))
+}
+
+/// Verify an `X-Line-Signature` header against the raw request body.
+/// The signature is base64(HMAC-SHA256(channel_secret, body)).
+pub fn verify_line_signature(channel_secret: &str, body: &[u8], signature_b64: &str) -> bool {
+    let Ok(given) = base64::engine::general_purpose::STANDARD.decode(signature_b64) else {
+        return false;
+    };
+    let mut mac = Hmac::<Sha256>::new_from_slice(channel_secret.as_bytes())
+        .expect("HMAC accepts any key length");
+    mac.update(body);
+    // verify_slice is constant-time.
+    mac.verify_slice(&given).is_ok()
+}
+
+/// Push a plain-text message to one LINE user via one OA's channel token.
+pub async fn push_text(access_token: &str, to: &str, text: &str) -> AppResult<()> {
+    let client = reqwest::Client::new();
+    let body = serde_json::json!({
+        "to": to,
+        "messages": [{ "type": "text", "text": text }],
+    });
+    let response = client
+        .post(LINE_PUSH_URL)
+        .bearer_auth(access_token)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| AppError::OAuth(format!("LINE push request failed: {e}")))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let detail = response.text().await.unwrap_or_default();
+        return Err(AppError::OAuth(format!(
+            "LINE push rejected: {status} {detail}"
+        )));
+    }
+    Ok(())
+}
+
+/// Property-affinity push routing (docs/launch-plan.md):
+/// the event property's OA speaks if the member is its friend; otherwise
+/// any other friended OA; otherwise no push. For program-wide events
+/// (`event_property = None`) the property of the most recent stay leads.
+///
+/// Returns `Ok(true)` if a message was delivered to LINE, `Ok(false)` if the
+/// member has no LINE identity / no friendship / no configured channel —
+/// those are normal situations, not errors.
+pub async fn push_to_member(
+    db: &PgPool,
+    settings: &Settings,
+    user_id: Uuid,
+    event_property: Option<Property>,
+    text: &str,
+) -> AppResult<bool> {
+    // Resolve the member's LINE userId (LINE Login / LIFF identity).
+    let line_user_id: Option<String> = sqlx::query_scalar!(
+        r#"SELECT oauth_provider_id FROM users WHERE id = $1 AND oauth_provider = 'line'"#,
+        user_id
+    )
+    .fetch_optional(db)
+    .await?
+    .flatten();
+
+    let Some(line_user_id) = line_user_id else {
+        return Ok(false);
+    };
+
+    // Which OAs is this LINE user currently a friend of?
+    let friended: Vec<String> = sqlx::query_scalar!(
+        r#"SELECT property FROM line_friendships WHERE line_user_id = $1 AND is_friend"#,
+        line_user_id
+    )
+    .fetch_all(db)
+    .await?;
+
+    if friended.is_empty() {
+        return Ok(false);
+    }
+
+    // Lead OA: the event's property, or for program-wide events the
+    // property of the most recent stay.
+    let lead = match event_property {
+        Some(p) => Some(p),
+        None => sqlx::query_scalar!(
+            r#"SELECT property FROM stays WHERE user_id = $1 ORDER BY created_at DESC LIMIT 1"#,
+            user_id
+        )
+        .fetch_optional(db)
+        .await?
+        .and_then(|p| p.parse::<Property>().ok()),
+    };
+
+    // Ordered candidates: lead first, then the rest.
+    let mut candidates: Vec<Property> = Vec::with_capacity(Property::ALL.len());
+    if let Some(lead) = lead {
+        candidates.push(lead);
+    }
+    for p in Property::ALL {
+        if !candidates.contains(&p) {
+            candidates.push(p);
+        }
+    }
+
+    for property in candidates {
+        if !friended.iter().any(|f| f == property.as_str()) {
+            continue;
+        }
+        let Some(channel) = settings.line_messaging.channel(property.as_str()) else {
+            continue;
+        };
+        let Some(token) = channel.access_token.as_ref() else {
+            tracing::warn!(property = %property, "LINE channel not configured; skipping push");
+            continue;
+        };
+        match push_text(token, &line_user_id, text).await {
+            Ok(()) => return Ok(true),
+            Err(e) => {
+                // Fall through to the next friended OA rather than failing
+                // the caller — push is best-effort by design.
+                tracing::warn!(property = %property, error = %e, "LINE push failed; trying next OA");
+            },
+        }
+    }
+
+    Ok(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn signature_verification_accepts_valid_hmac() {
+        let secret = "test-channel-secret";
+        let body = br#"{"events":[]}"#;
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let sig = base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+        assert!(verify_line_signature(secret, body, &sig));
+    }
+
+    #[test]
+    fn signature_verification_rejects_wrong_secret_and_garbage() {
+        let body = br#"{"events":[]}"#;
+        let mut mac = Hmac::<Sha256>::new_from_slice(b"secret-a").unwrap();
+        mac.update(body);
+        let sig = base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes());
+        assert!(!verify_line_signature("secret-b", body, &sig));
+        assert!(!verify_line_signature("secret-a", body, "not-base64!!"));
+        assert!(!verify_line_signature("secret-a", b"tampered", &sig));
+    }
+}

--- a/backend-rust/src/services/mod.rs
+++ b/backend-rust/src/services/mod.rs
@@ -8,7 +8,9 @@
 pub mod cf_access;
 pub mod email;
 pub mod idempotency;
+pub mod line;
 pub mod oauth;
+pub mod pms_channel;
 pub mod promptpay;
 pub mod slipok;
 pub mod sse;

--- a/backend-rust/src/services/pms_channel.rs
+++ b/backend-rust/src/services/pms_channel.rs
@@ -1,0 +1,279 @@
+//! PMS booking-channel client (ADR-0003).
+//!
+//! The loyalty app holds no room inventory: availability is queried live
+//! from the PMS and confirmed bookings are created there. This module is
+//! the outbound HTTP client for the PMS channel API; the interface
+//! contract is locked in docs/launch-plan.md.
+
+use chrono::{DateTime, NaiveDate, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+use crate::config::Settings;
+use crate::error::{AppError, AppResult};
+use crate::types::Property;
+
+/// One bookable room type as reported by the PMS.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PmsRoomType {
+    pub room_type_id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub nightly_price: Decimal,
+    pub available_count: i32,
+}
+
+/// Availability response from the PMS.
+#[derive(Debug, Deserialize)]
+pub struct PmsAvailability {
+    pub property: String,
+    pub check_in: NaiveDate,
+    pub check_out: NaiveDate,
+    pub room_types: Vec<PmsRoomType>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PmsGuest {
+    pub name: String,
+    pub phone: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PmsCreateBookingRequest {
+    pub property: Property,
+    pub room_type_id: String,
+    pub check_in: NaiveDate,
+    pub check_out: NaiveDate,
+    pub guests: i32,
+    pub guest: PmsGuest,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub membership_id: Option<String>,
+    /// "deposit50" | "full"
+    pub payment: String,
+}
+
+/// A held (tentative) booking created in the PMS.
+#[derive(Debug, Deserialize)]
+pub struct PmsBookingCreated {
+    pub pms_booking_id: String,
+    pub total: Decimal,
+    pub amount_due_now: Decimal,
+    pub hold_expires_at: DateTime<Utc>,
+}
+
+pub struct PmsChannelClient {
+    base_url: String,
+    token: String,
+    http: reqwest::Client,
+}
+
+impl PmsChannelClient {
+    /// Build from settings; errors when the PMS channel is not configured
+    /// (PMS_BASE_URL / PMS_CHANNEL_TOKEN).
+    pub fn from_settings(settings: &Settings) -> AppResult<Self> {
+        let base_url =
+            settings.pms.base_url.clone().ok_or_else(|| {
+                AppError::Configuration("PMS_BASE_URL is not configured".to_string())
+            })?;
+        let token = settings.pms.channel_token.clone().ok_or_else(|| {
+            AppError::Configuration("PMS_CHANNEL_TOKEN is not configured".to_string())
+        })?;
+        Ok(Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            token,
+            http: reqwest::Client::new(),
+        })
+    }
+
+    pub async fn availability(
+        &self,
+        property: Property,
+        check_in: NaiveDate,
+        check_out: NaiveDate,
+        guests: i32,
+    ) -> AppResult<PmsAvailability> {
+        let url = format!("{}/api/channel/availability", self.base_url);
+        let response = self
+            .http
+            .get(&url)
+            .bearer_auth(&self.token)
+            .query(&[
+                ("property", property.as_str().to_string()),
+                ("check_in", check_in.to_string()),
+                ("check_out", check_out.to_string()),
+                ("guests", guests.to_string()),
+            ])
+            .send()
+            .await
+            .map_err(pms_unreachable)?;
+        Self::parse_json(response, "availability").await
+    }
+
+    pub async fn create_booking(
+        &self,
+        request: &PmsCreateBookingRequest,
+    ) -> AppResult<PmsBookingCreated> {
+        let url = format!("{}/api/channel/bookings", self.base_url);
+        let response = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.token)
+            .json(request)
+            .send()
+            .await
+            .map_err(pms_unreachable)?;
+        Self::parse_json(response, "create booking").await
+    }
+
+    /// Mark the deposit received. The PMS requires the received amount in
+    /// the body — it doesn't persist the guest's payment plan, so it can't
+    /// know whether 50% or 100% arrived (PMS contract addendum).
+    pub async fn payment_verified(&self, pms_booking_id: &str, amount: Decimal) -> AppResult<()> {
+        self.post_action(
+            pms_booking_id,
+            "payment-verified",
+            Some(serde_json::json!({ "amount": amount })),
+        )
+        .await
+    }
+
+    pub async fn release(&self, pms_booking_id: &str) -> AppResult<()> {
+        self.post_action(pms_booking_id, "release", None).await
+    }
+
+    async fn post_action(
+        &self,
+        pms_booking_id: &str,
+        action: &str,
+        body: Option<serde_json::Value>,
+    ) -> AppResult<()> {
+        let url = format!(
+            "{}/api/channel/bookings/{}/{}",
+            self.base_url, pms_booking_id, action
+        );
+        let mut request = self.http.post(&url).bearer_auth(&self.token);
+        if let Some(body) = body {
+            request = request.json(&body);
+        }
+        let response = request.send().await.map_err(pms_unreachable)?;
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let status = response.status();
+        let detail = response.text().await.unwrap_or_default();
+        Err(AppError::ExternalServiceUnavailable(format!(
+            "PMS {action} for booking {pms_booking_id} failed: {status} {detail}"
+        )))
+    }
+
+    async fn parse_json<T: serde::de::DeserializeOwned>(
+        response: reqwest::Response,
+        what: &str,
+    ) -> AppResult<T> {
+        let status = response.status();
+        if !status.is_success() {
+            let detail = response.text().await.unwrap_or_default();
+            // 4xx from the PMS (sold out, bad dates) surfaces as a client
+            // error; 5xx as service-unavailable.
+            return if status.is_client_error() {
+                Err(AppError::BadRequest(format!(
+                    "PMS rejected {what}: {detail}"
+                )))
+            } else {
+                Err(AppError::ExternalServiceUnavailable(format!(
+                    "PMS {what} failed: {status} {detail}"
+                )))
+            };
+        }
+        response.json::<T>().await.map_err(|e| {
+            AppError::ExternalServiceUnavailable(format!("PMS {what} response malformed: {e}"))
+        })
+    }
+}
+
+/// Sweep channel bookings whose payment window lapsed: release the PMS hold,
+/// then cancel the local channel row. Runs periodically from main.rs; the
+/// PMS also runs its own expiry sweep, so both sides are belt-and-braces
+/// (docs/launch-plan.md). Never panics/errors — failures log and retry on
+/// the next sweep. Returns how many holds were released.
+pub async fn release_expired_holds(db: &sqlx::PgPool, settings: &Settings) -> u64 {
+    let expired = match sqlx::query!(
+        r#"
+        SELECT id, pms_booking_id
+        FROM bookings
+        WHERE status = 'pending'
+          AND pms_booking_id IS NOT NULL
+          AND hold_expires_at IS NOT NULL
+          AND hold_expires_at < NOW()
+        LIMIT 50
+        "#
+    )
+    .fetch_all(db)
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!(error = %e, "hold-expiry sweep query failed");
+            return 0;
+        },
+    };
+
+    if expired.is_empty() {
+        return 0;
+    }
+
+    let client = match PmsChannelClient::from_settings(settings) {
+        Ok(c) => c,
+        Err(e) => {
+            // Channel bookings exist but the PMS client is unconfigured —
+            // loud, because holds are now expiring with no way to release.
+            tracing::error!(error = %e, count = expired.len(),
+                "expired channel holds found but PMS is not configured");
+            return 0;
+        },
+    };
+
+    let mut released = 0u64;
+    for row in expired {
+        let Some(pms_booking_id) = row.pms_booking_id else {
+            continue;
+        };
+        // Release the PMS side FIRST; only cancel locally once the PMS
+        // acknowledged, so a failed release retries on the next sweep.
+        if let Err(e) = client.release(&pms_booking_id).await {
+            tracing::warn!(error = %e, pms_booking_id = %pms_booking_id,
+                "PMS hold release failed; will retry next sweep");
+            continue;
+        }
+        match sqlx::query!(
+            r#"
+            UPDATE bookings
+            SET status = 'cancelled', cancelled_at = NOW(),
+                cancellation_reason = 'Payment window expired', updated_at = NOW()
+            WHERE id = $1 AND status = 'pending'
+            "#,
+            row.id
+        )
+        .execute(db)
+        .await
+        {
+            Ok(_) => released += 1,
+            Err(e) => {
+                tracing::error!(error = %e, booking_id = %row.id,
+                    "failed to cancel expired channel booking locally");
+            },
+        }
+    }
+    if released > 0 {
+        tracing::info!(released, "released expired channel-booking holds");
+    }
+    released
+}
+
+fn pms_unreachable(e: reqwest::Error) -> AppError {
+    if e.is_timeout() {
+        AppError::ExternalServiceTimeout(format!("PMS channel API timed out: {e}"))
+    } else {
+        AppError::ExternalServiceUnavailable(format!("PMS channel API unreachable: {e}"))
+    }
+}

--- a/backend-rust/src/services/promptpay.rs
+++ b/backend-rust/src/services/promptpay.rs
@@ -26,8 +26,10 @@ impl PromptPayService {
         Ok(Self { tax_id: cleaned })
     }
 
-    /// Generate a PromptPay QR code as SVG string with the specified amount
-    pub fn generate_qr_svg(&self, amount: f64) -> Result<String, AppError> {
+    /// Generate the raw EMVCo PromptPay payload string for an amount.
+    /// The booking-channel flow returns this to the frontend, which renders
+    /// the QR client-side.
+    pub fn generate_payload(&self, amount: f64) -> Result<String, AppError> {
         // Validate amount range
         if !(0.01..=999_999.99).contains(&amount) {
             return Err(AppError::Validation(
@@ -38,12 +40,17 @@ impl PromptPayService {
         // Generate EMVCo payload using promptpay-rs
         let mut qr = PromptPayQR::new(&self.tax_id);
         qr.set_amount(amount);
-        let payload = qr
+        Ok(qr
             .create()
             .map_err(|e| {
                 AppError::Internal(format!("Failed to generate PromptPay payload: {}", e))
             })?
-            .to_string();
+            .to_string())
+    }
+
+    /// Generate a PromptPay QR code as SVG string with the specified amount
+    pub fn generate_qr_svg(&self, amount: f64) -> Result<String, AppError> {
+        let payload = self.generate_payload(amount)?;
 
         // Render payload as SVG QR code
         let code = QrCode::new(payload.as_bytes())
@@ -85,6 +92,16 @@ mod tests {
     fn test_new_invalid_tax_id_non_numeric() {
         let service = PromptPayService::new("0105556176ABC".to_string());
         assert!(service.is_err());
+    }
+
+    #[test]
+    fn test_generate_payload_is_raw_emvco_string() {
+        let service = PromptPayService::new("0105556176009".to_string()).unwrap();
+        let payload = service.generate_payload(1500.0).unwrap();
+        // EMVCo payloads begin with the "000201" payload-format indicator
+        // and are plain text, not markup.
+        assert!(payload.starts_with("000201"));
+        assert!(!payload.contains("<svg"));
     }
 
     #[test]

--- a/backend-rust/src/types/mod.rs
+++ b/backend-rust/src/types/mod.rs
@@ -385,3 +385,81 @@ mod tests {
         assert_eq!(format!("{}", SortOrder::Desc), "DESC");
     }
 }
+
+/// A physical hotel property.
+///
+/// ADR-0001: a property is an attribute of a stay/redemption/coupon
+/// restriction — never a partition of members, balances, or tiers.
+/// Stored in the database as lowercase text ("hf" | "hfville").
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Property {
+    Hf,
+    Hfville,
+}
+
+impl Property {
+    pub const ALL: [Property; 2] = [Property::Hf, Property::Hfville];
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Property::Hf => "hf",
+            Property::Hfville => "hfville",
+        }
+    }
+
+    /// Guest-facing English name.
+    pub fn display_name(&self) -> &'static str {
+        match self {
+            Property::Hf => "The Harbour Front Hotel",
+            Property::Hfville => "HF Ville",
+        }
+    }
+}
+
+impl std::str::FromStr for Property {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "hf" => Ok(Property::Hf),
+            "hfville" => Ok(Property::Hfville),
+            other => Err(format!("unknown property: {other}")),
+        }
+    }
+}
+
+impl std::fmt::Display for Property {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod property_tests {
+    use super::Property;
+    use std::str::FromStr;
+
+    #[test]
+    fn property_round_trips_through_str() {
+        for p in Property::ALL {
+            assert_eq!(Property::from_str(p.as_str()).unwrap(), p);
+        }
+    }
+
+    #[test]
+    fn property_serde_uses_lowercase() {
+        assert_eq!(
+            serde_json::to_string(&Property::Hfville).unwrap(),
+            "\"hfville\""
+        );
+        let p: Property = serde_json::from_str("\"hf\"").unwrap();
+        assert_eq!(p, Property::Hf);
+    }
+
+    #[test]
+    fn unknown_property_rejected() {
+        assert!(Property::from_str("HF").is_err());
+        assert!(Property::from_str("ville").is_err());
+    }
+}

--- a/backend-rust/tests/common/mod.rs
+++ b/backend-rust/tests/common/mod.rs
@@ -328,6 +328,12 @@ async fn ensure_template_db() -> Result<(), Box<dyn std::error::Error + Send + S
         include_str!("../../migrations/20260513020000_bookings_no_overlap.sql");
     template_pool.execute(bookings_no_overlap_migration).await?;
 
+    let property_line_channel_migration =
+        include_str!("../../migrations/20260710000000_property_line_channel.sql");
+    template_pool
+        .execute(property_line_channel_migration)
+        .await?;
+
     // Seed tiers
     template_pool
         .execute(
@@ -462,11 +468,26 @@ impl TestApp {
     /// Retries up to 5 times on transient "Tokio runtime shutdown" errors that
     /// can occur when parallel `#[tokio::test]` runtimes race during cleanup.
     pub async fn new() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Self::new_internal(None).await
+    }
+
+    /// Like [`TestApp::new`] but lets the test mutate `Settings` before the
+    /// router is built (e.g. point `pms.base_url` at a wiremock server or
+    /// configure a LINE messaging channel secret).
+    pub async fn new_with_config(
+        mutate: &(dyn Fn(&mut loyalty_backend::Settings) + Sync),
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Self::new_internal(Some(mutate)).await
+    }
+
+    async fn new_internal(
+        mutate: Option<&(dyn Fn(&mut loyalty_backend::Settings) + Sync)>,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         const MAX_RETRIES: u32 = 5;
         let mut last_error = None;
 
         for attempt in 0..MAX_RETRIES {
-            match Self::try_new().await {
+            match Self::try_new(mutate).await {
                 Ok(app) => return Ok(app),
                 Err(e) => {
                     let err_str = e.to_string();
@@ -490,7 +511,9 @@ impl TestApp {
     }
 
     /// Inner implementation of TestApp creation.
-    async fn try_new() -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+    async fn try_new(
+        mutate: Option<&(dyn Fn(&mut loyalty_backend::Settings) + Sync)>,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let _ = dotenvy::dotenv();
 
         // Ensure template DB is ready
@@ -539,7 +562,10 @@ impl TestApp {
         let redis = init_test_redis().await?;
 
         // Create application state and router
-        let config = create_test_config();
+        let mut config = create_test_config();
+        if let Some(mutate) = mutate {
+            mutate(&mut config);
+        }
         let state = loyalty_backend::AppState::new(pool.clone(), redis.clone(), config);
         let router = loyalty_backend::routes::create_router(state);
 
@@ -669,8 +695,16 @@ fn create_test_config() -> loyalty_backend::Settings {
         promptpay: PromptPayConfig::default(),
         security: SecurityConfig::default(),
         cf_access: CfAccessConfig::default(),
+        line_messaging: LineMessagingConfig::default(),
+        pms: PmsConfig::default(),
+        loyalty_service: LoyaltyServiceConfig {
+            token: Some(TEST_LOYALTY_SERVICE_TOKEN.to_string()),
+        },
     }
 }
+
+/// Service token used by machine-to-machine tests (PMS stay accrual).
+pub const TEST_LOYALTY_SERVICE_TOKEN: &str = "test-loyalty-service-token";
 
 // ============================================================================
 // Legacy Setup Functions (backward-compatible, now with per-test DB isolation)

--- a/backend-rust/tests/integration/booking_test.rs
+++ b/backend-rust/tests/integration/booking_test.rs
@@ -759,52 +759,58 @@ async fn test_complete_booking_cannot_complete_cancelled() {
 }
 
 // ============================================================================
-// test_check_availability - GET /api/bookings/availability
+// Channel availability - GET /api/bookings/availability (ADR-0003)
+// Availability truth lives in the PMS; the endpoint proxies it live.
 // ============================================================================
 
 #[tokio::test]
-async fn test_check_availability_returns_availability() {
-    let app = TestApp::new().await.expect("Failed to create test app");
+async fn test_channel_availability_proxies_pms() {
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
-    let user = TestUser::new("availability-check@test.com");
-    user.insert(app.db())
-        .await
-        .expect("Failed to insert test user");
-
-    // Seed room_types and rooms so the availability query has data
-    let room_type_id = Uuid::new_v4();
-    sqlx::query(
-        r#"
-        INSERT INTO room_types (id, name, price_per_night, max_guests, is_active)
-        VALUES ($1, 'Standard Room', 1500.00, 2, true)
-        "#,
-    )
-    .bind(room_type_id)
-    .execute(app.db())
-    .await
-    .expect("Failed to insert room type");
-
-    sqlx::query(
-        r#"
-        INSERT INTO rooms (id, room_type_id, room_number, floor, is_active)
-        VALUES ($1, $2, '201', 2, true)
-        "#,
-    )
-    .bind(Uuid::new_v4())
-    .bind(room_type_id)
-    .execute(app.db())
-    .await
-    .expect("Failed to insert room");
-
-    let client = app.authenticated_client(&user.id, &user.email);
+    let mock_pms = MockServer::start().await;
 
     let today = Utc::now().date_naive();
     let check_in = today + Duration::days(30);
     let check_out = today + Duration::days(33);
 
+    Mock::given(method("GET"))
+        .and(path("/api/channel/availability"))
+        .and(query_param("property", "hf"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "property": "hf",
+            "check_in": check_in.format("%Y-%m-%d").to_string(),
+            "check_out": check_out.format("%Y-%m-%d").to_string(),
+            "room_types": [{
+                "room_type_id": "std-hf",
+                "name": "Standard",
+                "description": "Standard room",
+                "nightly_price": 1500.0,
+                "available_count": 3
+            }]
+        })))
+        .mount(&mock_pms)
+        .await;
+
+    let pms_uri = mock_pms.uri();
+    let mutate = move |cfg: &mut loyalty_backend::Settings| {
+        cfg.pms.base_url = Some(pms_uri.clone());
+        cfg.pms.channel_token = Some("test-channel-token".to_string());
+    };
+    let app = TestApp::new_with_config(&mutate)
+        .await
+        .expect("Failed to create test app");
+
+    let user = TestUser::new("channel-availability@test.com");
+    user.insert(app.db())
+        .await
+        .expect("Failed to insert test user");
+
+    let client = app.authenticated_client(&user.id, &user.email);
+
     let response = client
         .get(&format!(
-            "/api/bookings/availability?checkIn={}&checkOut={}",
+            "/api/bookings/availability?property=hf&check_in={}&check_out={}&guests=2",
             check_in.format("%Y-%m-%d"),
             check_out.format("%Y-%m-%d")
         ))
@@ -813,89 +819,16 @@ async fn test_check_availability_returns_availability() {
     response.assert_status(200);
 
     let json: Value = response.json().expect("Response should be valid JSON");
-    assert!(
-        json.get("available").is_some(),
-        "Response should have 'available' field"
-    );
-    assert!(
-        json.get("availableRooms").is_some() || json.get("available_rooms").is_some(),
-        "Response should have available rooms count"
-    );
+    assert_eq!(json["property"], "hf");
+    assert_eq!(json["room_types"][0]["room_type_id"], "std-hf");
+    assert_eq!(json["room_types"][0]["available_count"], 3);
+    assert_eq!(json["room_types"][0]["nightly_price"], 1500.0);
 
     app.cleanup().await.ok();
 }
 
 #[tokio::test]
-async fn test_check_availability_with_room_type() {
-    let app = TestApp::new().await.expect("Failed to create test app");
-
-    let user = TestUser::new("availability-roomtype@test.com");
-    user.insert(app.db())
-        .await
-        .expect("Failed to insert test user");
-
-    // Seed a Deluxe room type and room so the availability query has data
-    let room_type_id = Uuid::new_v4();
-    sqlx::query(
-        r#"
-        INSERT INTO room_types (id, name, price_per_night, max_guests, is_active)
-        VALUES ($1, 'Deluxe', 2500.00, 2, true)
-        "#,
-    )
-    .bind(room_type_id)
-    .execute(app.db())
-    .await
-    .expect("Failed to insert room type");
-
-    sqlx::query(
-        r#"
-        INSERT INTO rooms (id, room_type_id, room_number, floor, is_active)
-        VALUES ($1, $2, '301', 3, true)
-        "#,
-    )
-    .bind(Uuid::new_v4())
-    .bind(room_type_id)
-    .execute(app.db())
-    .await
-    .expect("Failed to insert room");
-
-    let client = app.authenticated_client(&user.id, &user.email);
-
-    let today = Utc::now().date_naive();
-    let check_in = today + Duration::days(30);
-    let check_out = today + Duration::days(33);
-
-    let response = client
-        .get(&format!(
-            "/api/bookings/availability?checkIn={}&checkOut={}&roomType=deluxe",
-            check_in.format("%Y-%m-%d"),
-            check_out.format("%Y-%m-%d")
-        ))
-        .await;
-
-    response.assert_status(200);
-
-    let json: Value = response.json().expect("Response should be valid JSON");
-    assert!(
-        json.get("available").is_some(),
-        "Response should have 'available' field"
-    );
-
-    if let Some(room_type) = json.get("roomType").or(json.get("room_type")) {
-        assert!(
-            room_type
-                .as_str()
-                .map(|s| s.to_lowercase().contains("deluxe"))
-                .unwrap_or(false),
-            "Room type should be deluxe"
-        );
-    }
-
-    app.cleanup().await.ok();
-}
-
-#[tokio::test]
-async fn test_check_availability_invalid_dates() {
+async fn test_channel_availability_invalid_dates() {
     let app = TestApp::new().await.expect("Failed to create test app");
 
     let user = TestUser::new("availability-invalid@test.com");
@@ -906,13 +839,13 @@ async fn test_check_availability_invalid_dates() {
     let client = app.authenticated_client(&user.id, &user.email);
 
     let today = Utc::now().date_naive();
-    // Check-out before check-in (invalid)
+    // Check-out before check-in (invalid) — rejected before any PMS call.
     let check_in = today + Duration::days(33);
     let check_out = today + Duration::days(30);
 
     let response = client
         .get(&format!(
-            "/api/bookings/availability?checkIn={}&checkOut={}",
+            "/api/bookings/availability?property=hf&check_in={}&check_out={}&guests=2",
             check_in.format("%Y-%m-%d"),
             check_out.format("%Y-%m-%d")
         ))
@@ -921,6 +854,40 @@ async fn test_check_availability_invalid_dates() {
     assert!(
         response.status == 400 || response.status == 422,
         "Expected 400 or 422 for invalid dates, got {}",
+        response.status
+    );
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_channel_availability_unconfigured_pms_is_server_error() {
+    // Default test config has no PMS wiring: valid queries must surface a
+    // server-side configuration error, not silently succeed.
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let user = TestUser::new("availability-nopms@test.com");
+    user.insert(app.db())
+        .await
+        .expect("Failed to insert test user");
+
+    let client = app.authenticated_client(&user.id, &user.email);
+
+    let today = Utc::now().date_naive();
+    let check_in = today + Duration::days(30);
+    let check_out = today + Duration::days(33);
+
+    let response = client
+        .get(&format!(
+            "/api/bookings/availability?property=hfville&check_in={}&check_out={}&guests=2",
+            check_in.format("%Y-%m-%d"),
+            check_out.format("%Y-%m-%d")
+        ))
+        .await;
+
+    assert!(
+        response.status >= 500,
+        "Expected 5xx when PMS is unconfigured, got {}",
         response.status
     );
 

--- a/backend-rust/tests/integration/mod.rs
+++ b/backend-rust/tests/integration/mod.rs
@@ -41,6 +41,7 @@ pub mod notification_test;
 pub mod oauth_test;
 pub mod slips_test;
 pub mod sse_test;
+pub mod stays_test;
 pub mod storage_test;
 pub mod survey_test;
 pub mod user_test;

--- a/backend-rust/tests/integration/stays_test.rs
+++ b/backend-rust/tests/integration/stays_test.rs
@@ -1,0 +1,259 @@
+//! Integration tests for the PMS integration surfaces:
+//! - POST /api/loyalty/stays (checkout accrual, service-token auth)
+//! - POST /api/line/webhook/{property} (friendship upsert, signature auth)
+//!
+//! Contracts locked in docs/launch-plan.md.
+
+use serde_json::Value;
+use uuid::Uuid;
+
+use crate::common::{TestApp, TestUser, TEST_LOYALTY_SERVICE_TOKEN};
+
+fn membership_id_of(user: &TestUser) -> String {
+    user.id.to_string()[..8].to_uppercase()
+}
+
+async fn seed_loyalty_row(pool: &sqlx::PgPool, user_id: Uuid) {
+    sqlx::query("INSERT INTO user_loyalty (user_id) VALUES ($1) ON CONFLICT DO NOTHING")
+        .bind(user_id)
+        .execute(pool)
+        .await
+        .expect("Failed to seed user_loyalty");
+}
+
+fn stay_body(pms_stay_id: &str, membership_id: &str, nights: i32) -> Value {
+    serde_json::json!({
+        "pms_stay_id": pms_stay_id,
+        "membership_id": membership_id,
+        "property": "hfville",
+        "check_in": "2026-07-01",
+        "check_out": format!("2026-07-{:02}", 1 + nights),
+        "nights": nights,
+    })
+}
+
+#[tokio::test]
+async fn test_record_stay_awards_nights_and_is_idempotent() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let user = TestUser::new("stay-accrual@test.com");
+    user.insert_with_profile(app.db(), "Stay", "Guest")
+        .await
+        .expect("Failed to insert test user");
+    seed_loyalty_row(app.db(), user.id).await;
+
+    let membership_id = membership_id_of(&user);
+    let client = app.client();
+    let auth_header = format!("Bearer {}", TEST_LOYALTY_SERVICE_TOKEN);
+    let headers = [("Authorization", auth_header.as_str())];
+
+    // First delivery: 201, nights recorded, property attributed.
+    let response = client
+        .post_with_headers(
+            "/api/loyalty/stays",
+            &stay_body("PMS-STAY-001", &membership_id, 2),
+            &headers,
+        )
+        .await;
+    response.assert_status(201);
+    let json: Value = response.json().expect("valid JSON");
+    assert_eq!(json["nights"], 2);
+    assert_eq!(json["property"], "hfville");
+    assert_eq!(json["already_processed"], false);
+
+    let nights: Option<i32> =
+        sqlx::query_scalar("SELECT total_nights FROM user_loyalty WHERE user_id = $1")
+            .bind(user.id)
+            .fetch_one(app.db())
+            .await
+            .expect("loyalty row");
+    assert_eq!(nights, Some(2), "total_nights should reflect the stay");
+
+    // Replay with the same pms_stay_id: 200, no double accrual.
+    let replay = client
+        .post_with_headers(
+            "/api/loyalty/stays",
+            &stay_body("PMS-STAY-001", &membership_id, 2),
+            &headers,
+        )
+        .await;
+    replay.assert_status(200);
+    let replay_json: Value = replay.json().expect("valid JSON");
+    assert_eq!(replay_json["already_processed"], true);
+
+    let nights_after: Option<i32> =
+        sqlx::query_scalar("SELECT total_nights FROM user_loyalty WHERE user_id = $1")
+            .bind(user.id)
+            .fetch_one(app.db())
+            .await
+            .expect("loyalty row");
+    assert_eq!(nights_after, Some(2), "replay must not double-accrue");
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_record_stay_rejects_bad_or_missing_token() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let user = TestUser::new("stay-badtoken@test.com");
+    user.insert_with_profile(app.db(), "Stay", "Guest")
+        .await
+        .expect("Failed to insert test user");
+
+    let membership_id = membership_id_of(&user);
+    let client = app.client();
+
+    let no_token = client
+        .post(
+            "/api/loyalty/stays",
+            &stay_body("PMS-STAY-002", &membership_id, 1),
+        )
+        .await;
+    no_token.assert_status(401);
+
+    let wrong_token = client
+        .post_with_headers(
+            "/api/loyalty/stays",
+            &stay_body("PMS-STAY-002", &membership_id, 1),
+            &[("Authorization", "Bearer wrong-token")],
+        )
+        .await;
+    wrong_token.assert_status(401);
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_record_stay_unknown_membership_is_404() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+
+    let client = app.client();
+    let auth_header = format!("Bearer {}", TEST_LOYALTY_SERVICE_TOKEN);
+
+    let response = client
+        .post_with_headers(
+            "/api/loyalty/stays",
+            &stay_body("PMS-STAY-003", "ZZZZZZZZ", 1),
+            &[("Authorization", auth_header.as_str())],
+        )
+        .await;
+    response.assert_status(404);
+
+    app.cleanup().await.ok();
+}
+
+// ============================================================================
+// LINE webhook — friendship upsert with signature verification
+// ============================================================================
+
+fn line_signature(secret: &str, body: &str) -> String {
+    use base64::Engine;
+    use hmac::{Hmac, Mac};
+    use sha2::Sha256;
+
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key");
+    mac.update(body.as_bytes());
+    base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
+}
+
+#[tokio::test]
+async fn test_line_webhook_records_follow_and_unfollow() {
+    const SECRET: &str = "test-line-channel-secret";
+
+    let mutate = |cfg: &mut loyalty_backend::Settings| {
+        cfg.line_messaging.hf.channel_secret = Some(SECRET.to_string());
+        cfg.line_messaging.hf.access_token = Some("test-access-token".to_string());
+    };
+    let app = TestApp::new_with_config(&mutate)
+        .await
+        .expect("Failed to create test app");
+
+    let client = app.client();
+    let line_user_id = "U1234567890abcdef1234567890abcdef";
+
+    // follow
+    let follow_body = serde_json::json!({
+        "events": [{ "type": "follow", "source": { "type": "user", "userId": line_user_id } }]
+    });
+    let follow_raw = serde_json::to_string(&follow_body).unwrap();
+    let follow_sig = line_signature(SECRET, &follow_raw);
+    let response = client
+        .post_with_headers(
+            "/api/line/webhook/hf",
+            &follow_body,
+            &[("x-line-signature", follow_sig.as_str())],
+        )
+        .await;
+    response.assert_status(200);
+
+    let is_friend: Option<bool> = sqlx::query_scalar(
+        "SELECT is_friend FROM line_friendships WHERE line_user_id = $1 AND property = 'hf'",
+    )
+    .bind(line_user_id)
+    .fetch_optional(app.db())
+    .await
+    .expect("query friendships");
+    assert_eq!(is_friend, Some(true), "follow should record a friendship");
+
+    // unfollow flips the flag
+    let unfollow_body = serde_json::json!({
+        "events": [{ "type": "unfollow", "source": { "type": "user", "userId": line_user_id } }]
+    });
+    let unfollow_raw = serde_json::to_string(&unfollow_body).unwrap();
+    let unfollow_sig = line_signature(SECRET, &unfollow_raw);
+    let response = client
+        .post_with_headers(
+            "/api/line/webhook/hf",
+            &unfollow_body,
+            &[("x-line-signature", unfollow_sig.as_str())],
+        )
+        .await;
+    response.assert_status(200);
+
+    let is_friend: Option<bool> = sqlx::query_scalar(
+        "SELECT is_friend FROM line_friendships WHERE line_user_id = $1 AND property = 'hf'",
+    )
+    .bind(line_user_id)
+    .fetch_optional(app.db())
+    .await
+    .expect("query friendships");
+    assert_eq!(is_friend, Some(false), "unfollow should flip is_friend");
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_line_webhook_rejects_bad_signature() {
+    const SECRET: &str = "test-line-channel-secret";
+
+    let mutate = |cfg: &mut loyalty_backend::Settings| {
+        cfg.line_messaging.hf.channel_secret = Some(SECRET.to_string());
+    };
+    let app = TestApp::new_with_config(&mutate)
+        .await
+        .expect("Failed to create test app");
+
+    let client = app.client();
+    let body = serde_json::json!({
+        "events": [{ "type": "follow", "source": { "type": "user", "userId": "Uspoofed" } }]
+    });
+
+    let response = client
+        .post_with_headers(
+            "/api/line/webhook/hf",
+            &body,
+            &[("x-line-signature", "aW52YWxpZC1zaWduYXR1cmU=")],
+        )
+        .await;
+    response.assert_status(401);
+
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM line_friendships WHERE line_user_id = 'Uspoofed'")
+            .fetch_one(app.db())
+            .await
+            .expect("count");
+    assert_eq!(count, 0, "spoofed event must not be recorded");
+
+    app.cleanup().await.ok();
+}

--- a/docs/adr/0001-one-program-across-properties.md
+++ b/docs/adr/0001-one-program-across-properties.md
@@ -1,0 +1,24 @@
+# One loyalty program across all properties
+
+The company operates two hotels (HF, HF Ville) but runs exactly one loyalty
+program. Membership, points, and nights-based tiers are program-wide: a
+member earns at either property and redeems at either property, and tier is
+computed from total nights summed across properties. Property is an
+*attribute* of a stay, redemption, or coupon restriction — never a partition
+of members, balances, or tiers.
+
+## Considered options
+
+- **Two programs (one per property)** — rejected: doubles engineering and
+  operations, weakens the guest value proposition, and contradicts how the
+  company already operates (finance and P&L are company-wide).
+- **Hybrid (shared tier, per-property points)** — rejected: the confusing
+  middle; coupons get property scoping instead (see `CONTEXT.md`:
+  a coupon may optionally be restricted to one property).
+
+## Consequences
+
+Once points from both properties commingle in one balance, splitting the
+program later is effectively impossible — this is a one-way door, chosen
+deliberately. The two LINE Official Accounts are two doors into the same
+program, not two programs.

--- a/docs/adr/0002-line-channels-single-provider.md
+++ b/docs/adr/0002-line-channels-single-provider.md
@@ -1,0 +1,18 @@
+# All LINE channels live under a single LINE provider
+
+The two OAs' Messaging API channels (HF, HF Ville) and the existing LINE
+Login channel (which the LIFF app attaches to) must all be created under the
+**same LINE provider** — the provider that already holds the Login channel
+whose `client_id` is in the OAuth config. LINE scopes userIds to the
+provider, so this is what makes the userId obtained from LIFF/Login identical
+to the userId each OA sees, giving us member↔OA-friend linking for free.
+
+## Consequences
+
+- **Channels can never be moved between providers.** Enabling Messaging API
+  on an OA under the wrong (e.g., freshly auto-created) provider is an
+  unrecoverable mistake short of recreating the channel. Whoever performs the
+  console step must select the existing provider explicitly.
+- Push routing (property-affinity, see `CONTEXT.md` **Friendship**) and
+  silent LIFF enrollment both depend on this shared userId space; under
+  split providers we would need LINE's per-OA account-linking flow instead.

--- a/docs/adr/0003-booking-channel-into-pms.md
+++ b/docs/adr/0003-booking-channel-into-pms.md
@@ -1,0 +1,27 @@
+# In-app booking is a channel into the PMS — the app holds no inventory
+
+Room-availability truth lives in the PMS (new-hotel, which also handles
+legacy iHOTEL writeback). The loyalty app is a *booking channel*: it queries
+live availability from a PMS API and creates confirmed bookings **in the
+PMS**. The app's local room tables serve as a per-property display catalog
+(photos, descriptions, prices) mapped to PMS room types; its booking rows are
+channel records referencing the PMS booking ID.
+
+## Considered options
+
+- **Independent inventory with two-way sync** (what the pre-existing schema
+  implies) — rejected: two sources of truth racing each other is an
+  overbooking machine.
+- **Allotment (PMS grants the app N rooms/night to sell)** — rejected: adds
+  manual allotment upkeep and shows false "sold out"; allotments exist for
+  third-party channels, and this channel is first-party.
+
+## Consequences
+
+- The app cannot confirm a booking when the PMS is unreachable — degraded
+  mode is "browse but not book", accepted deliberately.
+- `rooms` / `room_blocked_dates` stop being availability data; do not "fix"
+  the booking flow by resurrecting them as inventory.
+- Payment stays on the loyalty side (50% deposit or full, per-property
+  PromptPay receiving accounts, staff slip verification); the PMS booking
+  carries paid-vs-balance-due and unpaid bookings auto-release.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/launch-plan.md
+++ b/docs/launch-plan.md
@@ -1,0 +1,171 @@
+# Public-Launch Plan — LINE OA integration + real-customer readiness
+
+Decision record from the 2026-07-09 design session. Domain language lives in
+[`CONTEXT.md`](../CONTEXT.md); the three one-way-door decisions are ADRs
+[0001](adr/0001-one-program-across-properties.md) ·
+[0002](adr/0002-line-channels-single-provider.md) ·
+[0003](adr/0003-booking-channel-into-pms.md).
+
+**Launch shape: big bang.** One public date, both OAs simultaneously, with
+the loyalty core **and** live booking. The date is gated by **all six** open
+items in [`public-launch-readiness.md`](public-launch-readiness.md)
+(backups + restore drill, capacity test, PDPA doc, status page, support
+email, on-call).
+
+## Decisions at a glance
+
+| Area | Decision |
+| --- | --- |
+| Program | One program, both properties; tier from total nights (ADR-0001) |
+| LINE scope | LIFF front door + push messages; no chatbot |
+| Providers | All channels under the Login channel's provider (ADR-0002) |
+| Push routing | Property-affinity; per-OA friendships via follow/unfollow webhooks |
+| Enrollment | Silent auto-enroll on first LIFF open; no consent screen |
+| PDPA basis | Membership = contract; OA friendship = messaging opt-in; notice link in footer/rich menu |
+| CRM link | Member QR scanned at desk (primary) + optional phone field for staff search |
+| Accrual | PMS calls loyalty API on checkout; idempotent by PMS stay ID |
+| Booking | Channel into PMS, no local inventory (ADR-0003) |
+| Payment | 50% deposit or full (guest's choice); per-property PromptPay accounts; slip verification; auto-release unpaid |
+| Coupons | Program-wide by default; optional single-property restriction |
+
+## Locked interface contracts
+
+Agree these before any parallel implementation; drift here is the main
+rework risk.
+
+### PMS → loyalty (accrual, new endpoint in this repo)
+
+```
+POST /api/loyalty/stays          auth: Authorization: Bearer <LOYALTY_SERVICE_TOKEN>
+{
+  "pms_stay_id": "…",            // idempotency key — replays return 200 with same result
+  "membership_id": "…",          // from the Link (QR scan / phone search)
+  "property": "hf" | "hfville",
+  "check_in": "YYYY-MM-DD",
+  "check_out": "YYYY-MM-DD",
+  "nights": 2
+}
+```
+
+### Loyalty → PMS (booking channel, new endpoints in new-hotel)
+
+```
+GET  /api/channel/availability?property&check_in&check_out&guests
+     → room types with nightly prices and bookable counts
+POST /api/channel/bookings
+     { property, room_type, check_in, check_out, guest{name,phone},
+       membership_id?, payment: "deposit50" | "full" }
+     → { pms_booking_id, total, amount_due_now, hold_expires_at }
+POST /api/channel/bookings/{pms_booking_id}/payment-verified
+     { "amount": <THB received> }   — required: the PMS doesn't persist the
+                                      guest's deposit50/full choice
+POST /api/channel/bookings/{pms_booking_id}/release            (hold expired)
+```
+
+Implementation notes from the PMS side (feat/loyalty-channel in new-hotel):
+`pms_booking_id` is `"{hf|hfville}-{book_id}"` (per-site DBs have
+overlapping serials); the whole `/api/channel/*` surface ships dark behind
+`LOYALTY_CHANNEL_ENABLED` + `LOYALTY_CHANNEL_TOKEN`, and the checkout hook
+behind `LOYALTY_APP_URL` + `LOYALTY_SERVICE_TOKEN`. Deposits are not
+mirrored to legacy iHOTEL (no validated writeback recipe) — iHOTEL shows
+deposit 0 until checkout; tentative holds DO write back immediately so
+reception can't double-book during the payment window.
+
+New-hotel work goes through the coexistence guardrails (dual-write /
+iHOTEL writeback is that repo's problem, not this one's).
+
+### LINE surface (new endpoints in this repo)
+
+```
+POST /api/line/webhook/{property}   — signature-verified per channel secret;
+                                      handles follow / unfollow → friendships
+POST /api/auth/liff                 — body {id_token}; verifies with LINE,
+                                      silent-enrolls or matches provider_user_id,
+                                      issues the normal JWT cookie pair
+```
+
+### Config (env names)
+
+```
+LINE_MESSAGING_HF_ACCESS_TOKEN / LINE_MESSAGING_HF_CHANNEL_SECRET
+LINE_MESSAGING_HFVILLE_ACCESS_TOKEN / LINE_MESSAGING_HFVILLE_CHANNEL_SECRET
+LIFF_ID
+LOYALTY_SERVICE_TOKEN               (shared with new-hotel)
+PROMPTPAY_HF_ID / PROMPTPAY_HFVILLE_ID   (per-property receiving accounts)
+```
+
+## Workstream 1 — loyalty-app backend
+
+1. **Property foundation** — `property` enum (`hf` | `hfville`); columns on
+   points transactions, coupons (nullable restriction), bookings; new
+   `stays` table (accrual records, unique on `pms_stay_id`); new
+   `line_friendships` table (member, property/OA, followed_at, unfollowed_at).
+2. **Stay accrual endpoint** — `POST /api/loyalty/stays` (service token,
+   idempotent), awards points + nights via existing stored procedures,
+   emits the "you earned" push.
+3. **LIFF auth** — `POST /api/auth/liff`: LINE ID-token verification,
+   silent enroll (reuses `process_line_auth` linkage by `provider_user_id`),
+   JWT cookies as today.
+4. **Webhooks + push service** — per-property webhook route with signature
+   verification; push sender with property-affinity routing (event property →
+   that OA if friended → fallback other friended OA → no push).
+5. **Coupon property restriction** — nullable property on coupon +
+   redemption-time check.
+6. **Booking channel rework** — replace local-inventory search/confirm with
+   the PMS channel API; local room tables become display catalog keyed by
+   property + PMS room type; per-property PromptPay intent (50% / full),
+   slip verification marks PMS booking paid; expiry job calls release.
+
+## Workstream 2 — loyalty-app frontend
+
+1. **LIFF bootstrap** — detect LIFF context, `liff.getIDToken()` →
+   `/api/auth/liff`, no login wall inside LINE.
+2. **Member QR screen** — membership ID as QR, one tap from home (the desk
+   handshake that creates the Link).
+3. **Optional phone field** on profile (staff-search assist).
+4. **Property-aware booking UI** — property picker, catalog, deposit-or-full
+   choice, per-property PromptPay QR, slip upload (exists), balance-due copy.
+5. **Privacy-notice link** in footer (PDPA position).
+
+## Workstream 3 — new-hotel (PMS)
+
+1. Channel API: availability, create-booking (with hold + expiry),
+   payment-verified, release.
+2. Guest-profile Link: store `membership_id` on guest profile; QR-scan and
+   phone-search flows at the desk.
+3. Checkout hook: on checkout of a linked guest, call
+   `POST /api/loyalty/stays` (retry on failure; reconciliation sweep is a
+   post-launch backstop).
+
+## Workstream 4 — LINE console + ops (owner: Winut — I can't do these)
+
+1. Enable Messaging API on both OAs **choosing the existing Login channel's
+   provider** (ADR-0002 — irreversible if done wrong).
+2. Register the LIFF app on the Login channel; set endpoint URL.
+3. Rich menus for both OAs (same LIFF link; "Book" tile).
+4. Wire the new env secrets (tokens above) into deploy secrets.
+
+## Readiness gate (all six block the date)
+
+| Item | Owner |
+| --- | --- |
+| Backup secrets in GitHub Actions | Winut |
+| Restore drill performed + documented | Winut (guided) |
+| Capacity test incl. booking/availability path | repo |
+| PDPA doc (friendship-as-opt-in position) | repo |
+| Status page | Winut picks host; repo wires |
+| Support email + on-call rotation | Winut |
+
+## Ordering
+
+W1.1 (property foundation) unblocks everything backend. W1.2–W1.5 and W2
+proceed in parallel after it. W1.6 + W2.4 wait on W3.1 (channel API) —
+start W3 early. W4.1–2 are needed before any LIFF testing; do them first.
+
+## Deliberately deferred (post-launch)
+
+- Reconciliation sweep (PMS checkouts vs awarded stays)
+- Admin merge tool for duplicate members (email-registered member also
+  silently enrolled via LIFF)
+- In-chat bot replies (explicitly out of scope)
+- `booking_audit_log` retention revisit (tracked in readiness doc)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,3 @@
 VITE_API_URL=http://localhost:4000/api
+# LINE LIFF app id (from the LINE Login channel) — enables silent in-LINE login
+VITE_LIFF_ID=

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.3.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
+        "@line/liff": "^2.29.1",
         "@tailwindcss/forms": "^0.5.10",
         "@tanstack/react-query": "^5.90.11",
         "axios": "^1.16.0",
@@ -2809,6 +2810,868 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
+    "node_modules/@liff/activity": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/activity/-/activity-2.29.1.tgz",
+      "integrity": "sha512-7Gks7xwCVmvxPQkTNYjXTzTa4GXha48w9eUjHXKfD7pUfsRGrwLZ78dwWE8dtbcWdsUq3YfTW5kS9sYs3CoxUQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/native-bridge": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/add-to-home-screen": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/add-to-home-screen/-/add-to-home-screen-2.29.1.tgz",
+      "integrity": "sha512-V48Pg5yLdUKUIUFJuTZ8cGGLn+1fI3qf85KlRmDgnCcandkUkErtlMwmI0X99o0BEYc1JxGOA+a+4XP0teIYGw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/open-window": "2.29.1",
+        "@liff/types": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/analytics": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/analytics/-/analytics-2.29.1.tgz",
+      "integrity": "sha512-xfxDU8nmR2lP7rzvVCL8/hVbAuBFFZAtIccjwStU18GRIyaLhcuBrc0I69qE0JohPXLB6iBjteDhqvO/1ygPWQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/core": "2.29.1",
+        "@liff/get-profile": "2.29.1",
+        "@liff/get-version": "2.29.1",
+        "@liff/is-logged-in": "2.29.1",
+        "@liff/logger": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/types": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/check-availability": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/check-availability/-/check-availability-2.29.1.tgz",
+      "integrity": "sha512-k2a+K+iwFnDW9uQH+46Uj2Z5BYvTQI0xh2q866WoJM4/oSgeUi1WlzO3JTZrbeU8RIzW50vTLb1aCfvyhzszCw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/get-version": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/types": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/close-window": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/close-window/-/close-window-2.29.1.tgz",
+      "integrity": "sha512-vH3qcYPqxaTwMRnC6aEvE1D0//XIqphlB7iXqM85/KZ9ROd0eAiJ1Tg2fxOyemyGZO6x5sbVDUzxLdN1ba4Sgg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/get-line-version": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/native-bridge": "2.29.1",
+        "@liff/types": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/consts": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/consts/-/consts-2.29.1.tgz",
+      "integrity": "sha512-yVlcjNi3z0+7C+tcFTCsHoRI4gnE+Lwp9HCW8vD3RDDucjA16F5XatuSvAA0QLz+6+ixAkBLEiLQ9uufIprm3A==",
+      "license": "SEE LICENSE IN README.md",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/core": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/core/-/core-2.29.1.tgz",
+      "integrity": "sha512-TgK3NnHUe4X+W1WGnetMn43G0C6MbcwcOcb5hZGWtikTO/Z3/H78/DE3sl2r0avs0KMyWQxzyYMqXDXwNsA6Sg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/get-version": "2.29.1",
+        "@liff/init": "2.29.1",
+        "@liff/native-bridge": "2.29.1",
+        "@liff/ready": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/create-shortcut-on-home-screen": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/create-shortcut-on-home-screen/-/create-shortcut-on-home-screen-2.29.1.tgz",
+      "integrity": "sha512-3RdqJfUW7m7bFH1B+6WyYENn9/2tLz6H0UtbEb6uV5rkZerbXxbWmJ/mU/YsATxjcLlfk++fcgEblYFPEtsMuQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/open-window": "2.29.1",
+        "@liff/permanent-link": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/extensions": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/extensions/-/extensions-2.29.1.tgz",
+      "integrity": "sha512-+rgLSDYPN/1FhrTz2po28zs409sYIKdH3YFE/LPiofzRL3aVf5CAV2UI+WNBkpCinGGR1Aw7gVbui4bLg+URSA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/add-to-home-screen": "2.29.1",
+        "@liff/check-availability": "2.29.1",
+        "@liff/consts": "2.29.1",
+        "@liff/get-advertising-id": "2.29.1",
+        "@liff/get-line-version": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/logger": "2.29.1",
+        "@liff/scan-code": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/types": "2.29.1",
+        "@liff/util": "2.29.1"
+      }
+    },
+    "node_modules/@liff/get-advertising-id": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/get-advertising-id/-/get-advertising-id-2.29.1.tgz",
+      "integrity": "sha512-s/AxKA6ygtoN2VtQ9ccJHYEJwcXlXZOcfBMTXa4KD1P7qmviuD3ZqCv7HEXywypNp2JdKbcE0Lk4nlPRfAR3oA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/types": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-app-language": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/get-app-language/-/get-app-language-2.29.1.tgz",
+      "integrity": "sha512-NzTJBBcB+qLFx7JaASljfkJeVuEUxUiO/iO/0UwyBNsSZI4VorStijLC30hIv+JwR0hCDt9XRZFDHDA70+Wh3w==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/get-line-version": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-friendship": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/get-friendship/-/get-friendship-2.29.1.tgz",
+      "integrity": "sha512-vIKOK2IMKghlD3Zr6PaRq5Th14rOxt0/tIyQpHXYJItYGhLY/LLDBynaCjA4vFXna0kHKHrbV22zpyN9/9/YYQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/permission": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-language": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/get-language/-/get-language-2.29.1.tgz",
+      "integrity": "sha512-PrhyVBZFQ/JAAzxO320BAWirg3r2/Wnw+lV8n6wuO4tYyWbhODXJvlGTHC2FHzBr/EIbN53lg3mirkqSipjuBQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-line-version": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/get-line-version/-/get-line-version-2.29.1.tgz",
+      "integrity": "sha512-jGgKojwVhvXSQahY5yxO0N18BIgZiVXBjIME6dd2FtpXBOkaRttPvjF/p37xGgRHu3SCtByeuMxZ6XjZ4k5/7g==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-origins": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/get-origins/-/get-origins-2.29.1.tgz",
+      "integrity": "sha512-8aNfUKqY2GjfHLUIYcmeXxtYgon4WdNeOjJ+MEaR9ExgPPLh3kUSZVnb6LoDqkw/27nn5tUHp0YPaUEYwCHo9g==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-os": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/get-os/-/get-os-2.29.1.tgz",
+      "integrity": "sha512-mBiMetO03s99Wr6CnxcK7/mTzOkVqmC1N/tCF6FetlREawJ1YKNMg/UXAgtQSoEwekuX1tO8XkJYZZVkN8JuqQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-profile": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/get-profile/-/get-profile-2.29.1.tgz",
+      "integrity": "sha512-HstY1Imt5qOJbV9yT2uLngYVY2yaQWRhlFH8SWRcKZS1gg0UB4kwyKmnbiCf54zSTw1DYUeaSEQsOmVbDkBtcw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/permission": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/get-version": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/get-version/-/get-version-2.29.1.tgz",
+      "integrity": "sha512-XiAZiltvymQA70EgSmczPffR15vKbgkPPMrAasdCpkskgeenF23rGbcVQwOpqittZprRADBKEeCMDsbRuoDuxA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/hooks": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/hooks/-/hooks-2.29.1.tgz",
+      "integrity": "sha512-iBF4Og5CMAs2IO6gUaIcktQvoDLKrK6IngEvKo7djjgYcu2z+7+PSMqBCBhKnWNSIxapR1O9hn2T0Eos/lkNsQ==",
+      "license": "SEE LICENSE IN README.md",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/i18n": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/i18n/-/i18n-2.29.1.tgz",
+      "integrity": "sha512-lfy7iwWtn28FUNMI7h4J5nW5EuIXbJEz5tl6CZ9BIzDm/rI3hbRUxOYvjBpZqZXFUS5KFJrXLqCH9wZdl5V+Aw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/logger": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/iap": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/iap/-/iap-2.29.1.tgz",
+      "integrity": "sha512-muDl7jFGjAJtQJJYb3NU+O0RcTf0ukM929X6+SP88CJWq43Kn/1yLA//kmuAzMwnV+nUk0NGCOoNPfDCzr354w==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/native-bridge": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/init": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/init/-/init-2.29.1.tgz",
+      "integrity": "sha512-RANZDQKDlV9V6Af3xztYf6tUaXUnSplcXzWIqj8QM2Fjmdsi6CGn1AA4JnkB03tG+GcD9ze3ijg8mspvhTowow==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/check-availability": "2.29.1",
+        "@liff/close-window": "2.29.1",
+        "@liff/consts": "2.29.1",
+        "@liff/extensions": "2.29.1",
+        "@liff/get-line-version": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/hooks": "2.29.1",
+        "@liff/i18n": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/is-logged-in": "2.29.1",
+        "@liff/is-sub-window": "2.29.1",
+        "@liff/logger": "2.29.1",
+        "@liff/login": "2.29.1",
+        "@liff/logout": "2.29.1",
+        "@liff/message-bus": "2.29.1",
+        "@liff/native-bridge": "2.29.1",
+        "@liff/permanent-link": "2.29.1",
+        "@liff/ready": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/sub-window": "2.29.1",
+        "@liff/types": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1",
+        "@liff/verify-id-token": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-api-available": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/is-api-available/-/is-api-available-2.29.1.tgz",
+      "integrity": "sha512-dQta7qih/GOseVGJBSu9u/FD72/0eVofA4phML8yZJEjqIKBrWwOZ22MIFNwfFuKq69wtLNQVpLPtdJLj/u22w==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/get-line-version": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/is-logged-in": "2.29.1",
+        "@liff/is-sub-window": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-in-client": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/is-in-client/-/is-in-client-2.29.1.tgz",
+      "integrity": "sha512-p9isd9DyZTQyG5oen//ON/H/bK4n5K1VkecUlZJonHH2tTGofKFGPbJtp0R0UKhnspfOtaik8uFAbUOXKyb1ZQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-logged-in": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/is-logged-in/-/is-logged-in-2.29.1.tgz",
+      "integrity": "sha512-j6KnTuuOOk+MWSt7CaVcgQGzgWNPoQZQAITJp5p38R2+LDPpuTZ7vySpPZ3i/YpAI9RKhmCk9gVoEYWfpmgwnQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/store": "2.29.1",
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/is-sub-window": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/is-sub-window/-/is-sub-window-2.29.1.tgz",
+      "integrity": "sha512-NerfHwieeLN4uPzOZk9q2ET40JGjXFjAxkvhuuc5KFPwUYeNpq3cZ9D/A5jZm/0aTmdA3W6peMn3B8yaVaVtNg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/liff-types": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/liff-types/-/liff-types-2.29.1.tgz",
+      "integrity": "sha512-ainj+moA+PFYvTJQNNvNCidTewnLXClUfjGr940RxPEBmpXqQrrrOINmDjfoRuoAXMsgI2YnjdPPv5I9Luq80Q==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/activity": "2.29.1",
+        "@liff/analytics": "2.29.1",
+        "@liff/close-window": "2.29.1",
+        "@liff/create-shortcut-on-home-screen": "2.29.1",
+        "@liff/get-app-language": "2.29.1",
+        "@liff/get-friendship": "2.29.1",
+        "@liff/get-language": "2.29.1",
+        "@liff/get-line-version": "2.29.1",
+        "@liff/get-origins": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/get-profile": "2.29.1",
+        "@liff/get-version": "2.29.1",
+        "@liff/i18n": "2.29.1",
+        "@liff/iap": "2.29.1",
+        "@liff/init": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/is-logged-in": "2.29.1",
+        "@liff/is-sub-window": "2.29.1",
+        "@liff/login": "2.29.1",
+        "@liff/logout": "2.29.1",
+        "@liff/native-bridge": "2.29.1",
+        "@liff/open-window": "2.29.1",
+        "@liff/permanent-link": "2.29.1",
+        "@liff/permission": "2.29.1",
+        "@liff/ready": "2.29.1",
+        "@liff/request-friendship": "2.29.1",
+        "@liff/scan-code-v2": "2.29.1",
+        "@liff/send-messages": "2.29.1",
+        "@liff/share-target-picker": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/sub-window": "2.29.1",
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/logger": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/logger/-/logger-2.29.1.tgz",
+      "integrity": "sha512-YN7IjB1dCjvfT32QplKVQMjt6I3pV/EHeR9CG74EFOVBcGlfi5qoNAkl/2+h4KGe9Q/LDEbv8bGev9mg5WSvjQ==",
+      "license": "SEE LICENSE IN README.md",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/login": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/login/-/login-2.29.1.tgz",
+      "integrity": "sha512-F4u441W/+38TPhVm5Q6+TjMDF1rNvr4+ZKp8qmuPLRKUIU1rNhZtinnl6d2U3KKkYu2y8b2PGhfBMYTsVWUn/A==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/get-version": "2.29.1",
+        "@liff/hooks": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/is-sub-window": "2.29.1",
+        "@liff/logger": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/sub-window": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1",
+        "tiny-sha256": "^1.0.2"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/logout": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/logout/-/logout-2.29.1.tgz",
+      "integrity": "sha512-SaeUpN0qDVVSsTch4uw26GN7OFnLrwSAMgM0QqkmXgZbhjstRFpMoQoKHEHflrFx834m11kvFIPpr0LWjJ7XXQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/store": "2.29.1",
+        "@liff/use": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/message-bus": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/message-bus/-/message-bus-2.29.1.tgz",
+      "integrity": "sha512-riOYh7iWvf/Wr1YbUf4slwj8f9mUvoH5yFEMMkEQwzTfNxY0oVtef7d3O9ANY5Gai6PtVLnpvU9lzI9Dt1OteA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/native-bridge": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/native-bridge/-/native-bridge-2.29.1.tgz",
+      "integrity": "sha512-d+WgPqk98EwChXVGXBntmd9AiXVp22TbxZzI2MRjX7hjV3dWO0afR9uze9fqgN+QEBUiXEGj26mYah8GK+ZeTg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/logger": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/types": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/open-window": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/open-window/-/open-window-2.29.1.tgz",
+      "integrity": "sha512-4DI6UzhITXSrntekxz4Ph+23ceJAjMLBwFkw2KqQ3n6rniINzeX38Yfc0M0wEiXp9MZMOU1L48nMOXPTim026Q==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/get-line-version": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/native-bridge": "2.29.1",
+        "@liff/types": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/permanent-link": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/permanent-link/-/permanent-link-2.29.1.tgz",
+      "integrity": "sha512-7gMpXkbb47TR3+n7ux83KuXkTB31eaD9Aj4H0gRVSh1AeJ0DoUYuXf0UtvQW12DSotyxd+MtyDfXJsrC8hRJJg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/permission": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/permission/-/permission-2.29.1.tgz",
+      "integrity": "sha512-B2d98Y8QJrRm3hrv2ifgxY+HMmSBoMgkDrGnVGu7mqG4qGHmUOoSqP691RGHmcN5f2uXzGBJReM+ZyCxt0KKXQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/sub-window": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1",
+        "@liff/verify-id-token": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/ready": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/ready/-/ready-2.29.1.tgz",
+      "integrity": "sha512-m3GU8OspsO16eGWdcXo3+zqcg1p5oJk6OiVY8qPK4wEQLrB7PAMuGKSIHSuEk6B8Vqtga50KupVSOe7bfl8xBA==",
+      "license": "SEE LICENSE IN README.md",
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/request-friendship": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/request-friendship/-/request-friendship-2.29.1.tgz",
+      "integrity": "sha512-P/ygaOySNbav+Qc/KlWoXtE7Qv8S0rUOQIZxMwDRXmsUa5X9CnTdfQVahg7o4Cv7MDsyMNEFiESoUTL0y+WEFg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/sub-window": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/scan-code": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code/-/scan-code-2.29.1.tgz",
+      "integrity": "sha512-2THCrtJyxu1kEdYWRnxYBrfIRs6x6vtKXV3cblcF3XEZ8HJKH2xBx7GaBAeWEb21BNjPe2Mlg/3zUsRcF97dmg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/types": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/scan-code-v2": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/scan-code-v2/-/scan-code-v2-2.29.1.tgz",
+      "integrity": "sha512-d3cWJjP1fybPH9pyzlJrmX1cQ9uFFKrNDoGjLqE4p2Ch4Ypimvy5Kz3o9qIJVncIItCNg+3To+r6ceJFueZT7A==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/sub-window": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/send-messages": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/send-messages/-/send-messages-2.29.1.tgz",
+      "integrity": "sha512-rbAPRyy0qpawijwlgOuIJIyVXkKHNBXgPm7n+AtgIsBcz+oYfLBPkCQ/tfBkKbSfUmTtNSkr6IV4sfJa3SK9FA==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/get-line-version": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/permission": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1",
+        "@line/bot-sdk": "^10.0.0"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/server-api": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/server-api/-/server-api-2.29.1.tgz",
+      "integrity": "sha512-lTCUG3owquj91ePwOSmnMFxbXuBIqMhrxvy2ZEJXFTXxag6tySCezajjOeuPhOEX1mvma/rIwPzvp7J3qRbxzg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/share-target-picker": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/share-target-picker/-/share-target-picker-2.29.1.tgz",
+      "integrity": "sha512-8BeQDHx4qSU+wqutjOOM5rSmm61I5fKrkglcDPWZoojnThdGfiW+tITJ4j0zAfYK0FwWXI+842vx0RnfbiY3Cg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/analytics": "2.29.1",
+        "@liff/consts": "2.29.1",
+        "@liff/get-line-version": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/is-logged-in": "2.29.1",
+        "@liff/is-sub-window": "2.29.1",
+        "@liff/logger": "2.29.1",
+        "@liff/send-messages": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/types": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1",
+        "@liff/window-postmessage": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/store": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/store/-/store-2.29.1.tgz",
+      "integrity": "sha512-x5aJSxKw8TcVMMt8OncUFgejg9v+i+yaJrE8TcvJReWI9vuudRZktRnSWbknGvVJpJBRvHh1m2K6dPQ/ljdP2g==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/types": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/sub-window": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/sub-window/-/sub-window-2.29.1.tgz",
+      "integrity": "sha512-JEJErRRo/S5F9ckTNCJSs4hVLAvyAtFYplmT1GiBrlbdl3r7RkREwGEKYWq/oLBdR6cCEz/tgQKof/HARQCAeg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/close-window": "2.29.1",
+        "@liff/consts": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/is-sub-window": "2.29.1",
+        "@liff/logger": "2.29.1",
+        "@liff/message-bus": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/types": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/types/-/types-2.29.1.tgz",
+      "integrity": "sha512-q20zgLpVL8FqyBaLwcC5iHBKRIkOz+1IIr5ETdBNKA7re5d08grz5XJdHfoAinf26wAPzWKxsHJTHNSreSCA+w==",
+      "license": "SEE LICENSE IN README.md"
+    },
+    "node_modules/@liff/use": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/use/-/use-2.29.1.tgz",
+      "integrity": "sha512-DoBXRnfg/UXZXik3QExgJgSR0gafaF/nMGV0PXlaXF0AjZCB9q8R7FsoTz7A2JXTSulu5iaE0XZHEZ7xjJYDsg==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/hooks": "2.29.1",
+        "@liff/logger": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/util": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/util/-/util-2.29.1.tgz",
+      "integrity": "sha512-RQx4jr238HQfGIeWsOROr8BYak2WNHexqF8UL6AEkQixY5G4C3wgajiQ4IxjT4Qy6w9kZu+EnJCmAefVLQFGyQ==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/logger": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/verify-id-token": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/verify-id-token/-/verify-id-token-2.29.1.tgz",
+      "integrity": "sha512-m1sVPeUGKOP7omN3Oq+JN9c7azFzOPGaYZVS5hMlNcJm4bjQUeuGjei0FWAIsYfSZd0WbqlLZ8CkolmWEG5G5Q==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@liff/window-postmessage": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@liff/window-postmessage/-/window-postmessage-2.29.1.tgz",
+      "integrity": "sha512-pzmXvcCBHblw44oB+0iNY76GOHB4PRmA+C+AHvbuZG9vRZgz6F8vXgCoJTLOexAdSPcxdF/NQVrj1bnQ8jOYCw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/consts": "2.29.1",
+        "@liff/logger": "2.29.1",
+        "@liff/util": "2.29.1"
+      },
+      "peerDependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@line/bot-sdk": {
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/@line/bot-sdk/-/bot-sdk-10.8.0.tgz",
+      "integrity": "sha512-1Mdpw/WPS3QP6fGiwPRTL27k8MgmMe7rVKCKsItP/kPzogX7a/X1ipQqk/F6RkorP9DNyJIx590hnVUkfBQf3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/node": "^24.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "axios": "^1.7.4"
+      }
+    },
+    "node_modules/@line/liff": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/@line/liff/-/liff-2.29.1.tgz",
+      "integrity": "sha512-8SM0aWBe0sPDwGSgq1Qod5T9kCMSt7FECXq2cuc5w5LUcJsLhD+N2G4QuwKX62e6iMFHouRhmewew9Sit/TPMw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@liff/activity": "2.29.1",
+        "@liff/analytics": "2.29.1",
+        "@liff/close-window": "2.29.1",
+        "@liff/consts": "2.29.1",
+        "@liff/core": "2.29.1",
+        "@liff/create-shortcut-on-home-screen": "2.29.1",
+        "@liff/extensions": "2.29.1",
+        "@liff/get-app-language": "2.29.1",
+        "@liff/get-friendship": "2.29.1",
+        "@liff/get-language": "2.29.1",
+        "@liff/get-line-version": "2.29.1",
+        "@liff/get-origins": "2.29.1",
+        "@liff/get-os": "2.29.1",
+        "@liff/get-profile": "2.29.1",
+        "@liff/get-version": "2.29.1",
+        "@liff/hooks": "2.29.1",
+        "@liff/i18n": "2.29.1",
+        "@liff/iap": "2.29.1",
+        "@liff/init": "2.29.1",
+        "@liff/is-api-available": "2.29.1",
+        "@liff/is-in-client": "2.29.1",
+        "@liff/is-logged-in": "2.29.1",
+        "@liff/is-sub-window": "2.29.1",
+        "@liff/liff-types": "2.29.1",
+        "@liff/login": "2.29.1",
+        "@liff/logout": "2.29.1",
+        "@liff/native-bridge": "2.29.1",
+        "@liff/open-window": "2.29.1",
+        "@liff/permanent-link": "2.29.1",
+        "@liff/permission": "2.29.1",
+        "@liff/ready": "2.29.1",
+        "@liff/request-friendship": "2.29.1",
+        "@liff/scan-code-v2": "2.29.1",
+        "@liff/send-messages": "2.29.1",
+        "@liff/server-api": "2.29.1",
+        "@liff/share-target-picker": "2.29.1",
+        "@liff/store": "2.29.1",
+        "@liff/sub-window": "2.29.1",
+        "@liff/use": "2.29.1",
+        "@liff/util": "2.29.1",
+        "tslib": "^2.3.0",
+        "whatwg-fetch": "^3.0.0"
+      }
+    },
     "node_modules/@lukeed/ms": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
@@ -3618,7 +4481,6 @@
       "version": "24.10.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.4.tgz",
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -10015,6 +10877,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-sha256": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-sha256/-/tiny-sha256-1.0.2.tgz",
+      "integrity": "sha512-IdsPtu8eJ0SwuCWUFm2euFH3jJvtpGQC0VpZNZlqxRvQ2zGvSjbXDO+4T8Rm5ETsmCQHHvKUGds69bJYrlb3Tg==",
+      "license": "Public domain"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -10164,6 +11032,13 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -10331,7 +11206,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -10742,6 +11616,12 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@line/liff": "^2.29.1",
     "@tailwindcss/forms": "^0.5.10",
     "@tanstack/react-query": "^5.90.11",
     "axios": "^1.16.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,6 +38,8 @@ const AdminTransactionHistoryPage = lazy(() => import('./pages/admin/AdminTransa
 const EmailServicePage = lazy(() => import('./pages/admin/EmailServicePage'));
 const BookingPage = lazy(() => import('./pages/BookingPage'));
 const MyBookingsPage = lazy(() => import('./pages/MyBookingsPage'));
+const MemberCardPage = lazy(() => import('./pages/MemberCardPage'));
+const PrivacyPage = lazy(() => import('./pages/PrivacyPage'));
 const RoomTypeManagement = lazy(() => import('./pages/admin/RoomTypeManagement'));
 const RoomManagement = lazy(() => import('./pages/admin/RoomManagement'));
 const RoomAvailability = lazy(() => import('./pages/admin/RoomAvailability'));
@@ -47,6 +49,7 @@ import { checkPWAInstallPrompt } from './utils/pwaUtils';
 import { notificationService } from './services/notificationService';
 import { logger } from './utils/logger';
 import { migrateAuthStorageForCookieRefreshToken } from './utils/authStorageMigration';
+import { initLiffAutoLogin } from './utils/liffAuth';
 
 function App() {
   const isAuthenticated = useAuthStore((state) => state.isAuthenticated);
@@ -166,6 +169,14 @@ function App() {
           }
         }
         
+        // LIFF silent auto-login: only inside the LINE in-app browser and
+        // only when no session was rehydrated above. Outside LINE this is
+        // a strict no-op (the SDK isn't even downloaded), so the web
+        // behaviour is unchanged.
+        if (!useAuthStore.getState().accessToken) {
+          await initLiffAutoLogin();
+        }
+
         // Only log in development mode
         if (import.meta.env?.DEV) {
           const finalState = useAuthStore.getState();
@@ -264,6 +275,10 @@ function App() {
           path="/oauth/success"
           element={<OAuthSuccessPage />}
         />
+        <Route
+          path="/privacy"
+          element={<PrivacyPage />}
+        />
 
         {/* Protected routes */}
         <Route
@@ -279,6 +294,14 @@ function App() {
           element={
             <ProtectedRoute>
               <ProfilePage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/member-card"
+          element={
+            <ProtectedRoute>
+              <MemberCardPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/layout/MainLayout.tsx
+++ b/frontend/src/components/layout/MainLayout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
 import { useAuthStore } from '../../store/authStore';
 import { getUserDisplayName } from '../../utils/userHelpers';
 import { useTranslation } from 'react-i18next';
@@ -45,6 +46,17 @@ export default function MainLayout({ children, title, showProfileBanner = true }
           {children}
         </div>
       </main>
+
+      {/* Footer */}
+      <footer className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 text-center">
+        <Link
+          to="/privacy"
+          className="text-sm text-stone-400 hover:text-stone-600"
+          data-testid="footer-privacy-link"
+        >
+          {t('privacy.footerLink')}
+        </Link>
+      </footer>
     </div>
   );
 }

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -162,7 +162,7 @@
     "manageAccountLinks": "Manage Connected Accounts",
     "role": "Role",
     "customer": "Customer",
-    "staff": "Staff", 
+    "staff": "Staff",
     "admin": "Admin",
     "superAdmin": "Super Admin",
     "loggedInAs": "Logged in as {{email}}",
@@ -186,7 +186,7 @@
     "phonePlaceholder": "+1 (555) 123-4567",
     "accountLinkingDescription2": "Link multiple accounts together to access your data from different login methods.",
     "membershipId": "Membership ID",
-    "copyMembershipId": "Copy membership ID", 
+    "copyMembershipId": "Copy membership ID",
     "membershipIdCopied": "Membership ID copied successfully",
     "membershipIdFormat": "8-digit ID starting with 269",
     "personalInformation": "Personal Information",
@@ -341,6 +341,9 @@
     "backToDashboard": "Back to Dashboard"
   },
   "errors": {
+    "failedToLoadCoupons": "Unable to load your coupons. Please try refreshing the page.",
+    "validationFailed": "This coupon couldn't be validated. Please check the code and try again.",
+    "redemptionFailed": "Unable to redeem this coupon right now. Please contact support if the problem continues.",
     "notFound": "Page Not Found",
     "notFoundDescription": "The page you're looking for doesn't exist or has been moved.",
     "unauthorized": "Access Denied",
@@ -355,8 +358,9 @@
     "tryAgain": "Try Again",
     "goHome": "Return to Dashboard",
     "contactSupport": "Contact Support",
-    "emailAlreadyRegistered": "This email is already registered",
-    "emailAlreadyInUse": "This email is already in use by another account"
+    "error": "Error occurred",
+    "failedToLoadAssignments": "Failed to load coupon assignments",
+    "failedToRemoveCoupons": "Failed to remove coupons"
   },
   "languages": {
     "en": "English",
@@ -395,7 +399,7 @@
     "used": "used",
     "expired": "expired",
     "deducted": "deducted",
-    "pointsEarned": "Points Earned",
+    "pointsEarned": "Points Earned Successfully!",
     "pointsDeducted": "Points Deducted",
     "transactionHistory": "Transaction History",
     "noTransactions": "No transactions yet",
@@ -413,7 +417,6 @@
     "amountSpent": "Amount Spent",
     "stayId": "Stay ID (Optional)",
     "earnPoints": "Earn Points",
-    "pointsEarned": "Points Earned Successfully!",
     "dashboard": {
       "title": "Your Loyalty Rewards",
       "welcome": "Manage your rewards and track your progress",
@@ -430,9 +433,9 @@
       "selectUser": "Choose a customer to view their loyalty details",
       "userDetails": "User Details",
       "currentPoints": "Current Points",
-        "currentTier": "Current Tier",
+      "currentTier": "Current Tier",
       "recentTransactions": "Recent Transactions",
-      "noTransactions": "No transactions found",
+      "noTransactions": "No transactions available",
       "noUsers": "No users found",
       "refresh": "Refresh",
       "expirePoints": "Expire Old Points",
@@ -464,8 +467,7 @@
       },
       "transactionHistory": "Transaction History",
       "transactions": "transactions",
-      "viewTransactionHistory": "View transaction history",
-      "noTransactions": "No transactions available"
+      "viewTransactionHistory": "View transaction history"
     },
     "coupons": {
       "title": "Digital Coupon Management",
@@ -908,7 +910,7 @@
     "noCouponsDescription": "You don't have any active coupons right now. Keep earning points to unlock exclusive offers!",
     "noUsedCoupons": "No Used Coupons",
     "noUsedCouponsDescription": "You haven't used any coupons yet.",
-    "noExpiredCoupons": "No Expired Coupons", 
+    "noExpiredCoupons": "No Expired Coupons",
     "noExpiredCouponsDescription": "You don't have any expired coupons.",
     "activeCoupons": "Active Coupons",
     "usedCoupons": "Used Coupons",
@@ -994,37 +996,15 @@
     "settings": "Settings",
     "help": "Help & Support"
   },
-  "errors": {
-    "failedToLoadCoupons": "Unable to load your coupons. Please try refreshing the page.",
-    "validationFailed": "This coupon couldn't be validated. Please check the code and try again.",
-    "redemptionFailed": "Unable to redeem this coupon right now. Please contact support if the problem continues.",
-    "notFound": "Page Not Found",
-    "notFoundDescription": "The page you're looking for doesn't exist or has been moved.",
-    "unauthorized": "Access Denied",
-    "unauthorizedDescription": "You don't have permission to access this page. Please sign in with appropriate credentials.",
-    "forbidden": "Access Forbidden",
-    "serverError": "Something Went Wrong",
-    "serverErrorDescription": "We're experiencing technical difficulties. Our team has been notified.",
-    "networkError": "Connection Problem",
-    "networkErrorDescription": "Please check your internet connection and try again.",
-    "unknownError": "Unexpected Error",
-    "unknownErrorDescription": "Something unexpected happened. Please try again or contact support if the problem persists.",
-    "tryAgain": "Try Again",
-    "goHome": "Return to Dashboard",
-    "contactSupport": "Contact Support",
-    "error": "Error occurred",
-    "failedToLoadAssignments": "Failed to load coupon assignments",
-    "failedToRemoveCoupons": "Failed to remove coupons"
-  },
   "surveys": {
     "title": "Customer Surveys",
     "subtitle": "Help us improve by sharing your feedback - you can retake surveys anytime!",
     "untitled": "Untitled Survey",
-    "loading": "Loading available surveys...",
+    "loading": "Loading survey...",
     "noSurveys": "No surveys available",
     "noPublicSurveys": "No surveys are currently available. We'll notify you when new surveys become available!",
     "noInvitedSurveys": "You haven't been invited to participate in any surveys yet. Check back soon!",
-    "takeSurvey": "Start Survey",
+    "takeSurvey": "Take Survey",
     "viewDetails": "View Survey Details",
     "questions": "questions",
     "question": "question",
@@ -1043,13 +1023,10 @@
       "required": "This question is required - please provide an answer",
       "invalid": "Please provide a valid answer for this question"
     },
-    "loading": "Loading survey...",
     "description": "Description",
     "preview": "Preview ({{count}} questions)",
     "created": "Created",
-    "takeSurvey": "Take Survey",
     "backToSurveys": "Back to Surveys",
-    "notFound": "Survey not found",
     "accessType": {
       "public": "Public",
       "invited": "Invited"
@@ -1324,7 +1301,7 @@
         "allTemplates": "All Templates",
         "categories": {
           "feedback": "Feedback",
-          "loyalty": "Loyalty", 
+          "loyalty": "Loyalty",
           "events": "Events",
           "quick": "Quick",
           "custom": "Custom"
@@ -1355,7 +1332,7 @@
                 "text": "How likely are you to recommend us to others?",
                 "options": {
                   "veryLikely": "Very likely",
-                  "likely": "Likely", 
+                  "likely": "Likely",
                   "neutral": "Neutral",
                   "unlikely": "Unlikely",
                   "veryUnlikely": "Very unlikely"
@@ -1406,7 +1383,7 @@
                   "pool": "Swimming pool",
                   "gym": "Gym/Fitness center",
                   "spa": "Spa",
-                  "restaurant": "Restaurant", 
+                  "restaurant": "Restaurant",
                   "bar": "Bar",
                   "business": "Business center",
                   "concierge": "Concierge services"
@@ -1642,7 +1619,13 @@
     "totalForNights": "Total for {{nights}} nights",
     "roomsLeft": "{{count}} room(s) left",
     "pointsYouWillEarn": "You'll earn {{points}} points!",
-    "maxGuests": "Max {{count}} guests"
+    "maxGuests": "Max {{count}} guests",
+    "selectProperty": "Select hotel",
+    "property": "Hotel",
+    "guestName": "Guest name",
+    "guestPhone": "Phone number",
+    "guestPhonePlaceholder": "e.g. 081-234-5678",
+    "guestDetailsRequired": "Please fill in the guest name and phone number"
   },
   "payment": {
     "title": "Payment",
@@ -1706,6 +1689,38 @@
     "showBankDetails": "Show bank transfer details",
     "hideBankDetails": "Hide bank transfer details",
     "yourSlips": "Your uploaded slips",
-    "removeSlip": "Remove slip"
+    "removeSlip": "Remove slip",
+    "balanceDueAtCheckin": "Balance due at check-in",
+    "holdExpiresIn": "Please pay within {{time}} — the room is held for you until then",
+    "holdExpired": "The payment window has expired and the room hold was released. Please start a new booking.",
+    "startOver": "Start a new booking",
+    "propertyAccount": "Payment goes to {{property}}'s account"
+  },
+  "property": {
+    "hf": "The Harbour Front Hotel",
+    "hfville": "HF Ville"
+  },
+  "memberCard": {
+    "title": "Member Card",
+    "dashboardDescription": "Show your QR at the front desk",
+    "membershipId": "Membership ID",
+    "qrAlt": "Membership QR code",
+    "qrError": "Could not generate the QR code",
+    "generating": "Generating QR code...",
+    "noMembershipId": "Your membership ID is not ready yet. Please contact the front desk.",
+    "showAtDesk": "Show this QR code at the front desk when you check in, so your stay counts toward your membership."
+  },
+  "privacy": {
+    "title": "Privacy Notice",
+    "footerLink": "Privacy notice",
+    "whatWeStoreTitle": "What we store",
+    "whatWeStoreBody": "Your name, your LINE identity, your phone number (only if you choose to add it), and your stay history — used to run the loyalty program: nights, tier, points, and coupons.",
+    "whyTitle": "Why we store it",
+    "whyBody": "Membership data is processed to operate your membership (our contract with you). We do not sell your data or share it outside the hotel group.",
+    "messagesTitle": "Messages from us",
+    "messagesBody": "Adding one of our hotels' LINE official accounts as a friend is your opt-in to receive membership messages from that hotel. Blocking the account stops its messages at any time.",
+    "contactTitle": "Contact",
+    "contactBody": "For data questions, export, or deletion requests, contact the hotel support email or the front desk.",
+    "backToApp": "Back to the app"
   }
 }

--- a/frontend/src/i18n/locales/th/translation.json
+++ b/frontend/src/i18n/locales/th/translation.json
@@ -420,7 +420,7 @@
     "used": "ใช้",
     "expired": "หมดอายุ",
     "deducted": "หัก",
-    "pointsEarned": "ได้รับคะแนน",
+    "pointsEarned": "รับคะแนนสำเร็จ!",
     "pointsDeducted": "หักคะแนน",
     "transactionHistory": "ประวัติการทำรายการ",
     "noTransactions": "ยังไม่มีรายการ",
@@ -438,7 +438,6 @@
     "amountSpent": "ยอดเงินที่ใช้จ่าย",
     "stayId": "รหัสการเข้าพัก (ไม่บังคับ)",
     "earnPoints": "รับคะแนน",
-    "pointsEarned": "รับคะแนนสำเร็จ!",
     "dashboard": {
       "title": "แดชบอร์ดโปรแกรมสะสมคะแนน",
       "welcome": "ยินดีต้อนรับสู่แดชบอร์ดโปรแกรมสะสมคะแนน",
@@ -457,7 +456,7 @@
       "currentPoints": "คะแนนปัจจุบัน",
       "currentTier": "ระดับสมาชิกปัจจุบัน",
       "recentTransactions": "ธุรกรรมล่าสุด",
-      "noTransactions": "ไม่พบธุรกรรม",
+      "noTransactions": "ไม่มีธุรกรรม",
       "noUsers": "ไม่พบผู้ใช้",
       "refresh": "รีเฟรช",
       "expirePoints": "ทำให้คะแนนเก่าหมดอายุ",
@@ -489,8 +488,7 @@
       },
       "transactionHistory": "ประวัติธุรกรรม",
       "transactions": "ธุรกรรม",
-      "viewTransactionHistory": "ดูประวัติธุรกรรม",
-      "noTransactions": "ไม่มีธุรกรรม"
+      "viewTransactionHistory": "ดูประวัติธุรกรรม"
     },
     "coupons": {
       "title": "จัดการคูปอง",
@@ -1066,13 +1064,10 @@
       "required": "คำถามนี้จำเป็นต้องตอบ",
       "invalid": "กรุณาให้คำตอบที่ถูกต้อง"
     },
-    "loading": "กำลังโหลดแบบสำรวจ...",
     "description": "คำอธิบาย",
     "preview": "ตัวอย่าง ({{count}} คำถาม)",
     "created": "สร้างเมื่อ",
-    "takeSurvey": "ทำแบบสำรวจ",
     "backToSurveys": "กลับไปแบบสำรวจ",
-    "notFound": "ไม่พบแบบสำรวจ",
     "accessType": {
       "public": "สาธารณะ",
       "invited": "ได้รับเชิญ"
@@ -1181,31 +1176,31 @@
         }
       },
       "questionEditor": {
-        "questionNumber": "คำถาม {{number}}",
-        "questionText": "ข้อความคำถาม *",
-        "questionTextPlaceholder": "ใส่คำถามของคุณ...",
-        "fieldRequired": "ฟิลด์นี้จำเป็นต้องกรอก",
+        "questionNumber": "คำถามที่ {{number}}",
+        "questionText": "ข้อความคำถาม",
+        "questionTextPlaceholder": "กรอกคำถามของคุณที่นี่...",
         "description": "คำอธิบาย (ไม่บังคับ)",
-        "descriptionPlaceholder": "ข้อมูลเพิ่มเติมหรือคำแนะนำ...",
+        "descriptionPlaceholder": "เพิ่มบริบทหรือคำแนะนำเพิ่มเติมสำหรับคำถามนี้...",
+        "fieldRequired": "ฟิลด์นี้จำเป็นต้องกรอก",
         "answerOptions": "ตัวเลือกคำตอบ",
-        "optionTextPlaceholder": "ข้อความตัวเลือก...",
+        "optionTextPlaceholder": "กรอกข้อความตัวเลือก...",
         "optionValuePlaceholder": "ค่า",
-        "addOption": "เพิ่มตัวเลือก",
-        "newOptionText": "ตัวเลือก {{number}}",
+        "newOptionText": "ตัวเลือกที่ {{number}}",
+        "addOption": "+ เพิ่มตัวเลือก",
         "minRating": "คะแนนต่ำสุด",
         "maxRating": "คะแนนสูงสุด",
-        "requiredQuestion": "คำถามที่ต้องตอบ",
-        "preview": "ตัวอย่าง:",
-        "previewPlaceholder": "ข้อความคำถามจะแสดงที่นี่...",
-        "textInputPlaceholder": "การใส่ข้อความ",
-        "longTextInputPlaceholder": "การใส่ข้อความยาว",
+        "requiredQuestion": "คำถามบังคับ",
+        "preview": "ตัวอย่าง",
+        "previewPlaceholder": "(ข้อความคำถามจะแสดงที่นี่)",
+        "textInputPlaceholder": "พิมพ์คำตอบของคุณที่นี่...",
+        "longTextInputPlaceholder": "พิมพ์คำตอบแบบละเอียดของคุณที่นี่...",
         "questionTypes": {
-          "singleChoice": "ตัวเลือกเดี่ยว",
-          "multipleChoice": "ตัวเลือกหลายตัว",
+          "singleChoice": "เลือกคำตอบเดียว",
+          "multipleChoice": "เลือกได้หลายคำตอบ",
           "text": "ข้อความสั้น",
           "textarea": "ข้อความยาว",
-          "rating5": "คะแนน 5 ดาว",
-          "rating10": "คะแนน 10 ระดับ",
+          "rating5": "ให้คะแนน 5 ดาว",
+          "rating10": "ให้คะแนน 10 ระดับ",
           "yesNo": "ใช่/ไม่ใช่"
         }
       },
@@ -1273,35 +1268,6 @@
         "emptyOptionsCount": "กรุณากรอกข้อความตัวเลือกทั้งหมด (พบตัวเลือกว่าง {{count}} รายการ)",
         "questionTextRequired": "ต้องกรอกข้อความคำถาม",
         "titleAndQuestionRequired": "กรุณาใส่ชื่อและอย่างน้อยหนึ่งคำถาม"
-      },
-      "questionEditor": {
-        "questionNumber": "คำถามที่ {{number}}",
-        "questionText": "ข้อความคำถาม",
-        "questionTextPlaceholder": "กรอกคำถามของคุณที่นี่...",
-        "description": "คำอธิบาย (ไม่บังคับ)",
-        "descriptionPlaceholder": "เพิ่มบริบทหรือคำแนะนำเพิ่มเติมสำหรับคำถามนี้...",
-        "fieldRequired": "ฟิลด์นี้จำเป็นต้องกรอก",
-        "answerOptions": "ตัวเลือกคำตอบ",
-        "optionTextPlaceholder": "กรอกข้อความตัวเลือก...",
-        "optionValuePlaceholder": "ค่า",
-        "newOptionText": "ตัวเลือกที่ {{number}}",
-        "addOption": "+ เพิ่มตัวเลือก",
-        "minRating": "คะแนนต่ำสุด",
-        "maxRating": "คะแนนสูงสุด",
-        "requiredQuestion": "คำถามบังคับ",
-        "preview": "ตัวอย่าง",
-        "previewPlaceholder": "(ข้อความคำถามจะแสดงที่นี่)",
-        "textInputPlaceholder": "พิมพ์คำตอบของคุณที่นี่...",
-        "longTextInputPlaceholder": "พิมพ์คำตอบแบบละเอียดของคุณที่นี่...",
-        "questionTypes": {
-          "singleChoice": "เลือกคำตอบเดียว",
-          "multipleChoice": "เลือกได้หลายคำตอบ",
-          "text": "ข้อความสั้น",
-          "textarea": "ข้อความยาว",
-          "rating5": "ให้คะแนน 5 ดาว",
-          "rating10": "ให้คะแนน 10 ระดับ",
-          "yesNo": "ใช่/ไม่ใช่"
-        }
       },
       "analytics": {
         "title": "การวิเคราะห์แบบสำรวจ",
@@ -1373,7 +1339,7 @@
         "allTemplates": "เทมเพลตทั้งหมด",
         "categories": {
           "feedback": "ความคิดเห็น",
-          "loyalty": "ความจงรักภักดี", 
+          "loyalty": "ความจงรักภักดี",
           "events": "อีเวนท์",
           "quick": "รวดเร็ว",
           "custom": "กำหนดเอง"
@@ -1404,7 +1370,7 @@
                 "text": "คุณมีแนวโน้มที่จะแนะนำเราให้คนอื่นแค่ไหน?",
                 "options": {
                   "veryLikely": "มีแนวโน้มมาก",
-                  "likely": "มีแนวโน้ม", 
+                  "likely": "มีแนวโน้ม",
                   "neutral": "เฉยๆ",
                   "unlikely": "ไม่มีแนวโน้ม",
                   "veryUnlikely": "ไม่มีแนวโน้มเลย"
@@ -1455,7 +1421,7 @@
                   "pool": "สระว่ายน้ำ",
                   "gym": "ยิม/ศูนย์ออกกำลังกาย",
                   "spa": "สปา",
-                  "restaurant": "ร้านอาหาร", 
+                  "restaurant": "ร้านอาหาร",
                   "bar": "บาร์",
                   "business": "ศูนย์ธุรกิจ",
                   "concierge": "บริการคอนเซียร์จ"
@@ -1691,7 +1657,13 @@
     "totalForNights": "รวม {{nights}} คืน",
     "roomsLeft": "เหลือ {{count}} ห้อง",
     "pointsYouWillEarn": "คุณจะได้รับ {{points}} คะแนน!",
-    "maxGuests": "สูงสุด {{count}} ท่าน"
+    "maxGuests": "สูงสุด {{count}} ท่าน",
+    "selectProperty": "เลือกโรงแรม",
+    "property": "โรงแรม",
+    "guestName": "ชื่อผู้เข้าพัก",
+    "guestPhone": "เบอร์โทรศัพท์",
+    "guestPhonePlaceholder": "เช่น 081-234-5678",
+    "guestDetailsRequired": "กรุณากรอกชื่อผู้เข้าพักและเบอร์โทรศัพท์"
   },
   "payment": {
     "title": "การชำระเงิน",
@@ -1755,6 +1727,38 @@
     "showBankDetails": "แสดงข้อมูลการโอน",
     "hideBankDetails": "ซ่อนข้อมูลการโอน",
     "yourSlips": "สลิปที่อัปโหลดแล้ว",
-    "removeSlip": "ลบสลิป"
+    "removeSlip": "ลบสลิป",
+    "balanceDueAtCheckin": "ยอดคงเหลือชำระตอนเช็คอิน",
+    "holdExpiresIn": "กรุณาชำระภายใน {{time}} — เราจองห้องไว้ให้คุณจนถึงเวลานั้น",
+    "holdExpired": "หมดเวลาชำระเงิน ระบบได้ปล่อยห้องที่จองไว้แล้ว กรุณาเริ่มจองใหม่",
+    "startOver": "เริ่มจองใหม่",
+    "propertyAccount": "ยอดชำระเข้าบัญชีของ{{property}}"
+  },
+  "property": {
+    "hf": "โรงแรมเดอะฮาร์เบอร์ฟร้อนท์",
+    "hfville": "เอชเอฟ วิลล์"
+  },
+  "memberCard": {
+    "title": "บัตรสมาชิก",
+    "dashboardDescription": "แสดง QR ที่แผนกต้อนรับ",
+    "membershipId": "รหัสสมาชิก",
+    "qrAlt": "คิวอาร์โค้ดสมาชิก",
+    "qrError": "สร้างคิวอาร์โค้ดไม่สำเร็จ",
+    "generating": "กำลังสร้างคิวอาร์โค้ด...",
+    "noMembershipId": "รหัสสมาชิกของคุณยังไม่พร้อม กรุณาติดต่อแผนกต้อนรับ",
+    "showAtDesk": "แสดงคิวอาร์โค้ดนี้ที่แผนกต้อนรับตอนเช็คอิน เพื่อให้การเข้าพักนับเข้าสมาชิกของคุณ"
+  },
+  "privacy": {
+    "title": "ประกาศความเป็นส่วนตัว",
+    "footerLink": "ประกาศความเป็นส่วนตัว",
+    "whatWeStoreTitle": "ข้อมูลที่เราเก็บ",
+    "whatWeStoreBody": "ชื่อของคุณ ข้อมูลบัญชี LINE เบอร์โทรศัพท์ (เฉพาะเมื่อคุณเลือกกรอก) และประวัติการเข้าพัก — ใช้เพื่อดำเนินโปรแกรมสมาชิก: จำนวนคืน ระดับสมาชิก คะแนน และคูปอง",
+    "whyTitle": "เหตุผลที่เก็บข้อมูล",
+    "whyBody": "ข้อมูลสมาชิกถูกประมวลผลเพื่อให้บริการสมาชิกภาพของคุณ (สัญญาระหว่างเรากับคุณ) เราไม่ขายหรือแบ่งปันข้อมูลของคุณนอกเครือโรงแรม",
+    "messagesTitle": "ข้อความจากเรา",
+    "messagesBody": "การเพิ่มบัญชี LINE Official ของโรงแรมเป็นเพื่อน ถือเป็นการยินยอมรับข้อความเกี่ยวกับสมาชิกจากโรงแรมนั้น การบล็อกบัญชีจะหยุดข้อความได้ทุกเมื่อ",
+    "contactTitle": "ติดต่อ",
+    "contactBody": "สอบถามเรื่องข้อมูล ขอสำเนา หรือขอลบข้อมูล ติดต่ออีเมลฝ่ายบริการของโรงแรมหรือแผนกต้อนรับ",
+    "backToApp": "กลับสู่แอป"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN/translation.json
+++ b/frontend/src/i18n/locales/zh-CN/translation.json
@@ -157,7 +157,7 @@
     "manageAccountLinks": "管理关联账户",
     "role": "角色",
     "customer": "客户",
-    "staff": "员工", 
+    "staff": "员工",
     "admin": "管理员",
     "superAdmin": "超级管理员",
     "loggedInAs": "当前登录：{{email}}",
@@ -332,22 +332,9 @@
     "backToDashboard": "返回仪表板"
   },
   "errors": {
-    "notFound": "页面未找到",
-    "notFoundDescription": "您要访问的页面不存在或已被移动。",
-    "unauthorized": "访问被拒绝",
-    "unauthorizedDescription": "您没有权限访问此页面。请使用适当的凭据登录。",
-    "forbidden": "访问被禁止",
-    "serverError": "出现错误",
-    "serverErrorDescription": "我们遇到了技术问题。我们的团队已收到通知。",
-    "networkError": "连接问题",
-    "networkErrorDescription": "请检查您的网络连接并重试。",
-    "unknownError": "未知错误",
-    "unknownErrorDescription": "发生了意外情况。请重试，如果问题持续存在，请联系技术支持。",
-    "tryAgain": "重试",
-    "goHome": "返回仪表板",
-    "contactSupport": "联系技术支持",
-    "emailAlreadyRegistered": "此邮箱已被注册",
-    "emailAlreadyInUse": "此邮箱已被其他账户使用"
+    "failedToLoadCoupons": "无法加载您的优惠券。请尝试刷新页面。",
+    "validationFailed": "无法验证此优惠券。请检查代码并重试。",
+    "redemptionFailed": "目前无法兑换此优惠券。如果问题持续存在，请联系技术支持。"
   },
   "languages": {
     "en": "English",
@@ -411,9 +398,9 @@
       "selectUser": "选择客户以查看其积分详情",
       "userDetails": "用户详情",
       "currentPoints": "当前积分",
-        "currentTier": "当前等级",
+      "currentTier": "当前等级",
       "recentTransactions": "最近交易",
-      "noTransactions": "未找到交易记录",
+      "noTransactions": "没有交易记录",
       "noUsers": "未找到用户",
       "refresh": "刷新",
       "expirePoints": "使旧积分过期",
@@ -445,8 +432,7 @@
       },
       "transactionHistory": "交易历史",
       "transactions": "笔交易",
-      "viewTransactionHistory": "查看交易历史",
-      "noTransactions": "没有交易记录"
+      "viewTransactionHistory": "查看交易历史"
     },
     "coupons": {
       "title": "数字优惠券管理",
@@ -597,26 +583,6 @@
     "qrError": "生成二维码失败",
     "couponCode": "优惠券代码"
   },
-  "errors": {
-    "failedToLoadCoupons": "无法加载您的优惠券。请尝试刷新页面。",
-    "validationFailed": "无法验证此优惠券。请检查代码并重试。",
-    "redemptionFailed": "目前无法使用此优惠券。如果问题仍然存在，请联系客服。",
-    "notFound": "页面未找到",
-    "notFoundDescription": "您查找的页面不存在或已被移动。",
-    "unauthorized": "访问被拒绝",
-    "unauthorizedDescription": "您无权访问此页面。请使用适当的凭据登录。",
-    "forbidden": "禁止访问",
-    "serverError": "出现问题",
-    "serverErrorDescription": "我们遇到了技术问题。我们的团队已经收到通知。",
-    "networkError": "连接问题",
-    "networkErrorDescription": "请检查您的网络连接并重试。",
-    "unknownError": "意外错误",
-    "unknownErrorDescription": "发生了意外情况。请重试或联系客服如果问题仍然存在。",
-    "tryAgain": "重试",
-    "goHome": "返回仪表板",
-    "contactSupport": "联系客服",
-    "error": "发生错误"
-  },
   "navigation": {
     "dashboard": "仪表板",
     "backToDashboard": "← 返回仪表板",
@@ -630,16 +596,11 @@
     "settings": "设置",
     "help": "帮助与支持"
   },
-  "errors": {
-    "failedToLoadCoupons": "无法加载您的优惠券。请尝试刷新页面。",
-    "validationFailed": "无法验证此优惠券。请检查代码并重试。",
-    "redemptionFailed": "目前无法兑换此优惠券。如果问题持续存在，请联系技术支持。"
-  },
   "surveys": {
     "title": "客户调研",
     "subtitle": "通过分享您的反馈帮助我们改进 - 您可以随时重新参与调研！",
     "untitled": "无标题调研",
-    "loading": "加载可用调研中...",
+    "loading": "加载调研中...",
     "noSurveys": "暂无调研",
     "noPublicSurveys": "目前没有可用的调研。有新调研时我们会通知您！",
     "noInvitedSurveys": "您尚未被邀请参与任何调研。请稍后回来查看！",
@@ -667,13 +628,10 @@
       "required": "此问题为必答题 - 请提供答案",
       "invalid": "请为此问题提供有效答案"
     },
-    "loading": "加载调研中...",
     "description": "描述",
     "preview": "预览 ({{count}} 个问题)",
     "created": "创建于",
-    "takeSurvey": "开始调研",
     "backToSurveys": "返回调研",
-    "notFound": "未找到调研",
     "accessType": {
       "public": "公开",
       "invited": "受邀"
@@ -882,68 +840,6 @@
           "yesNo": "是/否"
         }
       },
-      "analytics": {
-        "title": "调研分析与洞察",
-        "overview": "性能概览",
-        "responses": "总回答数",
-        "completion": "完成率",
-        "averageTime": "平均完成时间",
-        "questionAnalytics": "逐题分析",
-        "responseDistribution": "回答分布",
-        "noResponses": "尚未收集到回答",
-        "insights": "关键洞察",
-        "trends": "回答趋势",
-        "exportData": "导出调研数据"
-      },
-      "invitations": {
-        "title": "调研邀请",
-        "sendInvitations": "发送调研邀请",
-        "inviteUsers": "邀请特定用户",
-        "selectUsers": "选择接收者",
-        "invitationsSent": "成功发送 {{count}} 份邀请",
-        "noInvitations": "此调研尚未发送邀请",
-        "inviteByEmail": "通过邮箱地址邀请",
-        "bulkInvite": "批量邀请",
-        "trackingStatus": "跟踪邀请状态",
-        "publicSurveyTitle": "这是公开调研",
-        "publicSurveyDescription": "公开调研对应用中的所有用户自动可用。无需邀请 - 用户可以直接从他们的\"参与调研\"菜单中找到并参与此调研。",
-        "publicSurveyType": "公开",
-        "surveyType": "调研类型"
-      },
-      "couponAssignment": {
-        "title": "调研奖励",
-        "description": "分配用户完成此调研时自动获得的优惠券",
-        "assignCoupon": "分配优惠券奖励",
-        "editAssignment": "编辑优惠券分配",
-        "selectCoupon": "选择要分配的优惠券",
-        "noAvailableCoupons": "没有可分配的活跃优惠券",
-        "rewardCondition": "奖励条件",
-        "alwaysOnCompletion": "用户完成调研时（100%回答）将自动获得优惠券。",
-        "awardedOnCompletion": "完成后获得",
-        "maxAwards": "最大奖励数量",
-        "unlimited": "无限制",
-        "maxAwardsHelp": "留空表示无限奖励，或设置总奖励上限",
-        "customExpiry": "自定义过期时间（天）",
-        "useCouponExpiry": "使用优惠券的过期日期",
-        "customExpiryHelp": "从奖励日期开始用自定义时长覆盖优惠券的过期时间",
-        "reason": "分配原因",
-        "reasonPlaceholder": "为什么要将此优惠券分配给此调研？",
-        "assign": "分配优惠券",
-        "update": "更新分配",
-        "remove": "移除分配",
-        "awarded": "已奖励",
-        "completed": "已完成",
-        "noAssignments": "未分配优惠券奖励",
-        "noAssignmentsHelp": "分配优惠券以自动奖励完成此调研的用户",
-        "confirmRemove": "您确定要移除此优惠券分配吗？用户将不再因完成调研而获得此奖励。",
-        "loadError": "加载优惠券分配失败",
-        "assignSuccess": "优惠券已成功分配给调研",
-        "assignError": "分配优惠券给调研失败",
-        "updateSuccess": "优惠券分配更新成功",
-        "updateError": "更新优惠券分配失败",
-        "removeSuccess": "优惠券分配移除成功",
-        "removeError": "移除优惠券分配失败"
-      },
       "templates": {
         "title": "调研模板",
         "subtitle": "从预制模板开始或创建自己的模板",
@@ -951,7 +847,7 @@
         "allTemplates": "所有模板",
         "categories": {
           "feedback": "反馈",
-          "loyalty": "忠诚度", 
+          "loyalty": "忠诚度",
           "events": "活动",
           "quick": "快速",
           "custom": "自定义"
@@ -981,7 +877,7 @@
                 "text": "您向他人推荐我们的可能性有多大？",
                 "options": {
                   "veryLikely": "很可能",
-                  "likely": "可能", 
+                  "likely": "可能",
                   "neutral": "中性",
                   "unlikely": "不太可能",
                   "veryUnlikely": "完全不可能"
@@ -1032,7 +928,7 @@
                   "pool": "游泳池",
                   "gym": "健身房/健身中心",
                   "spa": "水疗中心",
-                  "restaurant": "餐厅", 
+                  "restaurant": "餐厅",
                   "bar": "酒吧",
                   "business": "商务中心",
                   "concierge": "礼宾服务"
@@ -1144,5 +1040,47 @@
       "fetchDetailsFailed": "获取用户详情失败"
     },
     "confirmDelete": "您确定要删除 {{name}} 吗？此操作无法撤销。"
+  },
+  "property": {
+    "hf": "海滨酒店 (The Harbour Front)",
+    "hfville": "HF Ville"
+  },
+  "memberCard": {
+    "title": "会员卡",
+    "dashboardDescription": "在前台出示您的二维码",
+    "membershipId": "会员编号",
+    "qrAlt": "会员二维码",
+    "qrError": "二维码生成失败",
+    "generating": "正在生成二维码...",
+    "noMembershipId": "您的会员编号尚未生成，请联系前台。",
+    "showAtDesk": "入住时请在前台出示此二维码，让您的入住计入会员记录。"
+  },
+  "privacy": {
+    "title": "隐私声明",
+    "footerLink": "隐私声明",
+    "whatWeStoreTitle": "我们存储的信息",
+    "whatWeStoreBody": "您的姓名、LINE 账号信息、电话号码（仅当您选择填写时）以及入住记录——用于运营会员计划：住宿晚数、会员等级、积分和优惠券。",
+    "whyTitle": "存储原因",
+    "whyBody": "会员数据用于履行您的会员服务（我们与您之间的合约）。我们不会出售您的数据，也不会在酒店集团之外共享。",
+    "messagesTitle": "来自我们的消息",
+    "messagesBody": "添加我们酒店的 LINE 官方账号为好友，即表示您同意接收该酒店的会员消息。随时屏蔽该账号即可停止接收消息。",
+    "contactTitle": "联系方式",
+    "contactBody": "如需咨询数据、导出或删除，请联系酒店支持邮箱或前台。",
+    "backToApp": "返回应用"
+  },
+  "booking": {
+    "selectProperty": "选择酒店",
+    "property": "酒店",
+    "guestName": "入住人姓名",
+    "guestPhone": "电话号码",
+    "guestPhonePlaceholder": "例如 081-234-5678",
+    "guestDetailsRequired": "请填写入住人姓名和电话号码"
+  },
+  "payment": {
+    "balanceDueAtCheckin": "入住时应付余额",
+    "holdExpiresIn": "请在 {{time}} 内付款——房间将为您保留至该时间",
+    "holdExpired": "付款时间已过，房间保留已释放。请重新预订。",
+    "startOver": "重新预订",
+    "propertyAccount": "款项将支付到{{property}}的账户"
   }
 }

--- a/frontend/src/pages/BookingPage.tsx
+++ b/frontend/src/pages/BookingPage.tsx
@@ -1,22 +1,29 @@
-import { useState, useRef, useCallback, useMemo } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
-import { FiCalendar, FiUsers, FiCheck, FiStar, FiWifi, FiTv, FiCoffee, FiUpload, FiX, FiCheckCircle, FiClock, FiAlertCircle, FiDownload } from 'react-icons/fi';
+import { FiCalendar, FiUsers, FiCheck, FiUpload, FiX, FiCheckCircle, FiClock, FiAlertCircle, FiMapPin } from 'react-icons/fi';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import QRCode from 'qrcode';
 import clsx from 'clsx';
 import MainLayout from '../components/layout/MainLayout';
 import { bookingService } from '../services/bookingService';
-import { paymentService } from '../services/paymentService';
+import {
+  channelBookingService,
+  type Property,
+  type PaymentOption,
+  type ChannelBookingResponse,
+} from '../services/channelBookingService';
+import { useAuthStore } from '../store/authStore';
+import { logger } from '../utils/logger';
 import toast from 'react-hot-toast';
-import companyQRCode from '../assets/company-promptpay-qr.png';
-import kbankLogo from '../assets/kbank-logo.png';
 
-// Amenity icons mapping
-const amenityIcons: Record<string, React.ReactNode> = {
-  wifi: <FiWifi className="w-4 h-4" />,
-  tv: <FiTv className="w-4 h-4" />,
-  minibar: <FiCoffee className="w-4 h-4" />,
-};
+// The booking flow is a CHANNEL into the PMS (ADR-0003): availability is
+// queried live and a confirmed booking is created in the PMS. Payment is a
+// PromptPay transfer into the booked property's own receiving account —
+// the QR payload arrives with the booking response; nothing is hardcoded
+// here.
+
+const PROPERTIES: Property[] = ['hf', 'hfville'];
 
 interface BookingStep {
   number: number;
@@ -24,31 +31,38 @@ interface BookingStep {
   completed: boolean;
 }
 
-type PaymentType = 'deposit' | 'full';
 type SlipStatus = 'pending' | 'uploaded' | 'verified' | 'failed';
 
-interface CreatedBooking {
-  id: string;
-  totalPrice: number;
+function formatCountdown(msLeft: number): string {
+  const totalSeconds = Math.max(0, Math.floor(msLeft / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }
 
 export default function BookingPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const user = useAuthStore((state) => state.user);
 
   // Form state
+  const [property, setProperty] = useState<Property | null>(null);
   const [checkIn, setCheckIn] = useState('');
   const [checkOut, setCheckOut] = useState('');
-  const [selectedRoomTypeId, setSelectedRoomTypeId] = useState<string | null>(null);
   const [numGuests, setNumGuests] = useState(1);
-  const [notes, setNotes] = useState('');
+  const [selectedRoomTypeId, setSelectedRoomTypeId] = useState<string | null>(null);
+  const [guestName, setGuestName] = useState(
+    [user?.firstName, user?.lastName].filter(Boolean).join(' '),
+  );
+  const [guestPhone, setGuestPhone] = useState(user?.phone ?? '');
+  const [paymentOption, setPaymentOption] = useState<PaymentOption>('deposit50');
   const [currentStep, setCurrentStep] = useState(1);
 
   // Payment state
-  const [createdBooking, setCreatedBooking] = useState<CreatedBooking | null>(null);
-  const [paymentType, setPaymentType] = useState<PaymentType>('deposit');
-  const [isPaymentConfirmed, setIsPaymentConfirmed] = useState(false);
+  const [createdBooking, setCreatedBooking] = useState<ChannelBookingResponse | null>(null);
+  const [qrDataUrl, setQrDataUrl] = useState<string>('');
+  const [holdMsLeft, setHoldMsLeft] = useState<number | null>(null);
   const [slipFile, setSlipFile] = useState<File | null>(null);
   const [slipPreview, setSlipPreview] = useState<string | null>(null);
   const [slipStatus, setSlipStatus] = useState<SlipStatus>('pending');
@@ -60,33 +74,48 @@ export default function BookingPage() {
   const today = new Date().toISOString().split('T')[0];
   const minCheckOut = checkIn ? new Date(new Date(checkIn).getTime() + 86400000).toISOString().split('T')[0] : today;
 
-  // Calculate nights
   const nights = checkIn && checkOut
     ? Math.ceil((new Date(checkOut).getTime() - new Date(checkIn).getTime()) / (1000 * 60 * 60 * 24))
     : 0;
 
-  // Queries
-  const { data: roomTypesWithAvailability, isLoading: isLoadingRoomTypes } = useQuery({
-    queryKey: ['bookings', 'availability', checkIn, checkOut],
-    queryFn: () => bookingService.checkAvailability(new Date(checkIn), new Date(checkOut)),
-    enabled: !!checkIn && !!checkOut && nights > 0,
+  // Live availability from the PMS via the channel endpoint
+  const { data: availability, isLoading: isLoadingRoomTypes } = useQuery({
+    queryKey: ['bookings', 'channel-availability', property, checkIn, checkOut, numGuests],
+    queryFn: () => {
+      if (!property) {
+        throw new Error('property is required when availability query is enabled');
+      }
+      return channelBookingService.getAvailability(property, checkIn, checkOut, numGuests);
+    },
+    enabled: !!property && !!checkIn && !!checkOut && nights > 0,
   });
 
-  const selectedRoomType = roomTypesWithAvailability?.find(rt => rt.id === selectedRoomTypeId);
-  const totalPrice = selectedRoomType ? selectedRoomType.pricePerNight * nights : 0;
-  const pointsEarned = Math.floor(totalPrice * 10);
+  const roomTypes = availability?.room_types;
+  const selectedRoomType = roomTypes?.find(rt => rt.room_type_id === selectedRoomTypeId);
+  const totalPrice = selectedRoomType ? selectedRoomType.nightly_price * nights : 0;
+  const depositAmount = Math.round(totalPrice * 0.5);
+  const amountDueNow = paymentOption === 'deposit50' ? depositAmount : totalPrice;
 
-  // Mutations
   const createBookingMutation = useMutation({
-    mutationFn: (data: { roomTypeId: string; checkIn: Date; checkOut: Date; numGuests: number; notes?: string }) =>
-      bookingService.createBooking(data),
+    mutationFn: () => {
+      if (!property || !selectedRoomTypeId) {
+        throw new Error('property and room type are required');
+      }
+      return channelBookingService.createBooking({
+        property,
+        room_type_id: selectedRoomTypeId,
+        check_in: checkIn,
+        check_out: checkOut,
+        guests: numGuests,
+        guest_name: guestName.trim(),
+        guest_phone: guestPhone.trim(),
+        payment_option: paymentOption,
+      });
+    },
     onSuccess: async (data) => {
       await queryClient.invalidateQueries({ queryKey: ['bookings'] });
       toast.success(t('booking.bookingSuccess'));
-      setCreatedBooking({
-        id: data.id,
-        totalPrice: Number(data.totalPrice),
-      });
+      setCreatedBooking(data);
       setCurrentStep(4);
     },
     onError: (error: Error) => {
@@ -94,46 +123,50 @@ export default function BookingPage() {
     },
   });
 
-  // Calculate payment amounts
-  const depositAmount = createdBooking ? Math.round(createdBooking.totalPrice * 0.5) : 0;
-  const fullAmount = createdBooking ? createdBooking.totalPrice : 0;
-  const amountToPay = paymentType === 'deposit' ? depositAmount : fullAmount;
-
-  // Fetch dynamic PromptPay QR (SVG) for the chosen amount once the user has
-  // confirmed their payment type. Falls back to the bundled image if the
-  // backend can't produce a QR (e.g. PromptPay Tax ID not configured).
-  const {
-    data: promptPayQr,
-    isLoading: isLoadingQr,
-    isError: isQrError,
-  } = useQuery({
-    queryKey: ['payments', 'promptpay-qr', createdBooking?.id, amountToPay],
-    queryFn: () => {
-      if (!createdBooking?.id) {
-        throw new Error('createdBooking.id is required when QR query is enabled');
-      }
-      return paymentService.getPromptPayQr(amountToPay, createdBooking.id);
-    },
-    enabled: Boolean(isPaymentConfirmed && createdBooking?.id && amountToPay > 0),
-    staleTime: 60_000,
-    retry: 1,
-  });
-
-  // Encode the SVG payload as a data URL so the existing <img>/download
-  // markup can render and offer it as a downloadable file without any
-  // additional asset round-trip.
-  const promptPayQrSrc = useMemo(() => {
-    if (promptPayQr?.svg) {
-      return `data:image/svg+xml;utf8,${encodeURIComponent(promptPayQr.svg)}`;
+  // Render the per-property PromptPay QR from the payload in the booking
+  // response (same QRCode.toDataURL pattern as the coupon QR modal).
+  useEffect(() => {
+    if (!createdBooking?.promptpay_qr_payload) {
+      setQrDataUrl('');
+      return;
     }
-    return null;
-  }, [promptPayQr]);
+    let cancelled = false;
+    QRCode.toDataURL(createdBooking.promptpay_qr_payload, {
+      width: 320,
+      margin: 2,
+      errorCorrectionLevel: 'M',
+    })
+      .then((url) => {
+        if (!cancelled) {
+          setQrDataUrl(url);
+        }
+      })
+      .catch((error: unknown) => {
+        logger.error(
+          'Failed to render PromptPay QR:',
+          error instanceof Error ? error.message : String(error),
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [createdBooking]);
 
-  // Fall back to the bundled company QR image when the dynamic generator is
-  // unavailable. This keeps the page functional during local dev where the
-  // PromptPay Tax ID env var may not be set.
-  const fallbackQrUrl = import.meta.env.VITE_PROMPTPAY_QR_IMAGE_URL ?? companyQRCode;
-  const displayedQrUrl = promptPayQrSrc ?? fallbackQrUrl;
+  // Hold-expiry countdown. The PMS releases the room if the deposit is not
+  // verified before hold_expires_at; keep the guest aware of the clock.
+  useEffect(() => {
+    if (!createdBooking?.hold_expires_at) {
+      setHoldMsLeft(null);
+      return;
+    }
+    const expiresAt = new Date(createdBooking.hold_expires_at).getTime();
+    const tick = () => setHoldMsLeft(expiresAt - Date.now());
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+  }, [createdBooking]);
+
+  const holdExpired = holdMsLeft !== null && holdMsLeft <= 0 && slipStatus === 'pending' && !slipPreview;
 
   // File handling functions
   const handleFileSelect = useCallback((file: File) => {
@@ -195,10 +228,8 @@ export default function BookingPage() {
       // Two-step flow (mirrors MyBookingsPage):
       //   1. POST /api/slips/upload      -> stores the file, returns the URL
       //   2. POST /api/bookings/:id/slips -> attaches the URL to the booking
-      // The backend `/api/slips/upload` route lives in
-      // `backend-rust/src/routes/slips.rs` and enforces auth + 10MB + JPG/PNG.
       const { url } = await bookingService.uploadSlip(slipFile);
-      await bookingService.addSlip(createdBooking.id, url);
+      await bookingService.addSlip(createdBooking.booking_id, url);
 
       setSlipStatus('uploaded');
       await queryClient.invalidateQueries({ queryKey: ['bookings'] });
@@ -216,32 +247,37 @@ export default function BookingPage() {
   }, [navigate]);
 
   const handleDateSubmit = () => {
-    if (checkIn && checkOut && nights > 0) {
+    if (property && checkIn && checkOut && nights > 0) {
       setCurrentStep(2);
     }
   };
 
   const handleRoomTypeSelect = (roomTypeId: string) => {
-    const roomType = roomTypesWithAvailability?.find(rt => rt.id === roomTypeId);
-    if (roomType && roomType.availableRooms > 0) {
+    const roomType = roomTypes?.find(rt => rt.room_type_id === roomTypeId);
+    if (roomType && roomType.available_count > 0) {
       setSelectedRoomTypeId(roomTypeId);
-      setNumGuests(Math.min(numGuests, roomType.maxGuests));
       setCurrentStep(3);
     }
   };
 
   const handleBookingSubmit = () => {
-    if (!selectedRoomTypeId || !checkIn || !checkOut) {
+    if (!selectedRoomTypeId || !checkIn || !checkOut || !property) {
       return;
     }
+    if (!guestName.trim() || !guestPhone.trim()) {
+      toast.error(t('booking.guestDetailsRequired'));
+      return;
+    }
+    createBookingMutation.mutate();
+  };
 
-    createBookingMutation.mutate({
-      roomTypeId: selectedRoomTypeId,
-      checkIn: new Date(checkIn),
-      checkOut: new Date(checkOut),
-      numGuests,
-      notes: notes || undefined,
-    });
+  const restartBooking = () => {
+    setCreatedBooking(null);
+    setSelectedRoomTypeId(null);
+    setSlipFile(null);
+    setSlipPreview(null);
+    setSlipStatus('pending');
+    setCurrentStep(1);
   };
 
   const steps: BookingStep[] = [
@@ -278,7 +314,7 @@ export default function BookingPage() {
         </div>
       </div>
 
-      {/* Step 1: Select Dates */}
+      {/* Step 1: Property, dates, guests */}
       {currentStep === 1 && (
         <div className="bg-white rounded-lg shadow p-6 max-w-md mx-auto">
           <h2 className="text-xl font-semibold mb-6 flex items-center">
@@ -287,6 +323,34 @@ export default function BookingPage() {
           </h2>
 
           <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-stone-700 mb-2">
+                {t('booking.selectProperty')}
+              </label>
+              <div className="grid grid-cols-1 gap-3">
+                {PROPERTIES.map((p) => (
+                  <label
+                    key={p}
+                    className={clsx('flex items-center p-3 border-2 rounded-lg cursor-pointer transition-colors',
+                      property === p ? 'border-primary-500 bg-primary-50' : 'border-stone-200 hover:border-stone-300'
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name="property"
+                      value={p}
+                      checked={property === p}
+                      onChange={() => setProperty(p)}
+                      className="text-primary-600 focus:ring-primary-500"
+                      data-testid={`property-${p}`}
+                    />
+                    <FiMapPin className="ml-3 mr-2 text-primary-600 flex-shrink-0" />
+                    <span className="font-medium">{t(`property.${p}`)}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+
             <div>
               <label className="block text-sm font-medium text-stone-700 mb-1">
                 {t('booking.checkIn')}
@@ -321,6 +385,24 @@ export default function BookingPage() {
               />
             </div>
 
+            <div>
+              <label className="block text-sm font-medium text-stone-700 mb-1">
+                {t('booking.numberOfGuests')}
+              </label>
+              <select
+                value={numGuests}
+                onChange={(e) => setNumGuests(parseInt(e.target.value))}
+                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+                data-testid="num-guests"
+              >
+                {[1, 2, 3, 4].map((n) => (
+                  <option key={n} value={n}>
+                    {n} {n === 1 ? t('booking.guest') : t('booking.guests')}
+                  </option>
+                ))}
+              </select>
+            </div>
+
             {nights > 0 && (
               <p className="text-sm text-stone-600">
                 {t('booking.nightsSelected', { count: nights })}
@@ -329,7 +411,7 @@ export default function BookingPage() {
 
             <button
               onClick={handleDateSubmit}
-              disabled={!checkIn || !checkOut || nights <= 0}
+              disabled={!property || !checkIn || !checkOut || nights <= 0}
               className="w-full py-2 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:bg-stone-300 disabled:cursor-not-allowed"
               data-testid="continue-to-rooms"
             >
@@ -355,6 +437,7 @@ export default function BookingPage() {
           </div>
 
           <p className="text-stone-600 mb-4">
+            {property && <span className="font-medium">{t(`property.${property}`)} · </span>}
             {t('booking.stayDates', {
               checkIn: new Date(checkIn).toLocaleDateString(),
               checkOut: new Date(checkOut).toLocaleDateString(),
@@ -366,25 +449,25 @@ export default function BookingPage() {
             <div className="flex justify-center py-12">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
             </div>
-          ) : roomTypesWithAvailability?.length === 0 ? (
+          ) : roomTypes?.length === 0 ? (
             <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
               <p className="text-yellow-800">{t('booking.noRoomsAvailable')}</p>
             </div>
           ) : (
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {roomTypesWithAvailability?.map((roomType) => (
+              {roomTypes?.map((roomType) => (
                 <div
-                  key={roomType.id}
+                  key={roomType.room_type_id}
                   className={clsx('bg-white rounded-lg shadow overflow-hidden',
-                    roomType.availableRooms === 0 ? 'opacity-50' : 'hover:shadow-lg cursor-pointer'
+                    roomType.available_count === 0 ? 'opacity-50' : 'hover:shadow-lg cursor-pointer'
                   )}
-                  onClick={() => roomType.availableRooms > 0 && handleRoomTypeSelect(roomType.id)}
-                  data-testid={`room-type-${roomType.id}`}
+                  onClick={() => roomType.available_count > 0 && handleRoomTypeSelect(roomType.room_type_id)}
+                  data-testid={`room-type-${roomType.room_type_id}`}
                 >
                   {/* Room Image */}
-                  {roomType.images && roomType.images.length > 0 ? (
+                  {roomType.photo_url ? (
                     <img
-                      src={roomType.images[0]}
+                      src={roomType.photo_url}
                       alt={roomType.name}
                       className="w-full h-48 object-cover"
                     />
@@ -400,44 +483,18 @@ export default function BookingPage() {
                       <p className="text-stone-600 text-sm mt-1 line-clamp-2">{roomType.description}</p>
                     )}
 
-                    {/* Amenities */}
-                    {roomType.amenities && roomType.amenities.length > 0 && (
-                      <div className="flex flex-wrap gap-2 mt-3">
-                        {roomType.amenities.slice(0, 4).map((amenity) => (
-                          <span
-                            key={amenity}
-                            className="inline-flex items-center px-2 py-1 bg-stone-100 rounded text-xs text-stone-600"
-                          >
-                            {amenityIcons[amenity] ?? null}
-                            <span className="ml-1">{amenity}</span>
-                          </span>
-                        ))}
-                      </div>
-                    )}
-
-                    {/* Room Info */}
-                    <div className="flex items-center justify-between mt-4">
-                      <div className="flex items-center text-sm text-stone-500">
-                        <FiUsers className="mr-1" />
-                        {t('booking.maxGuests', { count: roomType.maxGuests })}
-                      </div>
-                      {roomType.bedType && (
-                        <span className="text-sm text-stone-500 capitalize">{roomType.bedType}</span>
-                      )}
-                    </div>
-
                     {/* Price and Availability */}
                     <div className="mt-4 pt-4 border-t">
                       <div className="flex items-center justify-between">
                         <div>
                           <span className="text-2xl font-bold text-primary-600">
-                            ฿{roomType.pricePerNight.toLocaleString()}
+                            ฿{roomType.nightly_price.toLocaleString()}
                           </span>
                           <span className="text-stone-500 text-sm">/{t('booking.night')}</span>
                         </div>
                         <div className="text-right">
                           <div className="text-lg font-semibold">
-                            ฿{(roomType.pricePerNight * nights).toLocaleString()}
+                            ฿{(roomType.nightly_price * nights).toLocaleString()}
                           </div>
                           <div className="text-sm text-stone-500">
                             {t('booking.totalForNights', { nights })}
@@ -446,12 +503,12 @@ export default function BookingPage() {
                       </div>
 
                       <div className={clsx('mt-2 text-sm',
-                        roomType.availableRooms === 0 ? 'text-red-600' : 'text-green-600'
+                        roomType.available_count === 0 ? 'text-red-600' : 'text-green-600'
                       )}
                       >
-                        {roomType.availableRooms === 0
+                        {roomType.available_count === 0
                           ? t('booking.soldOut')
-                          : t('booking.roomsLeft', { count: roomType.availableRooms })}
+                          : t('booking.roomsLeft', { count: roomType.available_count })}
                       </div>
                     </div>
                   </div>
@@ -482,6 +539,10 @@ export default function BookingPage() {
 
               <div className="grid grid-cols-2 gap-4 text-sm">
                 <div>
+                  <span className="text-stone-500">{t('booking.property')}:</span>
+                  <span className="ml-2 font-medium">{property ? t(`property.${property}`) : ''}</span>
+                </div>
+                <div>
                   <span className="text-stone-500">{t('booking.roomType')}:</span>
                   <span className="ml-2 font-medium">{selectedRoomType.name}</span>
                 </div>
@@ -497,45 +558,102 @@ export default function BookingPage() {
                   <span className="text-stone-500">{t('booking.nights')}:</span>
                   <span className="ml-2 font-medium">{nights}</span>
                 </div>
+                <div>
+                  <span className="text-stone-500">{t('booking.numberOfGuests')}:</span>
+                  <span className="ml-2 font-medium">{numGuests}</span>
+                </div>
               </div>
             </div>
 
             {/* Guest Details */}
             <div className="border-b pb-6">
-              <h3 className="font-semibold text-lg mb-4">{t('booking.guestDetails')}</h3>
+              <h3 className="font-semibold text-lg mb-4 flex items-center">
+                <FiUsers className="mr-2" />
+                {t('booking.guestDetails')}
+              </h3>
 
               <div className="space-y-4">
                 <div>
                   <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('booking.numberOfGuests')}
+                    {t('booking.guestName')}
                   </label>
-                  <select
-                    value={numGuests}
-                    onChange={(e) => setNumGuests(parseInt(e.target.value))}
+                  <input
+                    type="text"
+                    value={guestName}
+                    onChange={(e) => setGuestName(e.target.value)}
                     className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
-                    data-testid="num-guests"
-                  >
-                    {Array.from({ length: selectedRoomType.maxGuests }, (_, i) => i + 1).map((n) => (
-                      <option key={n} value={n}>
-                        {n} {n === 1 ? t('booking.guest') : t('booking.guests')}
-                      </option>
-                    ))}
-                  </select>
+                    data-testid="guest-name"
+                  />
                 </div>
 
                 <div>
                   <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('booking.specialRequests')}
+                    {t('booking.guestPhone')}
                   </label>
-                  <textarea
-                    value={notes}
-                    onChange={(e) => setNotes(e.target.value)}
-                    rows={3}
-                    placeholder={t('booking.specialRequestsPlaceholder')}
+                  <input
+                    type="tel"
+                    value={guestPhone}
+                    onChange={(e) => setGuestPhone(e.target.value)}
+                    placeholder={t('booking.guestPhonePlaceholder')}
                     className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
-                    data-testid="special-requests"
+                    data-testid="guest-phone"
                   />
                 </div>
+              </div>
+            </div>
+
+            {/* Payment option (50% deposit or full) */}
+            <div className="border-b pb-6">
+              <h3 className="font-semibold text-lg mb-4">{t('payment.selectPaymentType')}</h3>
+
+              <div className="space-y-3">
+                <label
+                  className={clsx('flex items-start p-4 border-2 rounded-lg cursor-pointer transition-colors',
+                    paymentOption === 'deposit50' ? 'border-primary-500 bg-primary-50' : 'border-stone-200 hover:border-stone-300'
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="paymentOption"
+                    value="deposit50"
+                    checked={paymentOption === 'deposit50'}
+                    onChange={() => setPaymentOption('deposit50')}
+                    className="mt-1 text-primary-600 focus:ring-primary-500"
+                  />
+                  <div className="ml-3 flex-1">
+                    <div className="flex justify-between items-center">
+                      <span className="font-medium">{t('payment.deposit')}</span>
+                      <span className="text-lg font-bold text-primary-600">
+                        ฿{depositAmount.toLocaleString('th-TH')}
+                      </span>
+                    </div>
+                    <p className="text-sm text-stone-500 mt-1">{t('payment.depositDescription')}</p>
+                  </div>
+                </label>
+
+                <label
+                  className={clsx('flex items-start p-4 border-2 rounded-lg cursor-pointer transition-colors',
+                    paymentOption === 'full' ? 'border-primary-500 bg-primary-50' : 'border-stone-200 hover:border-stone-300'
+                  )}
+                >
+                  <input
+                    type="radio"
+                    name="paymentOption"
+                    value="full"
+                    checked={paymentOption === 'full'}
+                    onChange={() => setPaymentOption('full')}
+                    className="mt-1 text-primary-600 focus:ring-primary-500"
+                  />
+                  <div className="ml-3 flex-1">
+                    <div className="flex justify-between items-center">
+                      <span className="font-medium">{t('payment.payInFull')}</span>
+                      <span className="text-lg font-bold text-primary-600">
+                        ฿{totalPrice.toLocaleString('th-TH')}
+                      </span>
+                    </div>
+                    <p className="text-sm text-stone-500 mt-1">{t('payment.payInFullDescription')}</p>
+                  </div>
+                </label>
               </div>
             </div>
 
@@ -546,7 +664,7 @@ export default function BookingPage() {
               <div className="space-y-2 text-sm">
                 <div className="flex justify-between">
                   <span>
-                    ฿{selectedRoomType.pricePerNight.toLocaleString()} x {nights} {nights === 1 ? t('booking.night') : t('booking.nights')}
+                    ฿{selectedRoomType.nightly_price.toLocaleString()} x {nights} {nights === 1 ? t('booking.night') : t('booking.nights')}
                   </span>
                   <span>฿{totalPrice.toLocaleString()}</span>
                 </div>
@@ -554,26 +672,17 @@ export default function BookingPage() {
                   <span>{t('booking.total')}</span>
                   <span className="text-primary-600">฿{totalPrice.toLocaleString()}</span>
                 </div>
-              </div>
-            </div>
-
-            {/* Points Earned */}
-            <div className="bg-yellow-50 rounded-lg p-4 flex items-center">
-              <FiStar className="w-8 h-8 text-yellow-500 mr-4" />
-              <div>
-                <p className="font-semibold text-yellow-800">
-                  {t('booking.pointsYouWillEarn', { points: pointsEarned.toLocaleString() })}
-                </p>
-                <p className="text-sm text-yellow-700">
-                  {t('booking.pointsDescription')}
-                </p>
+                <div className="flex justify-between text-sm text-stone-600">
+                  <span>{t('payment.amountToPay')}</span>
+                  <span>฿{amountDueNow.toLocaleString()}</span>
+                </div>
               </div>
             </div>
 
             {/* Submit Button */}
             <button
               onClick={handleBookingSubmit}
-              disabled={createBookingMutation.isPending}
+              disabled={createBookingMutation.isPending || !guestName.trim() || !guestPhone.trim()}
               className="w-full py-3 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:bg-stone-300 disabled:cursor-not-allowed font-semibold"
               data-testid="confirm-booking"
             >
@@ -598,175 +707,77 @@ export default function BookingPage() {
           </div>
 
           <div className="bg-white rounded-lg shadow p-6 space-y-6">
-            {/* Payment Type Selection */}
-            <div className={isPaymentConfirmed ? '' : 'border-b pb-6'}>
-              <h3 className="font-semibold text-lg mb-4">{t('payment.selectPaymentType')}</h3>
-
-              {!isPaymentConfirmed ? (
-                <>
-                  <div className="space-y-3">
-                    <label
-                      className={clsx('flex items-start p-4 border-2 rounded-lg cursor-pointer transition-colors',
-                        paymentType === 'deposit' ? 'border-primary-500 bg-primary-50' : 'border-stone-200 hover:border-stone-300'
-                      )}
-                    >
-                      <input
-                        type="radio"
-                        name="paymentType"
-                        value="deposit"
-                        checked={paymentType === 'deposit'}
-                        onChange={() => setPaymentType('deposit')}
-                        className="mt-1 text-primary-600 focus:ring-primary-500"
-                      />
-                      <div className="ml-3 flex-1">
-                        <div className="flex justify-between items-center">
-                          <span className="font-medium">{t('payment.deposit')}</span>
-                          <span className="text-lg font-bold text-primary-600">
-                            ฿{depositAmount.toLocaleString('th-TH')}
-                          </span>
-                        </div>
-                        <p className="text-sm text-stone-500 mt-1">{t('payment.depositDescription')}</p>
-                      </div>
-                    </label>
-
-                    <label
-                      className={clsx('flex items-start p-4 border-2 rounded-lg cursor-pointer transition-colors',
-                        paymentType === 'full' ? 'border-primary-500 bg-primary-50' : 'border-stone-200 hover:border-stone-300'
-                      )}
-                    >
-                      <input
-                        type="radio"
-                        name="paymentType"
-                        value="full"
-                        checked={paymentType === 'full'}
-                        onChange={() => setPaymentType('full')}
-                        className="mt-1 text-primary-600 focus:ring-primary-500"
-                      />
-                      <div className="ml-3 flex-1">
-                        <div className="flex justify-between items-center">
-                          <span className="font-medium">{t('payment.payInFull')}</span>
-                          <span className="text-lg font-bold text-primary-600">
-                            ฿{fullAmount.toLocaleString('th-TH')}
-                          </span>
-                        </div>
-                        <p className="text-sm text-stone-500 mt-1">{t('payment.payInFullDescription')}</p>
-                      </div>
-                    </label>
-                  </div>
-
-                  <button
-                    onClick={() => setIsPaymentConfirmed(true)}
-                    className="w-full mt-4 py-3 bg-primary-600 text-white rounded-lg font-medium hover:bg-primary-700 transition-colors"
-                  >
-                    {t('payment.confirmPaymentType')}
-                  </button>
-                </>
-              ) : (
-                <div className="p-4 bg-primary-50 border-2 border-primary-200 rounded-lg">
-                  <div className="flex justify-between items-center">
-                    <div>
-                      <p className="font-medium">
-                        {paymentType === 'deposit' ? t('payment.deposit') : t('payment.payInFull')}
-                      </p>
-                      <p className="text-sm text-stone-500">{t('payment.amountToPay')}</p>
-                    </div>
-                    <p className="text-2xl font-bold text-primary-600">
-                      ฿{(paymentType === 'deposit' ? depositAmount : fullAmount).toLocaleString('th-TH')}
-                    </p>
-                  </div>
-                  <button
-                    onClick={() => setIsPaymentConfirmed(false)}
-                    className="mt-3 text-sm text-primary-600 hover:underline"
-                  >
-                    {t('payment.changePaymentType')}
-                  </button>
+            {/* Amount summary */}
+            <div className="p-4 bg-primary-50 border-2 border-primary-200 rounded-lg space-y-2">
+              <div className="flex justify-between items-center">
+                <div>
+                  <p className="font-medium">
+                    {paymentOption === 'deposit50' ? t('payment.deposit') : t('payment.payInFull')}
+                  </p>
+                  <p className="text-sm text-stone-500">{t('payment.amountToPay')}</p>
+                </div>
+                <p className="text-2xl font-bold text-primary-600" data-testid="amount-due-now">
+                  ฿{createdBooking.amount_due_now.toLocaleString('th-TH')}
+                </p>
+              </div>
+              {createdBooking.balance_due_at_checkin > 0 && (
+                <div className="flex justify-between items-center text-sm border-t border-primary-200 pt-2">
+                  <span className="text-stone-600">{t('payment.balanceDueAtCheckin')}</span>
+                  <span className="font-semibold" data-testid="balance-due">
+                    ฿{createdBooking.balance_due_at_checkin.toLocaleString('th-TH')}
+                  </span>
                 </div>
               )}
             </div>
 
-            {isPaymentConfirmed && (
+            {/* Hold expiry countdown */}
+            {holdMsLeft !== null && !holdExpired && slipStatus === 'pending' && (
+              <div className="flex items-center justify-center gap-2 text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg p-3" data-testid="hold-countdown">
+                <FiClock className="w-4 h-4" />
+                <span>{t('payment.holdExpiresIn', { time: formatCountdown(holdMsLeft) })}</span>
+              </div>
+            )}
+
+            {holdExpired ? (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center space-y-4" data-testid="hold-expired">
+                <FiAlertCircle className="w-8 h-8 text-red-500 mx-auto" />
+                <p className="font-medium text-red-800">{t('payment.holdExpired')}</p>
+                <button
+                  onClick={restartBooking}
+                  className="py-2 px-6 bg-primary-600 text-white rounded-md hover:bg-primary-700"
+                >
+                  {t('payment.startOver')}
+                </button>
+              </div>
+            ) : (
               <>
-                {/* Bank Transfer Option */}
-                <div className="pb-6">
-                  <h3 className="font-semibold text-lg mb-4">{t('payment.bankTransfer')}</h3>
-                  <div
-                    className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm space-y-2 cursor-pointer hover:border-primary-300 transition-colors"
-                    onClick={() => {
-                      navigator.clipboard.writeText('0461430473');
-                      toast.success(t('payment.copied'));
-                    }}
-                  >
-                    <div className="flex justify-between items-center">
-                      <span className="text-stone-500">{t('payment.bankName')}</span>
-                      <div className="flex items-center gap-2">
-                        <img src={kbankLogo} alt="KBank" className="h-6" />
-                        <span className="font-medium">กสิกรไทย</span>
-                      </div>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-stone-500">{t('payment.accountName')}</span>
-                      <span className="font-medium">บจก. สายชล เฮอริเทจ</span>
-                    </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-stone-500">{t('payment.accountNumber')}</span>
-                      <span className="font-medium font-mono">046-1-43047-3</span>
-                    </div>
-                    <p className="text-xs text-stone-400 text-center">{t('payment.clickToCopy')}</p>
-                  </div>
-                </div>
-
-                {/* Divider with "หรือ" */}
-                <div className="flex items-center gap-4 py-4">
-                  <div className="flex-1 border-t border-stone-200" />
-                  <span className="text-stone-400 text-sm">{t('payment.or')}</span>
-                  <div className="flex-1 border-t border-stone-200" />
-                </div>
-
-                {/* QR Code Display */}
+                {/* Per-property PromptPay QR */}
                 <div className="border-b pb-6">
                   <h3 className="font-semibold text-lg mb-4">{t('payment.scanQRCode')}</h3>
 
                   <div className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm space-y-4">
-                    {isLoadingQr ? (
+                    {qrDataUrl ? (
+                      <img
+                        src={qrDataUrl}
+                        alt="PromptPay QR Code"
+                        className="w-full max-w-xs mx-auto"
+                        data-testid="promptpay-qr"
+                      />
+                    ) : (
                       <div
                         className="flex items-center justify-center h-48"
                         data-testid="qr-loading"
                       >
                         <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-primary-600" />
                       </div>
-                    ) : (
-                      <img
-                        src={displayedQrUrl}
-                        alt="PromptPay QR Code"
-                        className="w-full"
-                        data-testid="promptpay-qr"
-                        onError={(e) => {
-                          (e.target as HTMLImageElement).src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 192 192"%3E%3Crect fill="%23f3f4f6" width="192" height="192"/%3E%3Ctext x="96" y="96" text-anchor="middle" dy=".3em" fill="%239ca3af" font-size="14"%3EQR Code%3C/text%3E%3C/svg%3E';
-                        }}
-                      />
-                    )}
-
-                    {isQrError && (
-                      <p
-                        className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded p-2 text-center"
-                        data-testid="qr-error"
-                      >
-                        {t('payment.qrFallback')}
-                      </p>
                     )}
 
                     <p className="text-sm text-stone-600 text-center">
                       {t('payment.scanInstructions')}
                     </p>
-
-                    <a
-                      href={displayedQrUrl}
-                      download={promptPayQrSrc ? 'promptpay-qr.svg' : 'promptpay-qr.png'}
-                      className="inline-flex items-center justify-center gap-2 w-full py-2 text-sm text-stone-500 hover:text-primary-600 transition-colors border-t pt-3"
-                    >
-                      <FiDownload className="w-4 h-4" />
-                      {t('payment.downloadQR')}
-                    </a>
+                    <p className="text-xs text-stone-500 text-center">
+                      {t('payment.propertyAccount', { property: t(`property.${availability?.property ?? 'hf'}`) })}
+                    </p>
                   </div>
                 </div>
 
@@ -819,7 +830,6 @@ export default function BookingPage() {
 
                   {slipStatus === 'uploaded' && (
                     <div className="space-y-4">
-                      {/* Show uploaded slip preview */}
                       {slipPreview && (
                         <div className="relative border rounded-lg overflow-hidden">
                           <img
@@ -830,7 +840,6 @@ export default function BookingPage() {
                         </div>
                       )}
 
-                      {/* Status message */}
                       <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 flex items-center">
                         <FiClock className="w-6 h-6 text-yellow-500 mr-3" />
                         <div>
@@ -839,9 +848,8 @@ export default function BookingPage() {
                         </div>
                       </div>
 
-                      {/* Change slip button */}
                       <button
-                        onClick={() => navigate(`/my-bookings?openBooking=${createdBooking.id}&tab=payment`)}
+                        onClick={() => navigate(`/my-bookings?openBooking=${createdBooking.booking_id}&tab=payment`)}
                         className="w-full py-2 text-primary-600 border border-primary-300 rounded-lg hover:bg-primary-50 transition-colors"
                       >
                         {t('payment.changeSlip')}
@@ -867,47 +875,47 @@ export default function BookingPage() {
                     </div>
                   )}
                 </div>
+
+                {/* Action Buttons */}
+                <div className="flex gap-4">
+                  <button
+                    onClick={handleSkipPayment}
+                    className="flex-1 py-3 px-4 border border-stone-300 text-stone-700 rounded-md hover:bg-stone-50"
+                    data-testid="skip-payment"
+                  >
+                    {t('payment.payLater')}
+                  </button>
+
+                  {slipPreview && slipStatus === 'pending' && (
+                    <button
+                      onClick={handleSlipUpload}
+                      disabled={isUploading}
+                      className="flex-1 py-3 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:bg-stone-300 disabled:cursor-not-allowed font-semibold"
+                      data-testid="submit-slip"
+                    >
+                      {isUploading ? (
+                        <span className="flex items-center justify-center">
+                          <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2" />
+                          {t('common.processing')}
+                        </span>
+                      ) : (
+                        t('payment.submitSlip')
+                      )}
+                    </button>
+                  )}
+
+                  {(slipStatus === 'uploaded' || slipStatus === 'verified') && (
+                    <button
+                      onClick={() => navigate('/my-bookings')}
+                      className="flex-1 py-3 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 font-semibold"
+                      data-testid="view-bookings"
+                    >
+                      {t('booking.myBookings')}
+                    </button>
+                  )}
+                </div>
               </>
             )}
-
-            {/* Action Buttons */}
-            <div className="flex gap-4">
-              <button
-                onClick={handleSkipPayment}
-                className="flex-1 py-3 px-4 border border-stone-300 text-stone-700 rounded-md hover:bg-stone-50"
-                data-testid="skip-payment"
-              >
-                {t('payment.payLater')}
-              </button>
-
-              {slipPreview && slipStatus === 'pending' && (
-                <button
-                  onClick={handleSlipUpload}
-                  disabled={isUploading}
-                  className="flex-1 py-3 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:bg-stone-300 disabled:cursor-not-allowed font-semibold"
-                  data-testid="submit-slip"
-                >
-                  {isUploading ? (
-                    <span className="flex items-center justify-center">
-                      <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2" />
-                      {t('common.processing')}
-                    </span>
-                  ) : (
-                    t('payment.submitSlip')
-                  )}
-                </button>
-              )}
-
-              {(slipStatus === 'uploaded' || slipStatus === 'verified') && (
-                <button
-                  onClick={() => navigate('/my-bookings')}
-                  className="flex-1 py-3 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 font-semibold"
-                  data-testid="view-bookings"
-                >
-                  {t('booking.myBookings')}
-                </button>
-              )}
-            </div>
           </div>
         </div>
       )}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useAuthStore } from '../store/authStore';
-import { FiUser, FiAward, FiUsers, FiGift, FiMail, FiCalendar } from 'react-icons/fi';
+import { FiUser, FiAward, FiUsers, FiGift, FiMail, FiCalendar, FiCreditCard } from 'react-icons/fi';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
@@ -135,6 +135,31 @@ export default function DashboardPage() {
               {t('dashboard.myServices')}
             </h2>
             <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {/* Member Card (QR for the front desk) */}
+              <Link
+                to="/member-card"
+                data-testid="nav-member-card"
+                className="bg-white overflow-hidden shadow rounded-lg hover:shadow-lg transition-shadow"
+              >
+                <div className="p-5">
+                  <div className="flex items-center">
+                    <div className="flex-shrink-0">
+                      <FiCreditCard className="h-6 w-6 text-primary-600" />
+                    </div>
+                    <div className="ml-5 w-0 flex-1">
+                      <dl>
+                        <dt className="text-lg font-semibold text-stone-900 truncate">
+                          {t('memberCard.title')}
+                        </dt>
+                        <dd className="mt-1 text-sm font-medium text-stone-500">
+                          {t('memberCard.dashboardDescription')}
+                        </dd>
+                      </dl>
+                    </div>
+                  </div>
+                </div>
+              </Link>
+
               {/* Profile & Loyalty Card */}
               <Link
                 to="/profile"

--- a/frontend/src/pages/MemberCardPage.tsx
+++ b/frontend/src/pages/MemberCardPage.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import QRCode from 'qrcode';
+import MainLayout from '../components/layout/MainLayout';
+import { useAuthStore } from '../store/authStore';
+import { userService } from '../services/userService';
+import { loyaltyService } from '../services/loyaltyService';
+import { getUserDisplayName } from '../utils/userHelpers';
+import { logger } from '../utils/logger';
+
+/**
+ * The member card: a QR code of the membership ID plus the readable ID and
+ * tier. Front-desk staff scan this at check-in to link the membership to
+ * the guest profile in the PMS — after that, stays accrue automatically.
+ */
+export default function MemberCardPage() {
+  const { t } = useTranslation();
+  const user = useAuthStore((state) => state.user);
+
+  const { data: profile } = useQuery({
+    queryKey: ['user', 'profile'],
+    queryFn: () => userService.getProfile(),
+    enabled: !user?.membershipId,
+  });
+
+  const { data: loyaltyStatus } = useQuery({
+    queryKey: ['loyalty', 'status'],
+    queryFn: () => loyaltyService.getUserLoyaltyStatus(),
+  });
+
+  const membershipId = user?.membershipId ?? profile?.membershipId ?? null;
+
+  const [qrDataUrl, setQrDataUrl] = useState<string>('');
+  const [qrFailed, setQrFailed] = useState(false);
+
+  useEffect(() => {
+    if (!membershipId) {
+      return;
+    }
+    let cancelled = false;
+    QRCode.toDataURL(membershipId, {
+      width: 288,
+      margin: 2,
+      errorCorrectionLevel: 'M',
+    })
+      .then((url) => {
+        if (!cancelled) {
+          setQrDataUrl(url);
+          setQrFailed(false);
+        }
+      })
+      .catch((error: unknown) => {
+        logger.error(
+          'Failed to generate member QR:',
+          error instanceof Error ? error.message : String(error),
+        );
+        if (!cancelled) {
+          setQrFailed(true);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [membershipId]);
+
+  return (
+    <MainLayout title={t('memberCard.title')}>
+      <div className="max-w-md mx-auto">
+        <div className="bg-white rounded-lg shadow overflow-hidden">
+          {/* Tier band */}
+          <div
+            className="px-6 py-4"
+            style={{ backgroundColor: loyaltyStatus?.tier_color ?? '#7f1d1d' }}
+          >
+            <p className="text-white text-sm opacity-90">{getUserDisplayName(user)}</p>
+            <p className="text-white text-lg font-bold" data-testid="member-card-tier">
+              {loyaltyStatus?.tier_name ?? ''}
+            </p>
+          </div>
+
+          <div className="p-6 text-center">
+            {membershipId ? (
+              <>
+                <div className="bg-white p-4 rounded-lg shadow-inner border-2 border-stone-200 inline-block mb-4">
+                  {qrDataUrl ? (
+                    <img
+                      src={qrDataUrl}
+                      alt={t('memberCard.qrAlt')}
+                      className="w-64 h-64 object-contain"
+                      data-testid="member-qr"
+                    />
+                  ) : (
+                    <div className="w-64 h-64 flex items-center justify-center text-sm text-stone-500">
+                      {qrFailed ? t('memberCard.qrError') : t('memberCard.generating')}
+                    </div>
+                  )}
+                </div>
+
+                <div className="text-sm text-stone-600 mb-1 font-medium">
+                  {t('memberCard.membershipId')}
+                </div>
+                <div
+                  className="text-lg font-mono bg-stone-100 px-4 py-2 rounded-lg border inline-block"
+                  data-testid="member-id"
+                >
+                  {membershipId}
+                </div>
+              </>
+            ) : (
+              <p className="text-stone-600 py-12" data-testid="member-id-missing">
+                {t('memberCard.noMembershipId')}
+              </p>
+            )}
+
+            <p className="text-sm text-stone-500 mt-6">{t('memberCard.showAtDesk')}</p>
+          </div>
+        </div>
+      </div>
+    </MainLayout>
+  );
+}

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -1,0 +1,60 @@
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import LanguageSwitcher from '../components/LanguageSwitcher';
+
+/**
+ * PDPA privacy notice. Publicly reachable (no auth) — linked from the
+ * footer and the OA rich menus. Documents the friendship-as-opt-in
+ * position: membership operates as contract; the LINE OA friendship is the
+ * messaging opt-in and blocking the OA is the opt-out.
+ */
+export default function PrivacyPage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <header className="bg-white shadow">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center py-6">
+          <h1 className="text-2xl font-bold text-stone-900">{t('privacy.title')}</h1>
+          <LanguageSwitcher />
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto py-8 px-4 sm:px-6 lg:px-8 space-y-6">
+        <section className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-lg font-semibold text-stone-900 mb-2">
+            {t('privacy.whatWeStoreTitle')}
+          </h2>
+          <p className="text-stone-700">{t('privacy.whatWeStoreBody')}</p>
+        </section>
+
+        <section className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-lg font-semibold text-stone-900 mb-2">
+            {t('privacy.whyTitle')}
+          </h2>
+          <p className="text-stone-700">{t('privacy.whyBody')}</p>
+        </section>
+
+        <section className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-lg font-semibold text-stone-900 mb-2">
+            {t('privacy.messagesTitle')}
+          </h2>
+          <p className="text-stone-700">{t('privacy.messagesBody')}</p>
+        </section>
+
+        <section className="bg-white rounded-lg shadow p-6">
+          <h2 className="text-lg font-semibold text-stone-900 mb-2">
+            {t('privacy.contactTitle')}
+          </h2>
+          <p className="text-stone-700">{t('privacy.contactBody')}</p>
+        </section>
+
+        <div className="text-center">
+          <Link to="/" className="text-primary-600 hover:underline">
+            {t('privacy.backToApp')}
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/pages/__tests__/BookingPage.test.tsx
+++ b/frontend/src/pages/__tests__/BookingPage.test.tsx
@@ -4,20 +4,16 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 /**
- * BookingPage tests
+ * BookingPage tests — channel booking flow (ADR-0003).
  *
- * These tests focus on the Step 4 (Payment) flow that was wired in
- * `feat/promptpay-slip-flow`:
- *   1. PromptPay QR is fetched dynamically once the user confirms a payment
- *      type (deposit vs. full).
- *   2. Slip upload calls `bookingService.uploadSlip` followed by
- *      `bookingService.addSlip`.
- *   3. Failure paths surface a toast and mark the slip status as failed.
- *
- * To keep the suite focused (and fast), we render BookingPage with
- * in-memory state advanced past steps 1–3 by driving the existing UI
- * controls; the room-availability and booking creation services are mocked
- * out to avoid touching the network.
+ * The page is a booking channel into the PMS:
+ *   1. Availability is fetched per property from the channel endpoint.
+ *   2. Confirming creates the booking with guest details + payment option
+ *      (50% deposit or full) in one call, per the locked contract in
+ *      docs/launch-plan.md.
+ *   3. The per-property PromptPay QR is rendered from the
+ *      `promptpay_qr_payload` in the response (no hardcoded account).
+ *   4. Slip upload calls `bookingService.uploadSlip` then `addSlip`.
  */
 
 function createTestQueryClient() {
@@ -38,24 +34,29 @@ function wrapper({ children }: { children: React.ReactNode }) {
 // Service mocks
 // ============================================================================
 
-const mockCheckAvailability = vi.fn();
-const mockCreateBooking = vi.fn();
+const mockGetAvailability = vi.fn();
+const mockCreateChannelBooking = vi.fn();
 const mockUploadSlip = vi.fn();
 const mockAddSlip = vi.fn();
-const mockGetPromptPayQr = vi.fn();
+const mockQrToDataURL = vi.fn();
+
+vi.mock('../../services/channelBookingService', () => ({
+  channelBookingService: {
+    getAvailability: (...args: unknown[]) => mockGetAvailability(...args),
+    createBooking: (...args: unknown[]) => mockCreateChannelBooking(...args),
+  },
+}));
 
 vi.mock('../../services/bookingService', () => ({
   bookingService: {
-    checkAvailability: (...args: unknown[]) => mockCheckAvailability(...args),
-    createBooking: (...args: unknown[]) => mockCreateBooking(...args),
     uploadSlip: (...args: unknown[]) => mockUploadSlip(...args),
     addSlip: (...args: unknown[]) => mockAddSlip(...args),
   },
 }));
 
-vi.mock('../../services/paymentService', () => ({
-  paymentService: {
-    getPromptPayQr: (...args: unknown[]) => mockGetPromptPayQr(...args),
+vi.mock('qrcode', () => ({
+  default: {
+    toDataURL: (...args: unknown[]) => mockQrToDataURL(...args),
   },
 }));
 
@@ -71,8 +72,6 @@ vi.mock('react-hot-toast', () => ({
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string, opts?: Record<string, unknown>) => {
-      // Return the key (or a key:count stub) so the tests assert on
-      // structural elements / test-ids rather than translated strings.
       if (opts && typeof opts === 'object' && 'count' in opts) {
         return `${key}:${opts.count as number}`;
       }
@@ -85,6 +84,18 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
 }));
 
+vi.mock('../../store/authStore', () => ({
+  useAuthStore: (selector: (state: unknown) => unknown) =>
+    selector({
+      user: {
+        id: 'user-1',
+        firstName: 'Test',
+        lastName: 'Guest',
+        phone: '0812345678',
+      },
+    }),
+}));
+
 vi.mock('../../components/layout/MainLayout', () => ({
   default: ({ children, title }: { children: React.ReactNode; title: string }) => (
     <div>
@@ -94,10 +105,6 @@ vi.mock('../../components/layout/MainLayout', () => ({
   ),
 }));
 
-// Stub the asset imports so vite/vitest doesn't choke in jsdom.
-vi.mock('../../assets/company-promptpay-qr.png', () => ({ default: 'company-qr.png' }));
-vi.mock('../../assets/kbank-logo.png', () => ({ default: 'kbank-logo.png' }));
-
 // Import the component AFTER all mocks are registered.
 import BookingPage from '../BookingPage';
 
@@ -106,45 +113,56 @@ import BookingPage from '../BookingPage';
 // ============================================================================
 
 const SAMPLE_ROOM_TYPE = {
-  id: 'room-type-1',
+  room_type_id: 'room-type-1',
   name: 'Deluxe Room',
   description: 'A nice room',
-  pricePerNight: 1000,
-  maxGuests: 2,
-  bedType: 'king',
-  amenities: ['wifi'],
-  images: [],
-  availableRooms: 5,
+  photo_url: null,
+  nightly_price: 1000,
+  available_count: 5,
+};
+
+const SAMPLE_AVAILABILITY = {
+  property: 'hf',
+  check_in: '2030-01-01',
+  check_out: '2030-01-03',
+  room_types: [SAMPLE_ROOM_TYPE],
+};
+
+const SAMPLE_BOOKING = {
+  booking_id: 'booking-123',
+  pms_booking_id: 'PMS-9',
+  total_amount: 2000,
+  amount_due_now: 1000,
+  balance_due_at_checkin: 1000,
+  promptpay_qr_payload: '00020101021129370016A000000677010111PAYLOAD',
+  // Far-future hold so the countdown never hits zero mid-test.
+  hold_expires_at: '2099-01-01T00:00:00Z',
 };
 
 /**
- * Drive the BookingPage UI from step 1 through to the payment screen so
- * each test starts from a known good state with a created booking.
+ * Drive the UI from step 1 (property + dates) to the payment screen.
  */
 async function advanceToPaymentStep(user: ReturnType<typeof userEvent.setup>) {
-  // Step 1: pick dates two nights apart. `userEvent.type` is unreliable on
+  // Step 1: property + two-night dates. `userEvent.type` is unreliable on
   // <input type="date"> in jsdom, so drive the value with fireEvent.change.
-  const checkIn = '2030-01-01';
-  const checkOut = '2030-01-03';
-  fireEvent.change(screen.getByTestId('check-in-date'), { target: { value: checkIn } });
-  fireEvent.change(screen.getByTestId('check-out-date'), { target: { value: checkOut } });
+  await user.click(screen.getByTestId('property-hf'));
+  fireEvent.change(screen.getByTestId('check-in-date'), { target: { value: '2030-01-01' } });
+  fireEvent.change(screen.getByTestId('check-out-date'), { target: { value: '2030-01-03' } });
   await user.click(screen.getByTestId('continue-to-rooms'));
 
   // Step 2: pick the only available room type.
   await waitFor(() => {
-    expect(screen.getByTestId(`room-type-${SAMPLE_ROOM_TYPE.id}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`room-type-${SAMPLE_ROOM_TYPE.room_type_id}`)).toBeInTheDocument();
   });
-  await user.click(screen.getByTestId(`room-type-${SAMPLE_ROOM_TYPE.id}`));
+  await user.click(screen.getByTestId(`room-type-${SAMPLE_ROOM_TYPE.room_type_id}`));
 
-  // Step 3: confirm the booking.
+  // Step 3: guest details are prefilled from the auth store; confirm.
   await waitFor(() => {
     expect(screen.getByTestId('confirm-booking')).toBeInTheDocument();
   });
   await user.click(screen.getByTestId('confirm-booking'));
 
-  // Step 4 should now be visible (payment).
-  // 'payment.title' appears in both the stepper and the section heading;
-  // assert ANY occurrence is rendered rather than requiring a unique match.
+  // Step 4 (payment) should now be visible.
   await waitFor(() => {
     expect(screen.getAllByText('payment.title').length).toBeGreaterThan(0);
   });
@@ -154,106 +172,119 @@ async function advanceToPaymentStep(user: ReturnType<typeof userEvent.setup>) {
 // Tests
 // ============================================================================
 
-describe('BookingPage — payment step (PromptPay QR + slip upload)', () => {
+describe('BookingPage — channel flow (property → rooms → confirm → payment)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockCheckAvailability.mockResolvedValue([SAMPLE_ROOM_TYPE]);
-    mockCreateBooking.mockResolvedValue({
-      id: 'booking-123',
-      totalPrice: 2000,
-    });
+    mockGetAvailability.mockResolvedValue(SAMPLE_AVAILABILITY);
+    mockCreateChannelBooking.mockResolvedValue(SAMPLE_BOOKING);
     mockUploadSlip.mockResolvedValue({ url: '/storage/slips/abc.png' });
     mockAddSlip.mockResolvedValue(undefined);
-    mockGetPromptPayQr.mockResolvedValue({
-      svg: '<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>',
-      amount: 1000,
-      currency: 'THB',
+    mockQrToDataURL.mockResolvedValue('data:image/png;base64,MOCKQR');
+  });
+
+  it('fetches availability with the locked contract params', async () => {
+    const user = userEvent.setup();
+    render(<BookingPage />, { wrapper });
+
+    await user.click(screen.getByTestId('property-hf'));
+    fireEvent.change(screen.getByTestId('check-in-date'), { target: { value: '2030-01-01' } });
+    fireEvent.change(screen.getByTestId('check-out-date'), { target: { value: '2030-01-03' } });
+    await user.click(screen.getByTestId('continue-to-rooms'));
+
+    await waitFor(() => {
+      expect(mockGetAvailability).toHaveBeenCalledWith('hf', '2030-01-01', '2030-01-03', 1);
     });
   });
 
-  it('should fetch the PromptPay QR for the deposit amount once payment type is confirmed', async () => {
+  it('creates the booking with property, guest details, and default deposit50', async () => {
     const user = userEvent.setup();
     render(<BookingPage />, { wrapper });
 
     await advanceToPaymentStep(user);
 
-    // QR should NOT be requested before the user confirms payment type.
-    expect(mockGetPromptPayQr).not.toHaveBeenCalled();
-
-    // Confirm the (default-selected) deposit payment type.
-    await user.click(screen.getByText('payment.confirmPaymentType'));
-
-    // Total price is 2000, deposit is 50% = 1000.
-    await waitFor(() => {
-      expect(mockGetPromptPayQr).toHaveBeenCalledWith(1000, 'booking-123');
-    });
-
-    // The dynamically-generated SVG should be rendered as a data URL <img>.
-    await waitFor(() => {
-      const qr = screen.getByTestId('promptpay-qr') as HTMLImageElement;
-      expect(qr.src).toContain('data:image/svg+xml');
+    expect(mockCreateChannelBooking).toHaveBeenCalledWith({
+      property: 'hf',
+      room_type_id: 'room-type-1',
+      check_in: '2030-01-01',
+      check_out: '2030-01-03',
+      guests: 1,
+      guest_name: 'Test Guest',
+      guest_phone: '0812345678',
+      payment_option: 'deposit50',
     });
   });
 
-  it('should re-fetch the QR when the user switches from deposit to pay-in-full', async () => {
+  it('sends payment_option "full" when the guest chooses to pay in full', async () => {
     const user = userEvent.setup();
     render(<BookingPage />, { wrapper });
 
-    await advanceToPaymentStep(user);
+    await user.click(screen.getByTestId('property-hf'));
+    fireEvent.change(screen.getByTestId('check-in-date'), { target: { value: '2030-01-01' } });
+    fireEvent.change(screen.getByTestId('check-out-date'), { target: { value: '2030-01-03' } });
+    await user.click(screen.getByTestId('continue-to-rooms'));
 
-    // Switch to "Pay in Full" (the radio whose value attribute is "full"),
-    // then confirm.
+    await waitFor(() => {
+      expect(screen.getByTestId(`room-type-${SAMPLE_ROOM_TYPE.room_type_id}`)).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId(`room-type-${SAMPLE_ROOM_TYPE.room_type_id}`));
+
+    // Switch the payment option radio to "full" before confirming.
+    await waitFor(() => {
+      expect(screen.getByTestId('confirm-booking')).toBeInTheDocument();
+    });
     const radios = screen.getAllByRole('radio');
     const fullRadio = radios.find((r) => r.getAttribute('value') === 'full');
     expect(fullRadio).toBeDefined();
     await user.click(fullRadio!);
-    await user.click(screen.getByText('payment.confirmPaymentType'));
+    await user.click(screen.getByTestId('confirm-booking'));
 
-    // Pay-in-full of total 2000 should request 2000 (not 1000).
     await waitFor(() => {
-      expect(mockGetPromptPayQr).toHaveBeenCalledWith(2000, 'booking-123');
+      expect(mockCreateChannelBooking).toHaveBeenCalled();
+    });
+    expect(mockCreateChannelBooking.mock.calls[0]?.[0]).toMatchObject({
+      payment_option: 'full',
     });
   });
 
-  it('should fall back to the bundled QR image when the dynamic generator fails', async () => {
+  it('renders the PromptPay QR from the response payload and shows amounts + hold countdown', async () => {
     const user = userEvent.setup();
-    mockGetPromptPayQr.mockRejectedValue(new Error('Tax ID not configured'));
     render(<BookingPage />, { wrapper });
 
     await advanceToPaymentStep(user);
-    await user.click(screen.getByText('payment.confirmPaymentType'));
 
-    // useQuery has retry: 1, so the error state lands after the second
-    // failed fetch. Bump timeout from 1s default to 4s to cover that.
-    await waitFor(
-      () => {
-        expect(screen.getByTestId('qr-error')).toBeInTheDocument();
-      },
-      { timeout: 4000 },
-    );
+    // QR is generated from the per-property payload — never a bundled image.
+    await waitFor(() => {
+      expect(mockQrToDataURL).toHaveBeenCalledWith(
+        SAMPLE_BOOKING.promptpay_qr_payload,
+        expect.any(Object),
+      );
+    });
+    await waitFor(() => {
+      const qr = screen.getByTestId('promptpay-qr') as HTMLImageElement;
+      expect(qr.src).toContain('data:image/png');
+    });
 
-    const qr = screen.getByTestId('promptpay-qr') as HTMLImageElement;
-    expect(qr.src).toContain('company-qr.png');
+    // Deposit summary: amount due now + balance due at check-in.
+    expect(screen.getByTestId('amount-due-now')).toHaveTextContent('1,000');
+    expect(screen.getByTestId('balance-due')).toHaveTextContent('1,000');
+
+    // Hold countdown is visible while payment is pending.
+    expect(screen.getByTestId('hold-countdown')).toBeInTheDocument();
   });
 
-  it('should call uploadSlip then addSlip when the user submits a payment slip', async () => {
+  it('calls uploadSlip then addSlip with the channel booking id', async () => {
     const user = userEvent.setup();
     render(<BookingPage />, { wrapper });
 
     await advanceToPaymentStep(user);
-    await user.click(screen.getByText('payment.confirmPaymentType'));
 
-    // Wait for the slip dropzone (only visible after payment type confirmed).
     await waitFor(() => {
       expect(screen.getByTestId('slip-input')).toBeInTheDocument();
     });
 
-    // Upload a tiny PNG file.
     const slipFile = new File(['fake-png-bytes'], 'slip.png', { type: 'image/png' });
-    const input = screen.getByTestId('slip-input') as HTMLInputElement;
-    await user.upload(input, slipFile);
+    await user.upload(screen.getByTestId('slip-input') as HTMLInputElement, slipFile);
 
-    // Submit the slip.
     await waitFor(() => {
       expect(screen.getByTestId('submit-slip')).toBeInTheDocument();
     });
@@ -267,13 +298,12 @@ describe('BookingPage — payment step (PromptPay QR + slip upload)', () => {
     expect(mockToastSuccess).toHaveBeenCalledWith('payment.slipUploaded');
   });
 
-  it('should surface an error toast when the slip upload fails', async () => {
+  it('surfaces an error toast when the slip upload fails', async () => {
     const user = userEvent.setup();
     mockUploadSlip.mockRejectedValue(new Error('network'));
     render(<BookingPage />, { wrapper });
 
     await advanceToPaymentStep(user);
-    await user.click(screen.getByText('payment.confirmPaymentType'));
 
     await waitFor(() => {
       expect(screen.getByTestId('slip-input')).toBeInTheDocument();

--- a/frontend/src/pages/__tests__/MemberCardPage.test.tsx
+++ b/frontend/src/pages/__tests__/MemberCardPage.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+/**
+ * MemberCardPage tests — the desk-scannable member QR (the physical
+ * handshake that creates the member ↔ PMS guest-profile Link).
+ */
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const mockQrToDataURL = vi.fn();
+vi.mock('qrcode', () => ({
+  default: {
+    toDataURL: (...args: unknown[]) => mockQrToDataURL(...args),
+  },
+}));
+
+const mockGetLoyaltyStatus = vi.fn();
+vi.mock('../../services/loyaltyService', () => ({
+  loyaltyService: {
+    getUserLoyaltyStatus: (...args: unknown[]) => mockGetLoyaltyStatus(...args),
+  },
+}));
+
+const mockGetProfile = vi.fn();
+vi.mock('../../services/userService', () => ({
+  userService: {
+    getProfile: (...args: unknown[]) => mockGetProfile(...args),
+  },
+}));
+
+let mockUser: Record<string, unknown> | null = null;
+vi.mock('../../store/authStore', () => ({
+  useAuthStore: (selector: (state: unknown) => unknown) => selector({ user: mockUser }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock('../../components/layout/MainLayout', () => ({
+  default: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ),
+}));
+
+import MemberCardPage from '../MemberCardPage';
+
+describe('MemberCardPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUser = {
+      id: 'user-1',
+      firstName: 'Test',
+      lastName: 'Guest',
+      membershipId: 'HF-000123',
+    };
+    mockGetLoyaltyStatus.mockResolvedValue({
+      tier_name: 'Gold',
+      tier_color: '#b45309',
+    });
+    mockQrToDataURL.mockResolvedValue('data:image/png;base64,MOCKQR');
+  });
+
+  it('renders the membership ID as a QR code plus readable ID and tier', async () => {
+    render(<MemberCardPage />, { wrapper });
+
+    // QR generated from the raw membership ID (what the desk scans).
+    await waitFor(() => {
+      expect(mockQrToDataURL).toHaveBeenCalledWith('HF-000123', expect.any(Object));
+    });
+
+    await waitFor(() => {
+      const qr = screen.getByTestId('member-qr') as HTMLImageElement;
+      expect(qr.src).toContain('data:image/png');
+    });
+
+    expect(screen.getByTestId('member-id')).toHaveTextContent('HF-000123');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('member-card-tier')).toHaveTextContent('Gold');
+    });
+
+    // membershipId came from the auth store — no profile fetch needed.
+    expect(mockGetProfile).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the profile when the auth store has no membershipId', async () => {
+    mockUser = { id: 'user-1', firstName: 'Test' };
+    mockGetProfile.mockResolvedValue({ membershipId: 'HF-000999' });
+
+    render(<MemberCardPage />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('member-id')).toHaveTextContent('HF-000999');
+    });
+  });
+
+  it('shows a hint instead of a broken QR when no membership ID exists anywhere', async () => {
+    mockUser = { id: 'user-1', firstName: 'Test' };
+    mockGetProfile.mockResolvedValue({});
+
+    render(<MemberCardPage />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('member-id-missing')).toBeInTheDocument();
+    });
+    expect(mockQrToDataURL).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -68,6 +68,18 @@ export const authService = {
     return response.data;
   },
 
+  /**
+   * Exchange a LINE LIFF ID token for a normal session. Only called from
+   * the LIFF bootstrap (`utils/liffAuth.ts`) when the app runs inside the
+   * LINE in-app browser — never on the web login page. The backend
+   * verifies the ID token with LINE, silently enrolls first-time LINE
+   * users, and returns the same body/cookie contract as `login`.
+   */
+  async liffLogin(idToken: string): Promise<LoginResponse> {
+    const response = await api.post<LoginResponse>('/auth/liff', { idToken });
+    return response.data;
+  },
+
   async register(data: RegisterData): Promise<RegisterResponse> {
     const response = await api.post<RegisterResponse>('/auth/register', data);
     return response.data;

--- a/frontend/src/services/channelBookingService.ts
+++ b/frontend/src/services/channelBookingService.ts
@@ -1,0 +1,71 @@
+import api from './authService';
+
+// Booking-channel contract (docs/launch-plan.md — "Locked interface
+// contracts"). The backend proxies availability from the PMS and creates
+// confirmed bookings in it; these shapes are hand-written on purpose — do
+// NOT regenerate them from the OpenAPI spec until the contract stabilises.
+
+export type Property = 'hf' | 'hfville';
+
+export interface ChannelRoomType {
+  room_type_id: string;
+  name: string;
+  description: string | null;
+  photo_url: string | null;
+  nightly_price: number;
+  available_count: number;
+}
+
+export interface ChannelAvailabilityResponse {
+  property: Property;
+  check_in: string;
+  check_out: string;
+  room_types: ChannelRoomType[];
+}
+
+export type PaymentOption = 'deposit50' | 'full';
+
+export interface CreateChannelBookingRequest {
+  property: Property;
+  room_type_id: string;
+  check_in: string;
+  check_out: string;
+  guests: number;
+  guest_name: string;
+  guest_phone: string;
+  payment_option: PaymentOption;
+}
+
+export interface ChannelBookingResponse {
+  booking_id: string;
+  pms_booking_id: string;
+  total_amount: number;
+  amount_due_now: number;
+  balance_due_at_checkin: number;
+  promptpay_qr_payload: string;
+  hold_expires_at: string;
+}
+
+export const channelBookingService = {
+  async getAvailability(
+    property: Property,
+    checkIn: string,
+    checkOut: string,
+    guests: number,
+  ): Promise<ChannelAvailabilityResponse> {
+    const response = await api.get<ChannelAvailabilityResponse>('/bookings/availability', {
+      params: {
+        property,
+        check_in: checkIn,
+        check_out: checkOut,
+        guests,
+      },
+    });
+    return response.data;
+  },
+
+  async createBooking(data: CreateChannelBookingRequest): Promise<ChannelBookingResponse> {
+    const response = await api.post<ChannelBookingResponse>('/bookings/channel', data);
+    return response.data;
+  },
+};

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -48,6 +48,12 @@ interface AuthState {
   // surface to the user. Never touches the email+password `login` or
   // Google/LINE OAuth paths above/below.
   cfExchangeLogin: () => Promise<boolean>;
+  // Silent LIFF auto-login. Only called by the LIFF bootstrap
+  // (`utils/liffAuth.ts`) when the app runs inside the LINE in-app
+  // browser. Returns whether the exchange succeeded instead of throwing —
+  // a failure just means the guest keeps browsing unauthenticated and the
+  // normal login page takes over, exactly as on the web.
+  liffLogin: (idToken: string) => Promise<boolean>;
   register: (data: {
     email: string;
     password: string;
@@ -115,6 +121,27 @@ export const useAuthStore = create<AuthState>()(
           // rethrow. The caller (ProtectedRoute) falls back to the normal
           // login form exactly as if this method didn't exist.
           logger.warn('Cloudflare Access exchange did not succeed:', error instanceof Error ? error.message : String(error));
+          return false;
+        }
+      },
+
+      liffLogin: async (idToken: string) => {
+        try {
+          const response = await authService.liffLogin(idToken);
+          // Same state shape as login() — a member who arrived through the
+          // LINE rich menu is indistinguishable from one who typed a
+          // password.
+          set({
+            user: response.user,
+            accessToken: response.tokens.accessToken,
+            isAuthenticated: true,
+          });
+          return true;
+        } catch (error: unknown) {
+          // No toast, no rethrow — silent enrollment must never greet a
+          // first-time guest with an error banner. The caller falls back
+          // to the normal unauthenticated flow.
+          logger.warn('LIFF login did not succeed:', error instanceof Error ? error.message : String(error));
           return false;
         }
       },

--- a/frontend/src/utils/__tests__/liffAuth.test.ts
+++ b/frontend/src/utils/__tests__/liffAuth.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * liffAuth tests — the silent LIFF auto-login bootstrap.
+ *
+ * The invariant under test: outside the LINE in-app browser (or without a
+ * configured VITE_LIFF_ID) the helper is a strict no-op — the SDK is never
+ * loaded and no store method is called — so web behaviour is unchanged.
+ */
+
+const mockLiff = {
+  init: vi.fn(),
+  isInClient: vi.fn(),
+  getIDToken: vi.fn(),
+  login: vi.fn(),
+};
+
+vi.mock('@line/liff', () => ({
+  default: mockLiff,
+}));
+
+const mockLiffLogin = vi.fn();
+let mockState: Record<string, unknown>;
+
+vi.mock('../../store/authStore', () => ({
+  useAuthStore: {
+    getState: () => mockState,
+  },
+}));
+
+import { initLiffAutoLogin, isLikelyLineInAppBrowser } from '../liffAuth';
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(window.navigator, 'userAgent', {
+    value: ua,
+    configurable: true,
+  });
+}
+
+const LINE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Line/14.0.0 LIFF';
+const WEB_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/126.0 Safari/537.36';
+
+describe('liffAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('VITE_LIFF_ID', 'liff-test-id');
+    mockState = {
+      isAuthenticated: false,
+      accessToken: null,
+      liffLogin: mockLiffLogin,
+    };
+    mockLiff.init.mockResolvedValue(undefined);
+    mockLiff.isInClient.mockReturnValue(true);
+    mockLiff.getIDToken.mockReturnValue('id-token-1');
+    mockLiffLogin.mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('detects the LINE in-app browser by user agent', () => {
+    setUserAgent(LINE_UA);
+    expect(isLikelyLineInAppBrowser()).toBe(true);
+    setUserAgent(WEB_UA);
+    expect(isLikelyLineInAppBrowser()).toBe(false);
+  });
+
+  it('is a no-op outside the LINE browser — SDK never initialised', async () => {
+    setUserAgent(WEB_UA);
+    const result = await initLiffAutoLogin();
+    expect(result).toBe(false);
+    expect(mockLiff.init).not.toHaveBeenCalled();
+    expect(mockLiffLogin).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op without VITE_LIFF_ID even inside LINE', async () => {
+    vi.stubEnv('VITE_LIFF_ID', '');
+    setUserAgent(LINE_UA);
+    const result = await initLiffAutoLogin();
+    expect(result).toBe(false);
+    expect(mockLiff.init).not.toHaveBeenCalled();
+  });
+
+  it('exchanges the ID token for a session inside LINE', async () => {
+    setUserAgent(LINE_UA);
+    const result = await initLiffAutoLogin();
+    expect(result).toBe(true);
+    expect(mockLiff.init).toHaveBeenCalledWith({ liffId: 'liff-test-id' });
+    expect(mockLiffLogin).toHaveBeenCalledWith('id-token-1');
+  });
+
+  it('skips the exchange when a session already exists', async () => {
+    setUserAgent(LINE_UA);
+    mockState = {
+      isAuthenticated: true,
+      accessToken: 'existing',
+      liffLogin: mockLiffLogin,
+    };
+    const result = await initLiffAutoLogin();
+    expect(result).toBe(true);
+    expect(mockLiffLogin).not.toHaveBeenCalled();
+  });
+
+  it('re-runs liff.login when the ID token is absent', async () => {
+    setUserAgent(LINE_UA);
+    mockLiff.getIDToken.mockReturnValue(null);
+    const result = await initLiffAutoLogin();
+    expect(result).toBe(false);
+    expect(mockLiff.login).toHaveBeenCalled();
+    expect(mockLiffLogin).not.toHaveBeenCalled();
+  });
+
+  it('never throws when liff.init fails', async () => {
+    setUserAgent(LINE_UA);
+    mockLiff.init.mockRejectedValue(new Error('LIFF init failed'));
+    const result = await initLiffAutoLogin();
+    expect(result).toBe(false);
+    expect(mockLiffLogin).not.toHaveBeenCalled();
+  });
+
+  it('returns false when opened in an external browser (not in client)', async () => {
+    setUserAgent(LINE_UA);
+    mockLiff.isInClient.mockReturnValue(false);
+    const result = await initLiffAutoLogin();
+    expect(result).toBe(false);
+    expect(mockLiffLogin).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/liffAuth.ts
+++ b/frontend/src/utils/liffAuth.ts
@@ -1,0 +1,63 @@
+import { useAuthStore } from '../store/authStore';
+import { logger } from './logger';
+
+// The LINE in-app browser always carries "Line/" in its user agent. We use
+// this as a cheap pre-check so the LIFF SDK is never even downloaded for
+// normal web visitors — the web code path must stay byte-for-byte
+// unchanged.
+const LINE_UA_PATTERN = /Line\//i;
+
+export function isLikelyLineInAppBrowser(): boolean {
+  return LINE_UA_PATTERN.test(navigator.userAgent);
+}
+
+/**
+ * Silent LIFF auto-login, called once from App bootstrap.
+ *
+ * Inside the LINE in-app browser (opened from an OA rich menu) this
+ * initialises the LIFF SDK, obtains the LINE ID token, and exchanges it at
+ * `POST /api/auth/liff` for a normal session — silently enrolling
+ * first-time guests. Outside LINE, or without a configured `VITE_LIFF_ID`,
+ * it is a no-op and the SDK is never loaded.
+ *
+ * Returns whether the user ended up authenticated. Never throws.
+ */
+export async function initLiffAutoLogin(): Promise<boolean> {
+  const liffId = import.meta.env.VITE_LIFF_ID;
+  if (!liffId || !isLikelyLineInAppBrowser()) {
+    return false;
+  }
+
+  try {
+    // Dynamic import keeps @line/liff out of the main bundle for the web.
+    const { default: liff } = await import('@line/liff');
+    await liff.init({ liffId });
+
+    if (!liff.isInClient()) {
+      // Opened in an external browser (e.g. a shared LIFF URL) — let the
+      // normal web login flow handle it.
+      return false;
+    }
+
+    const store = useAuthStore.getState();
+    if (store.isAuthenticated && store.accessToken) {
+      return true;
+    }
+
+    const idToken = liff.getIDToken();
+    if (!idToken) {
+      // Absent or consumed ID token — re-run LINE login inside the client
+      // to mint a fresh one. This redirects and re-enters the app.
+      liff.login({ redirectUri: window.location.href });
+      return false;
+    }
+
+    return await store.liffLogin(idToken);
+  } catch (error: unknown) {
+    logger.warn(
+      'LIFF auto-login skipped:',
+      error instanceof Error ? error.message : String(error),
+    );
+    return false;
+  }
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_URL: string
   readonly VITE_TRANSLATION_ENABLED?: string
+  readonly VITE_LIFF_ID?: string
   readonly DEV: boolean
   readonly PROD: boolean
   readonly MODE: string


### PR DESCRIPTION
Implements the launch plan agreed in the 2026-07-09 design session — see `docs/launch-plan.md`, `CONTEXT.md`, and ADRs 0001–0003 (all in this PR).

## What's here

**Design record** — glossary + three one-way-door ADRs (one program across properties · all LINE channels under one provider · booking as a channel into the PMS, no local inventory) + the launch plan with locked interface contracts.

**Backend**
- Property dimension (`hf` | `hfville`) across points, coupons, room types, bookings; new `stays` + `line_friendships` tables (idempotent migration `20260710000000`)
- `POST /api/auth/liff` — silent LIFF enrollment/login, identical cookie contract to `/api/auth/login`, reuses the LINE OAuth upsert (shared userId space, ADR-0002)
- `POST /api/line/webhook/{property}` — HMAC-verified follow/unfollow → friendships; property-affinity push service
- `POST /api/loyalty/stays` — service-token, idempotent-by-`pms_stay_id` checkout accrual: nights + points via `award_points`, property stamped, earn/tier push sent
- Booking channel (ADR-0003): live PMS availability, `POST /api/bookings/channel` creates a held PMS booking; 50% deposit or full via **per-property PromptPay accounts**; slip verification confirms the PMS booking (`{"amount"}` body per PMS contract addendum); 5-min expiry sweep releases lapsed holds
- Legacy local-inventory availability removed; latent `NOT IN`-with-NULL room queries guarded
- Coupons: optional per-property restriction enforced at redemption

**Frontend**
- LIFF bootstrap (silent auth inside LINE, web flow byte-identical outside)
- Member QR card (the front-desk Link handshake), optional phone on profile (already existed)
- Property-aware booking flow: picker → availability → deposit50/full → per-property PromptPay QR + hold countdown + existing slip upload
- PDPA privacy page + footer link (friendship-as-opt-in position)

## Counterpart

PMS side lives in `thehfhotel/new-hotel` branch `feat/loyalty-channel` (channel API, guest-profile Link, checkout hook) — ships dark behind `LOYALTY_CHANNEL_ENABLED`. Both sides implement the same locked contract; deviations are documented in `docs/launch-plan.md`.

## Test plan

- Backend: 367 unit + 287/287 integration (nextest; includes new coverage for accrual idempotency, webhook signature rejection, channel availability via mocked PMS) · clippy `-D warnings` · fmt · `cargo sqlx prepare --check` all green
- Frontend: 1987/1987 tests · lint 0 errors · typecheck · check:translations green
- Not yet live-testable end-to-end: requires LINE console setup (Messaging API under the existing Login channel's provider — irreversible, see ADR-0002) and env secrets (`LINE_MESSAGING_*`, `PMS_*`, `LOYALTY_SERVICE_TOKEN`, `PROMPTPAY_{HF,HFVILLE}_ID`, `VITE_LIFF_ID`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)