### PR TITLE
feat(frontend): UI overhaul PR1 — crimson design tokens + type scale + ratchet

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,7 +11,7 @@
     <link rel="icon" type="image/png" sizes="512x512" href="/icon-512.png" />
     <link rel="manifest" href="/manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#8B0000" />
+    <meta name="theme-color" content="#FAF9F7" />
     <meta name="description" content="Hotel Loyalty Program - Earn rewards with every stay" />
     <title>Hotel Loyalty App</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint . --report-unused-disable-directives",
+    "lint": "eslint . --report-unused-disable-directives && node scripts/check-design.cjs",
     "lint:strict": "eslint . --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --fix",
     "preview": "vite preview",

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -5,7 +5,7 @@
   "start_url": "/",
   "display": "standalone",
   "background_color": "#ffffff",
-  "theme_color": "#8B0000",
+  "theme_color": "#FAF9F7",
   "orientation": "portrait-primary",
   "icons": [
     {

--- a/frontend/scripts/check-design.cjs
+++ b/frontend/scripts/check-design.cjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * Design-system ratchet
+ *
+ * Counts banned styling patterns across src/ and compares each count against
+ * the committed baseline (design-baseline.json). The build fails only when a
+ * pattern's count INCREASES — existing debt is tolerated, new debt is not.
+ * As pages migrate to the design system, run with --update to ratchet the
+ * baseline down. When every count reaches 0 the script acts as a hard wall.
+ *
+ * Grammar being enforced (see the UI overhaul plan):
+ *   - one accent (brand-*), warm neutrals only (stone/ink), no cool grays
+ *   - weights 400/600/700 (500 "font-medium" and 800 "font-extrabold" banned)
+ *   - radii: rounded-lg (8px) / rounded-card (18px) / rounded-full only
+ *   - shadows: shadow-soft / shadow-pop only; legacy shadow-* are no-ops
+ *   - type via the named scale (text-body/title/display...), not text-3xl
+ *
+ * Usage: node scripts/check-design.cjs [--update]
+ * Exit codes: 0 = no pattern increased, 1 = regression found
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SRC_DIR = path.join(__dirname, '../src');
+const BASELINE_PATH = path.join(__dirname, 'design-baseline.json');
+
+const PATTERNS = {
+  'primary-alias': /\bprimary-[0-9]/g,                    // dead alias — must stay 0
+  'cool-grays': /[\s'"`:](?:gray|slate|zinc|neutral)-[0-9]/g,
+  'font-extrabold': /\bfont-extrabold\b/g,
+  'font-medium': /\bfont-medium\b/g,                      // weight 500 is absent from the ladder
+  'legacy-shadows': /\bshadow(?:-(?:sm|md|lg|xl|2xl|inner))?(?![-\w])/g, // anything but shadow-soft/pop/none
+  'off-grammar-radii': /\brounded-(?:md|xl|2xl|3xl)\b/g,
+  'oversized-titles': /\btext-(?:3xl|4xl|5xl)\b/g,
+  'hardcoded-hex': /#[0-9a-fA-F]{6}\b/g,
+};
+
+// shadow-soft / shadow-pop / shadow-none are the sanctioned tokens; the
+// legacy-shadows regex above would still match their "shadow" prefix, so
+// strip them before counting.
+const SANCTIONED = /\bshadow-(?:soft|pop|none)\b/g;
+
+function walk(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, files);
+    else if (/\.(tsx?|css)$/.test(entry.name)) files.push(full);
+  }
+  return files;
+}
+
+const counts = Object.fromEntries(Object.keys(PATTERNS).map((k) => [k, 0]));
+const examples = {};
+
+for (const file of walk(SRC_DIR)) {
+  const raw = fs.readFileSync(file, 'utf8');
+  const text = raw.replace(SANCTIONED, '');
+  for (const [name, re] of Object.entries(PATTERNS)) {
+    const matches = text.match(re);
+    if (matches) {
+      counts[name] += matches.length;
+      if (!examples[name]) examples[name] = path.relative(SRC_DIR, file);
+    }
+  }
+}
+
+if (process.argv.includes('--update')) {
+  fs.writeFileSync(BASELINE_PATH, JSON.stringify(counts, null, 2) + '\n');
+  console.log('design-baseline.json updated:');
+  console.table(counts);
+  process.exit(0);
+}
+
+const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
+let failed = false;
+let improved = false;
+
+for (const [name, count] of Object.entries(counts)) {
+  const allowed = baseline[name] ?? 0;
+  if (count > allowed) {
+    failed = true;
+    console.error(
+      `✗ ${name}: ${count} occurrences (baseline ${allowed}) — new off-system styling introduced` +
+        (examples[name] ? ` (first hit: src/${examples[name]})` : '')
+    );
+  } else if (count < allowed) {
+    improved = true;
+    console.log(`✓ ${name}: ${count} (baseline ${allowed} — ratchet down with --update)`);
+  }
+}
+
+if (failed) {
+  console.error(
+    '\nDesign ratchet failed. Use the design-system tokens/primitives instead ' +
+      '(brand-*, ink/surface/hairline, text-body/title/display, rounded-lg/card/full, ' +
+      'shadow-soft/pop). See frontend/scripts/check-design.cjs header.'
+  );
+  process.exit(1);
+}
+if (improved) {
+  console.log('\nDebt reduced — run `node scripts/check-design.cjs --update` to lock it in.');
+}
+console.log('Design ratchet OK.');

--- a/frontend/scripts/design-baseline.json
+++ b/frontend/scripts/design-baseline.json
@@ -1,0 +1,10 @@
+{
+  "primary-alias": 0,
+  "cool-grays": 0,
+  "font-extrabold": 4,
+  "font-medium": 550,
+  "legacy-shadows": 312,
+  "off-grammar-radii": 313,
+  "oversized-titles": 33,
+  "hardcoded-hex": 82
+}

--- a/frontend/src/components/LanguageSwitcher.tsx
+++ b/frontend/src/components/LanguageSwitcher.tsx
@@ -60,7 +60,7 @@ export default function LanguageSwitcher() {
                   <span>{language.name}</span>
                 </span>
                 {i18n.language === language.code && (
-                  <FiCheck className="h-4 w-4 text-primary-600" />
+                  <FiCheck className="h-4 w-4 text-brand-600" />
                 )}
               </button>
             ))}

--- a/frontend/src/components/admin/SlipViewerSidebar.tsx
+++ b/frontend/src/components/admin/SlipViewerSidebar.tsx
@@ -473,7 +473,7 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
                     onClick={() => setCurrentSlipIndex(index)}
                     className={`transition-all duration-200 rounded-full ${
                       currentSlipIndex === index
-                        ? 'w-6 h-2 bg-primary-600'
+                        ? 'w-6 h-2 bg-brand-600'
                         : 'w-2 h-2 bg-stone-300 hover:bg-stone-400'
                     }`}
                     aria-label={`Go to slip ${index + 1}`}

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -124,7 +124,7 @@ export default function ProtectedRoute({
             </p>
             <button
               onClick={() => window.history.back()}
-              className="mt-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+              className="mt-4 inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500"
             >
               Go Back
             </button>

--- a/frontend/src/components/loyalty/LoyaltyCarousel.tsx
+++ b/frontend/src/components/loyalty/LoyaltyCarousel.tsx
@@ -141,7 +141,7 @@ export default function LoyaltyCarousel({ loyaltyStatus, transactions }: Loyalty
             onClick={() => goToSlide(index)}
             className={`transition-all duration-300 rounded-full
               ${currentSlide === index
-                ? 'w-8 h-2 bg-primary-600'
+                ? 'w-8 h-2 bg-brand-600'
                 : 'w-2 h-2 bg-stone-300 hover:bg-stone-400'
               }`}
             aria-label={`Go to slide ${index + 1}`}

--- a/frontend/src/components/loyalty/TransactionList.tsx
+++ b/frontend/src/components/loyalty/TransactionList.tsx
@@ -182,7 +182,7 @@ export default function TransactionList({
               <div className="text-center pt-4">
                 <button
                   onClick={onLoadMore}
-                  className="px-4 py-2 text-sm font-medium text-primary-600 bg-primary-50 rounded-lg hover:bg-primary-100 transition-colors"
+                  className="px-4 py-2 text-sm font-medium text-brand-600 bg-brand-50 rounded-lg hover:bg-brand-100 transition-colors"
                 >
                   {t('common.loadMore')}
                 </button>

--- a/frontend/src/components/loyalty/__tests__/LoyaltyCarousel.test.tsx
+++ b/frontend/src/components/loyalty/__tests__/LoyaltyCarousel.test.tsx
@@ -148,7 +148,7 @@ describe('LoyaltyCarousel', () => {
       await user.click(nextButton);
 
       const dots = screen.getAllByRole('button').filter(btn => !btn.textContent?.includes('slide'));
-      const activeDot = dots.find(dot => dot.classList.contains('bg-primary-600'));
+      const activeDot = dots.find(dot => dot.classList.contains('bg-brand-600'));
       expect(activeDot).toBeDefined();
     });
 
@@ -184,7 +184,7 @@ describe('LoyaltyCarousel', () => {
       await user.click(prevButton);
 
       const dots = screen.getAllByRole('button').filter(btn => !btn.textContent?.includes('slide'));
-      const activeDot = dots.find(dot => dot.classList.contains('bg-primary-600'));
+      const activeDot = dots.find(dot => dot.classList.contains('bg-brand-600'));
       expect(activeDot).toBeDefined();
     });
 
@@ -225,7 +225,7 @@ describe('LoyaltyCarousel', () => {
         <LoyaltyCarousel loyaltyStatus={mockLoyaltyStatus} transactions={mockTransactions} />
       );
 
-      const activeDot = container.querySelector('.bg-primary-600');
+      const activeDot = container.querySelector('.bg-brand-600');
       expect(activeDot).toBeInTheDocument();
     });
 
@@ -249,7 +249,7 @@ describe('LoyaltyCarousel', () => {
       const nextButton = screen.getByRole('button', { name: /next slide/i });
       await user.click(nextButton);
 
-      const activeDots = container.querySelectorAll('.bg-primary-600');
+      const activeDots = container.querySelectorAll('.bg-brand-600');
       expect(activeDots.length).toBeGreaterThan(0);
     });
   });

--- a/frontend/src/components/notifications/NotificationCenter.tsx
+++ b/frontend/src/components/notifications/NotificationCenter.tsx
@@ -160,7 +160,7 @@ export default function NotificationCenter() {
       {/* Bell Icon Button */}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="relative p-2 text-stone-500 hover:text-stone-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 rounded-md"
+        className="relative p-2 text-stone-500 hover:text-stone-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 rounded-md"
         aria-label="Notifications"
       >
         <FiBell className="h-6 w-6" />
@@ -184,7 +184,7 @@ export default function NotificationCenter() {
                 {unreadCount > 0 && (
                   <button
                     onClick={markAllAsRead}
-                    className="text-sm text-primary-600 hover:text-primary-700 font-medium"
+                    className="text-sm text-brand-600 hover:text-brand-700 font-medium"
                   >
                     {t('notifications.markAllRead', 'Mark all read')}
                   </button>
@@ -208,7 +208,7 @@ export default function NotificationCenter() {
           <div className="max-h-96 overflow-y-auto">
             {isLoading ? (
               <div className="px-4 py-8 text-center text-stone-500">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto mb-2" />
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brand-600 mx-auto mb-2" />
                 {t('notifications.loading', 'Loading...')}
               </div>
             ) : notifications.length === 0 ? (
@@ -259,7 +259,7 @@ export default function NotificationCenter() {
                             {!notification.readAt && (
                               <button
                                 onClick={() => markAsRead([notification.id])}
-                                className="p-1 text-stone-400 hover:text-primary-600 transition-colors"
+                                className="p-1 text-stone-400 hover:text-brand-600 transition-colors"
                                 title={t('notifications.markRead', 'Mark as read')}
                               >
                                 <FiCheck className="h-4 w-4" />
@@ -316,7 +316,7 @@ export default function NotificationCenter() {
           {/* Footer */}
           {totalCount > 10 && (
             <div className="px-4 py-3 border-t border-stone-200 text-center">
-              <button className="text-sm text-primary-600 hover:text-primary-700 font-medium">
+              <button className="text-sm text-brand-600 hover:text-brand-700 font-medium">
                 {t('notifications.viewAll', 'View all notifications')}
               </button>
             </div>

--- a/frontend/src/components/profile/ProfileFormFields.tsx
+++ b/frontend/src/components/profile/ProfileFormFields.tsx
@@ -27,7 +27,7 @@ export function GenderField({ register, errors, showRequiredAsterisk = false, is
 
   const fieldClasses = isModal 
     ? "mt-1 block w-full px-3 py-2 border border-stone-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm text-stone-900 bg-white"
-    : "appearance-none block w-full px-3 py-2 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm";
+    : "appearance-none block w-full px-3 py-2 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm";
 
   const handleGenderChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value;
@@ -111,7 +111,7 @@ export function OccupationField({ register, errors, showRequiredAsterisk = false
 
   const fieldClasses = isModal 
     ? "mt-1 block w-full px-3 py-2 border border-stone-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm text-stone-900 bg-white"
-    : "appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm";
+    : "appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm";
 
   return (
     <div>
@@ -158,7 +158,7 @@ export function DateOfBirthField({ register, errors, showRequiredAsterisk = fals
 
   const fieldClasses = isModal 
     ? "mt-1 block w-full px-3 py-2 border border-stone-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm text-stone-900"
-    : "appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm";
+    : "appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm";
 
   return (
     <div>

--- a/frontend/src/components/profile/SettingsModal.tsx
+++ b/frontend/src/components/profile/SettingsModal.tsx
@@ -149,7 +149,7 @@ export default function SettingsModal({
               </h3>
               <button
                 onClick={onClose}
-                className="rounded-md bg-white text-stone-400 hover:text-stone-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
+                className="rounded-md bg-white text-stone-400 hover:text-stone-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
               >
                 <FiX className="h-6 w-6" />
               </button>
@@ -168,7 +168,7 @@ export default function SettingsModal({
                   />
                   {updateEmojiAvatarMutation.isPending && (
                     <div className="absolute inset-0 flex items-center justify-center">
-                      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-600" />
+                      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-brand-600" />
                     </div>
                   )}
                 </div>
@@ -178,7 +178,7 @@ export default function SettingsModal({
                     <button
                       onClick={() => setShowEmojiSelector(!showEmojiSelector)}
                       disabled={updateEmojiAvatarMutation.isPending}
-                      className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-primary-700 bg-primary-100 hover:bg-primary-200 disabled:opacity-50"
+                      className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-brand-700 bg-brand-100 hover:bg-brand-200 disabled:opacity-50"
                     >
                       <FiSmile className="mr-1 h-4 w-4" />
                       Choose Emoji
@@ -259,7 +259,7 @@ export default function SettingsModal({
                         ? 'bg-stone-100 cursor-not-allowed text-stone-500 border-stone-300'
                         : emailError
                         ? 'border-red-500 ring-1 ring-red-500 focus:ring-red-500 focus:border-red-500'
-                        : 'border-stone-300 focus:ring-primary-500 focus:border-primary-500'
+                        : 'border-stone-300 focus:ring-brand-500 focus:border-brand-500'
                     }`}
                     placeholder={t('profile.emailPlaceholder')}
                   />
@@ -295,7 +295,7 @@ export default function SettingsModal({
                       {...register('firstName')}
                       id="firstName"
                       type="text"
-                      className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                      className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                       placeholder={t('profile.firstNamePlaceholder')}
                     />
                   </div>
@@ -316,7 +316,7 @@ export default function SettingsModal({
                       {...register('lastName')}
                       id="lastName"
                       type="text"
-                      className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                      className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                       placeholder={t('profile.lastNamePlaceholder')}
                     />
                   </div>
@@ -338,7 +338,7 @@ export default function SettingsModal({
                     {...register('phone')}
                     id="phone"
                     type="tel"
-                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                     placeholder={t('profile.phonePlaceholder')}
                   />
                 </div>
@@ -369,14 +369,14 @@ export default function SettingsModal({
                 <button
                   type="button"
                   onClick={onClose}
-                  className="px-4 py-2 border border-stone-300 rounded-md shadow-sm text-sm font-medium text-stone-700 bg-white hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+                  className="px-4 py-2 border border-stone-300 rounded-md shadow-sm text-sm font-medium text-stone-700 bg-white hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500"
                 >
                   {t('common.cancel')}
                 </button>
                 <button
                   type="submit"
                   disabled={isSaving}
-                  className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isSaving ? t('common.saving') : t('common.save')}
                 </button>

--- a/frontend/src/components/profile/__tests__/ProfileFormFields.test.tsx
+++ b/frontend/src/components/profile/__tests__/ProfileFormFields.test.tsx
@@ -314,8 +314,8 @@ describe('GenderField', () => {
       renderGenderField({ isModal: false });
 
       const select = screen.getByRole('combobox', { name: /gender/i });
-      expect(select).toHaveClass('focus:ring-primary-500');
-      expect(select).toHaveClass('focus:border-primary-500');
+      expect(select).toHaveClass('focus:ring-brand-500');
+      expect(select).toHaveClass('focus:border-brand-500');
     });
   });
 });
@@ -508,8 +508,8 @@ describe('OccupationField', () => {
       renderOccupationField({ isModal: false });
 
       const select = screen.getByRole('combobox', { name: /occupation/i });
-      expect(select).toHaveClass('focus:ring-primary-500');
-      expect(select).toHaveClass('focus:border-primary-500');
+      expect(select).toHaveClass('focus:ring-brand-500');
+      expect(select).toHaveClass('focus:border-brand-500');
       expect(select).toHaveClass('pl-10'); // Space for icon
     });
 
@@ -680,8 +680,8 @@ describe('DateOfBirthField', () => {
       renderDateOfBirthField({ isModal: false });
 
       const input = screen.getByLabelText(/date of birth/i);
-      expect(input).toHaveClass('focus:ring-primary-500');
-      expect(input).toHaveClass('focus:border-primary-500');
+      expect(input).toHaveClass('focus:ring-brand-500');
+      expect(input).toHaveClass('focus:border-brand-500');
       expect(input).toHaveClass('pl-10'); // Space for icon
     });
 

--- a/frontend/src/pages/BookingPage.tsx
+++ b/frontend/src/pages/BookingPage.tsx
@@ -296,7 +296,7 @@ export default function BookingPage() {
             <div key={step.number} className="flex items-center">
               <div
                 className={clsx('flex items-center justify-center w-10 h-10 rounded-full', {
-                  'bg-primary-600 text-white': currentStep === step.number,
+                  'bg-brand-600 text-white': currentStep === step.number,
                   'bg-green-500 text-white': currentStep !== step.number && step.completed,
                   'bg-stone-200 text-stone-600': currentStep !== step.number && !step.completed,
                 })}
@@ -332,7 +332,7 @@ export default function BookingPage() {
                   <label
                     key={p}
                     className={clsx('flex items-center p-3 border-2 rounded-lg cursor-pointer transition-colors',
-                      property === p ? 'border-primary-500 bg-primary-50' : 'border-stone-200 hover:border-stone-300'
+                      property === p ? 'border-brand-500 bg-brand-50' : 'border-stone-200 hover:border-stone-300'
                     )}
                   >
                     <input
@@ -341,10 +341,10 @@ export default function BookingPage() {
                       value={p}
                       checked={property === p}
                       onChange={() => setProperty(p)}
-                      className="text-primary-600 focus:ring-primary-500"
+                      className="text-brand-600 focus:ring-brand-500"
                       data-testid={`property-${p}`}
                     />
-                    <FiMapPin className="ml-3 mr-2 text-primary-600 flex-shrink-0" />
+                    <FiMapPin className="ml-3 mr-2 text-brand-600 flex-shrink-0" />
                     <span className="font-medium">{t(`property.${p}`)}</span>
                   </label>
                 ))}
@@ -365,7 +365,7 @@ export default function BookingPage() {
                     setCheckOut('');
                   }
                 }}
-                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500"
                 data-testid="check-in-date"
               />
             </div>
@@ -380,7 +380,7 @@ export default function BookingPage() {
                 min={minCheckOut}
                 onChange={(e) => setCheckOut(e.target.value)}
                 disabled={!checkIn}
-                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-primary-500 focus:border-primary-500 disabled:bg-stone-100"
+                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500 disabled:bg-stone-100"
                 data-testid="check-out-date"
               />
             </div>
@@ -392,7 +392,7 @@ export default function BookingPage() {
               <select
                 value={numGuests}
                 onChange={(e) => setNumGuests(parseInt(e.target.value))}
-                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500"
                 data-testid="num-guests"
               >
                 {[1, 2, 3, 4].map((n) => (
@@ -412,7 +412,7 @@ export default function BookingPage() {
             <button
               onClick={handleDateSubmit}
               disabled={!property || !checkIn || !checkOut || nights <= 0}
-              className="w-full py-2 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:bg-stone-300 disabled:cursor-not-allowed"
+              className="w-full py-2 px-4 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:bg-stone-300 disabled:cursor-not-allowed"
               data-testid="continue-to-rooms"
             >
               {t('common.continue')}
@@ -430,7 +430,7 @@ export default function BookingPage() {
             </h2>
             <button
               onClick={() => setCurrentStep(1)}
-              className="text-primary-600 hover:underline"
+              className="text-brand-600 hover:underline"
             >
               {t('booking.changeDates')}
             </button>
@@ -447,7 +447,7 @@ export default function BookingPage() {
 
           {isLoadingRoomTypes ? (
             <div className="flex justify-center py-12">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-600" />
             </div>
           ) : roomTypes?.length === 0 ? (
             <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
@@ -487,7 +487,7 @@ export default function BookingPage() {
                     <div className="mt-4 pt-4 border-t">
                       <div className="flex items-center justify-between">
                         <div>
-                          <span className="text-2xl font-bold text-primary-600">
+                          <span className="text-2xl font-bold text-brand-600">
                             ฿{roomType.nightly_price.toLocaleString()}
                           </span>
                           <span className="text-stone-500 text-sm">/{t('booking.night')}</span>
@@ -526,7 +526,7 @@ export default function BookingPage() {
             <h2 className="text-xl font-semibold">{t('booking.confirmBooking')}</h2>
             <button
               onClick={() => setCurrentStep(2)}
-              className="text-primary-600 hover:underline"
+              className="text-brand-600 hover:underline"
             >
               {t('booking.changeRoom')}
             </button>
@@ -581,7 +581,7 @@ export default function BookingPage() {
                     type="text"
                     value={guestName}
                     onChange={(e) => setGuestName(e.target.value)}
-                    className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+                    className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500"
                     data-testid="guest-name"
                   />
                 </div>
@@ -595,7 +595,7 @@ export default function BookingPage() {
                     value={guestPhone}
                     onChange={(e) => setGuestPhone(e.target.value)}
                     placeholder={t('booking.guestPhonePlaceholder')}
-                    className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+                    className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500"
                     data-testid="guest-phone"
                   />
                 </div>
@@ -609,7 +609,7 @@ export default function BookingPage() {
               <div className="space-y-3">
                 <label
                   className={clsx('flex items-start p-4 border-2 rounded-lg cursor-pointer transition-colors',
-                    paymentOption === 'deposit50' ? 'border-primary-500 bg-primary-50' : 'border-stone-200 hover:border-stone-300'
+                    paymentOption === 'deposit50' ? 'border-brand-500 bg-brand-50' : 'border-stone-200 hover:border-stone-300'
                   )}
                 >
                   <input
@@ -618,12 +618,12 @@ export default function BookingPage() {
                     value="deposit50"
                     checked={paymentOption === 'deposit50'}
                     onChange={() => setPaymentOption('deposit50')}
-                    className="mt-1 text-primary-600 focus:ring-primary-500"
+                    className="mt-1 text-brand-600 focus:ring-brand-500"
                   />
                   <div className="ml-3 flex-1">
                     <div className="flex justify-between items-center">
                       <span className="font-medium">{t('payment.deposit')}</span>
-                      <span className="text-lg font-bold text-primary-600">
+                      <span className="text-lg font-bold text-brand-600">
                         ฿{depositAmount.toLocaleString('th-TH')}
                       </span>
                     </div>
@@ -633,7 +633,7 @@ export default function BookingPage() {
 
                 <label
                   className={clsx('flex items-start p-4 border-2 rounded-lg cursor-pointer transition-colors',
-                    paymentOption === 'full' ? 'border-primary-500 bg-primary-50' : 'border-stone-200 hover:border-stone-300'
+                    paymentOption === 'full' ? 'border-brand-500 bg-brand-50' : 'border-stone-200 hover:border-stone-300'
                   )}
                 >
                   <input
@@ -642,12 +642,12 @@ export default function BookingPage() {
                     value="full"
                     checked={paymentOption === 'full'}
                     onChange={() => setPaymentOption('full')}
-                    className="mt-1 text-primary-600 focus:ring-primary-500"
+                    className="mt-1 text-brand-600 focus:ring-brand-500"
                   />
                   <div className="ml-3 flex-1">
                     <div className="flex justify-between items-center">
                       <span className="font-medium">{t('payment.payInFull')}</span>
-                      <span className="text-lg font-bold text-primary-600">
+                      <span className="text-lg font-bold text-brand-600">
                         ฿{totalPrice.toLocaleString('th-TH')}
                       </span>
                     </div>
@@ -670,7 +670,7 @@ export default function BookingPage() {
                 </div>
                 <div className="flex justify-between font-semibold text-lg pt-2 border-t">
                   <span>{t('booking.total')}</span>
-                  <span className="text-primary-600">฿{totalPrice.toLocaleString()}</span>
+                  <span className="text-brand-600">฿{totalPrice.toLocaleString()}</span>
                 </div>
                 <div className="flex justify-between text-sm text-stone-600">
                   <span>{t('payment.amountToPay')}</span>
@@ -683,7 +683,7 @@ export default function BookingPage() {
             <button
               onClick={handleBookingSubmit}
               disabled={createBookingMutation.isPending || !guestName.trim() || !guestPhone.trim()}
-              className="w-full py-3 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:bg-stone-300 disabled:cursor-not-allowed font-semibold"
+              className="w-full py-3 px-4 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:bg-stone-300 disabled:cursor-not-allowed font-semibold"
               data-testid="confirm-booking"
             >
               {createBookingMutation.isPending ? (
@@ -708,7 +708,7 @@ export default function BookingPage() {
 
           <div className="bg-white rounded-lg shadow p-6 space-y-6">
             {/* Amount summary */}
-            <div className="p-4 bg-primary-50 border-2 border-primary-200 rounded-lg space-y-2">
+            <div className="p-4 bg-brand-50 border-2 border-brand-200 rounded-lg space-y-2">
               <div className="flex justify-between items-center">
                 <div>
                   <p className="font-medium">
@@ -716,12 +716,12 @@ export default function BookingPage() {
                   </p>
                   <p className="text-sm text-stone-500">{t('payment.amountToPay')}</p>
                 </div>
-                <p className="text-2xl font-bold text-primary-600" data-testid="amount-due-now">
+                <p className="text-2xl font-bold text-brand-600" data-testid="amount-due-now">
                   ฿{createdBooking.amount_due_now.toLocaleString('th-TH')}
                 </p>
               </div>
               {createdBooking.balance_due_at_checkin > 0 && (
-                <div className="flex justify-between items-center text-sm border-t border-primary-200 pt-2">
+                <div className="flex justify-between items-center text-sm border-t border-brand-200 pt-2">
                   <span className="text-stone-600">{t('payment.balanceDueAtCheckin')}</span>
                   <span className="font-semibold" data-testid="balance-due">
                     ฿{createdBooking.balance_due_at_checkin.toLocaleString('th-TH')}
@@ -744,7 +744,7 @@ export default function BookingPage() {
                 <p className="font-medium text-red-800">{t('payment.holdExpired')}</p>
                 <button
                   onClick={restartBooking}
-                  className="py-2 px-6 bg-primary-600 text-white rounded-md hover:bg-primary-700"
+                  className="py-2 px-6 bg-brand-600 text-white rounded-md hover:bg-brand-700"
                 >
                   {t('payment.startOver')}
                 </button>
@@ -768,7 +768,7 @@ export default function BookingPage() {
                         className="flex items-center justify-center h-48"
                         data-testid="qr-loading"
                       >
-                        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-primary-600" />
+                        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-brand-600" />
                       </div>
                     )}
 
@@ -789,7 +789,7 @@ export default function BookingPage() {
                   {slipStatus === 'pending' && !slipPreview && (
                     <div
                       className={clsx('border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors',
-                        isDragging ? 'border-primary-500 bg-primary-50' : 'border-stone-300 hover:border-primary-400'
+                        isDragging ? 'border-brand-500 bg-brand-50' : 'border-stone-300 hover:border-brand-400'
                       )}
                       onDragOver={handleDragOver}
                       onDragLeave={handleDragLeave}
@@ -850,7 +850,7 @@ export default function BookingPage() {
 
                       <button
                         onClick={() => navigate(`/my-bookings?openBooking=${createdBooking.booking_id}&tab=payment`)}
-                        className="w-full py-2 text-primary-600 border border-primary-300 rounded-lg hover:bg-primary-50 transition-colors"
+                        className="w-full py-2 text-brand-600 border border-brand-300 rounded-lg hover:bg-brand-50 transition-colors"
                       >
                         {t('payment.changeSlip')}
                       </button>
@@ -890,7 +890,7 @@ export default function BookingPage() {
                     <button
                       onClick={handleSlipUpload}
                       disabled={isUploading}
-                      className="flex-1 py-3 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:bg-stone-300 disabled:cursor-not-allowed font-semibold"
+                      className="flex-1 py-3 px-4 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:bg-stone-300 disabled:cursor-not-allowed font-semibold"
                       data-testid="submit-slip"
                     >
                       {isUploading ? (
@@ -907,7 +907,7 @@ export default function BookingPage() {
                   {(slipStatus === 'uploaded' || slipStatus === 'verified') && (
                     <button
                       onClick={() => navigate('/my-bookings')}
-                      className="flex-1 py-3 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 font-semibold"
+                      className="flex-1 py-3 px-4 bg-brand-600 text-white rounded-md hover:bg-brand-700 font-semibold"
                       data-testid="view-bookings"
                     >
                       {t('booking.myBookings')}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -30,7 +30,7 @@ export default function DashboardPage() {
     return (
       <div className="min-h-screen bg-stone-50 flex items-center justify-center" data-testid="dashboard-loading">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-600" />
+          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-brand-600" />
           <p className="mt-4 text-stone-600">{t('profile.loading')}</p>
         </div>
       </div>
@@ -115,7 +115,7 @@ export default function DashboardPage() {
           {loyaltyStatus && (
             <div className="mb-6">
               <div className="flex items-center space-x-2 mb-4">
-                <FiGift className="h-6 w-6 text-primary-600" />
+                <FiGift className="h-6 w-6 text-brand-600" />
                 <h2 className="text-xl font-semibold text-stone-900">
                   {t('loyalty.dashboard.title')}
                 </h2>
@@ -144,7 +144,7 @@ export default function DashboardPage() {
                 <div className="p-5">
                   <div className="flex items-center">
                     <div className="flex-shrink-0">
-                      <FiCreditCard className="h-6 w-6 text-primary-600" />
+                      <FiCreditCard className="h-6 w-6 text-brand-600" />
                     </div>
                     <div className="ml-5 w-0 flex-1">
                       <dl>
@@ -170,7 +170,7 @@ export default function DashboardPage() {
                   <div className="flex items-center justify-between mb-3">
                     <div className="flex items-center">
                       <div className="flex-shrink-0">
-                        <FiUser className="h-6 w-6 text-primary-600" />
+                        <FiUser className="h-6 w-6 text-brand-600" />
                       </div>
                       <div className="ml-3">
                         <dt className="text-lg font-semibold text-stone-900">
@@ -256,7 +256,7 @@ export default function DashboardPage() {
                 <div className="p-5">
                   <div className="flex items-center">
                     <div className="flex-shrink-0">
-                      <FiCalendar className="h-6 w-6 text-primary-600" />
+                      <FiCalendar className="h-6 w-6 text-brand-600" />
                     </div>
                     <div className="ml-5 w-0 flex-1">
                       <dl>

--- a/frontend/src/pages/MyBookingsPage.tsx
+++ b/frontend/src/pages/MyBookingsPage.tsx
@@ -306,7 +306,7 @@ export default function MyBookingsPage() {
     return (
       <MainLayout title={t('booking.myBookings')}>
         <div className="flex justify-center py-12">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600" />
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-600" />
         </div>
       </MainLayout>
     );
@@ -319,7 +319,7 @@ export default function MyBookingsPage() {
         <h2 className="text-xl font-semibold">{t('booking.myBookings')}</h2>
         <Link
           to="/booking"
-          className="inline-flex items-center px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700"
+          className="inline-flex items-center px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700"
           data-testid="new-booking-button"
         >
           <FiPlus className="mr-2" />
@@ -334,7 +334,7 @@ export default function MyBookingsPage() {
             onClick={() => setActiveTab('current')}
             className={clsx('py-2 px-1 border-b-2 font-medium text-sm',
               activeTab === 'current'
-                ? 'border-primary-500 text-primary-600'
+                ? 'border-brand-500 text-brand-600'
                 : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
             )}
             data-testid="tab-current"
@@ -345,7 +345,7 @@ export default function MyBookingsPage() {
             onClick={() => setActiveTab('history')}
             className={clsx('py-2 px-1 border-b-2 font-medium text-sm',
               activeTab === 'history'
-                ? 'border-primary-500 text-primary-600'
+                ? 'border-brand-500 text-brand-600'
                 : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
             )}
             data-testid="tab-history"
@@ -370,7 +370,7 @@ export default function MyBookingsPage() {
           {activeTab === 'current' && (
             <Link
               to="/booking"
-              className="inline-flex items-center px-6 py-3 bg-primary-600 text-white rounded-md hover:bg-primary-700"
+              className="inline-flex items-center px-6 py-3 bg-brand-600 text-white rounded-md hover:bg-brand-700"
             >
               <FiPlus className="mr-2" />
               {t('booking.bookYourFirstRoom')}
@@ -456,7 +456,7 @@ export default function MyBookingsPage() {
                   {/* Price, Upload Button and Chevron */}
                   <div className="flex items-center gap-3">
                     <div className="text-right">
-                      <div className="text-2xl font-bold text-primary-600">
+                      <div className="text-2xl font-bold text-brand-600">
                         ฿{Number(booking.totalPrice).toLocaleString()}
                       </div>
                       <div className="text-sm text-stone-500">
@@ -477,7 +477,7 @@ export default function MyBookingsPage() {
               {/* Booking Footer */}
               <div className="bg-stone-50 px-6 py-3 text-sm text-stone-500 flex items-center justify-between">
                 <span>{t('booking.bookedOn')}: {new Date(booking.createdAt).toLocaleDateString()}</span>
-                <span className="text-primary-600">{t('booking.clickForDetails')}</span>
+                <span className="text-brand-600">{t('booking.clickForDetails')}</span>
               </div>
             </div>
           ))}
@@ -525,14 +525,14 @@ export default function MyBookingsPage() {
                 <div>
                   <div className="text-sm text-stone-500 mb-1">{t('booking.checkIn')}</div>
                   <div className="font-semibold flex items-center">
-                    <FiCalendar className="mr-2 text-primary-600" />
+                    <FiCalendar className="mr-2 text-brand-600" />
                     {new Date(selectedBooking.checkInDate).toLocaleDateString()}
                   </div>
                 </div>
                 <div>
                   <div className="text-sm text-stone-500 mb-1">{t('booking.checkOut')}</div>
                   <div className="font-semibold flex items-center">
-                    <FiCalendar className="mr-2 text-primary-600" />
+                    <FiCalendar className="mr-2 text-brand-600" />
                     {new Date(selectedBooking.checkOutDate).toLocaleDateString()}
                   </div>
                 </div>
@@ -540,7 +540,7 @@ export default function MyBookingsPage() {
 
               {/* Nights Count */}
               <div className="text-center py-3 bg-stone-50 rounded-lg" data-testid="booking-nights-count">
-                <span className="text-lg font-semibold text-primary-600">
+                <span className="text-lg font-semibold text-brand-600">
                   {calculateNights(selectedBooking.checkInDate, selectedBooking.checkOutDate)}
                 </span>{' '}
                 <span className="text-stone-600">
@@ -577,9 +577,9 @@ export default function MyBookingsPage() {
               </div>
 
               {/* Total Price */}
-              <div className="text-center py-4 bg-primary-50 rounded-lg">
+              <div className="text-center py-4 bg-brand-50 rounded-lg">
                 <div className="text-sm text-stone-500 mb-1">{t('booking.totalPrice')}</div>
-                <div className="text-3xl font-bold text-primary-600">
+                <div className="text-3xl font-bold text-brand-600">
                   ฿{Number(selectedBooking.totalPrice).toLocaleString()}
                 </div>
               </div>
@@ -591,7 +591,7 @@ export default function MyBookingsPage() {
                     setSelectedBooking(null);
                     handleUploadSlipClick(selectedBooking.id);
                   }}
-                  className="w-full py-2 px-4 bg-primary-600 text-white rounded-md hover:bg-primary-700 text-center"
+                  className="w-full py-2 px-4 bg-brand-600 text-white rounded-md hover:bg-brand-700 text-center"
                 >
                   {t('payment.title')}
                 </button>
@@ -636,7 +636,7 @@ export default function MyBookingsPage() {
                     {canUploadSlip(selectedBooking) && (
                       <button
                         onClick={() => handleUploadSlipClick(selectedBooking.id)}
-                        className="flex items-center gap-2 px-3 py-2 text-sm text-primary-600 hover:bg-primary-50 rounded-lg border border-primary-200 transition-colors"
+                        className="flex items-center gap-2 px-3 py-2 text-sm text-brand-600 hover:bg-brand-50 rounded-lg border border-brand-200 transition-colors"
                       >
                         <FiPlus className="w-4 h-4" />
                         {t('payment.uploadMore')}
@@ -724,7 +724,7 @@ export default function MyBookingsPage() {
                 onChange={(e) => setCancelReason(e.target.value)}
                 rows={3}
                 placeholder={t('booking.cancelReasonPlaceholder')}
-                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-primary-500 focus:border-primary-500"
+                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500"
                 data-testid="cancel-reason-input"
               />
             </div>
@@ -801,7 +801,7 @@ export default function MyBookingsPage() {
                   <div>{t('booking.checkIn')}: {new Date(slipUploadBooking.checkInDate).toLocaleDateString()}</div>
                   <div>{t('booking.checkOut')}: {new Date(slipUploadBooking.checkOutDate).toLocaleDateString()}</div>
                 </div>
-                <div className="mt-2 text-lg font-bold text-primary-600">
+                <div className="mt-2 text-lg font-bold text-brand-600">
                   ฿{Number(slipUploadBooking.totalPrice).toLocaleString('th-TH')}
                 </div>
               </div>
@@ -854,7 +854,7 @@ export default function MyBookingsPage() {
                   {/* Toggle button for bank details */}
                   <button
                     onClick={() => setShowBankDetails(!showBankDetails)}
-                    className="w-full py-2 text-sm text-primary-600 hover:text-primary-700 border border-primary-200 rounded-lg hover:bg-primary-50 transition-colors"
+                    className="w-full py-2 text-sm text-brand-600 hover:text-brand-700 border border-brand-200 rounded-lg hover:bg-brand-50 transition-colors"
                   >
                     {showBankDetails ? t('payment.hideBankDetails') : t('payment.showBankDetails')}
                   </button>
@@ -866,7 +866,7 @@ export default function MyBookingsPage() {
                       <div className="text-center">
                         <h4 className="font-medium mb-3">{t('payment.bankTransfer')}</h4>
                         <div
-                          className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm text-left space-y-2 cursor-pointer hover:border-primary-300 transition-colors"
+                          className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm text-left space-y-2 cursor-pointer hover:border-brand-300 transition-colors"
                           onClick={() => {
                             navigator.clipboard.writeText('0461430473');
                             toast.success(t('payment.copied'));
@@ -913,7 +913,7 @@ export default function MyBookingsPage() {
                           <a
                             href={promptPayQRUrl}
                             download="promptpay-qr.png"
-                            className="inline-flex items-center justify-center gap-2 mt-3 w-full py-2 text-sm text-stone-500 hover:text-primary-600 transition-colors"
+                            className="inline-flex items-center justify-center gap-2 mt-3 w-full py-2 text-sm text-stone-500 hover:text-brand-600 transition-colors"
                           >
                             <FiDownload className="w-4 h-4" />
                             {t('payment.downloadQR')}
@@ -929,7 +929,7 @@ export default function MyBookingsPage() {
                   <div className="text-center">
                     <h4 className="font-medium mb-3">{t('payment.bankTransfer')}</h4>
                     <div
-                      className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm text-left space-y-2 cursor-pointer hover:border-primary-300 transition-colors"
+                      className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm text-left space-y-2 cursor-pointer hover:border-brand-300 transition-colors"
                       onClick={() => {
                         navigator.clipboard.writeText('0461430473');
                         toast.success(t('payment.copied'));
@@ -976,7 +976,7 @@ export default function MyBookingsPage() {
                       <a
                         href={promptPayQRUrl}
                         download="promptpay-qr.png"
-                        className="inline-flex items-center justify-center gap-2 mt-3 w-full py-2 text-sm text-stone-500 hover:text-primary-600 transition-colors"
+                        className="inline-flex items-center justify-center gap-2 mt-3 w-full py-2 text-sm text-stone-500 hover:text-brand-600 transition-colors"
                       >
                         <FiDownload className="w-4 h-4" />
                         {t('payment.downloadQR')}
@@ -993,7 +993,7 @@ export default function MyBookingsPage() {
                 {!slipPreview ? (
                   <div
                     className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
-                      isDragging ? 'border-primary-500 bg-primary-50' : 'border-stone-300 hover:border-primary-400'
+                      isDragging ? 'border-brand-500 bg-brand-50' : 'border-stone-300 hover:border-brand-400'
                     }`}
                     onDragOver={handleDragOver}
                     onDragLeave={handleDragLeave}
@@ -1043,7 +1043,7 @@ export default function MyBookingsPage() {
               <button
                 onClick={handleSlipUpload}
                 disabled={!slipFile || isUploading}
-                className="px-4 py-2 bg-primary-600 text-white rounded-md hover:bg-primary-700 disabled:bg-stone-300 disabled:cursor-not-allowed flex items-center"
+                className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:bg-stone-300 disabled:cursor-not-allowed flex items-center"
                 data-testid="slip-upload-submit"
               >
                 {isUploading ? (

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -50,7 +50,7 @@ export default function PrivacyPage() {
         </section>
 
         <div className="text-center">
-          <Link to="/" className="text-primary-600 hover:underline">
+          <Link to="/" className="text-brand-600 hover:underline">
             {t('privacy.backToApp')}
           </Link>
         </div>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -256,7 +256,7 @@ export default function ProfilePage() {
     return (
       <div className="min-h-screen bg-stone-50 flex items-center justify-center">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary-600" />
+          <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-brand-600" />
           <p className="mt-4 text-stone-600">{t('profile.loading')}</p>
         </div>
       </div>
@@ -277,7 +277,7 @@ export default function ProfilePage() {
               </h2>
               <button
                 onClick={() => setShowSettingsModal(true)}
-                className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500"
+                className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500"
               >
                 <FiSettings className="mr-2 h-4 w-4" />
                 {t('profile.editSettings')}

--- a/frontend/src/pages/__tests__/MyBookingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/MyBookingsPage.test.tsx
@@ -558,7 +558,7 @@ describe('MyBookingsPage', () => {
       const currentTab = screen.getByTestId('tab-current');
       const historyTab = screen.getByTestId('tab-history');
 
-      expect(currentTab).toHaveClass('border-primary-500', 'text-primary-600');
+      expect(currentTab).toHaveClass('border-brand-500', 'text-brand-600');
       expect(historyTab).toHaveClass('border-transparent', 'text-stone-500');
     });
 
@@ -586,7 +586,7 @@ describe('MyBookingsPage', () => {
       const historyTab = screen.getByTestId('tab-history');
       await user.click(historyTab);
 
-      expect(historyTab).toHaveClass('border-primary-500', 'text-primary-600');
+      expect(historyTab).toHaveClass('border-brand-500', 'text-brand-600');
     });
 
     it('should update active tab styling on switch', async () => {
@@ -598,17 +598,17 @@ describe('MyBookingsPage', () => {
       const historyTab = screen.getByTestId('tab-history');
 
       // Initially current is active
-      expect(currentTab).toHaveClass('border-primary-500');
+      expect(currentTab).toHaveClass('border-brand-500');
       expect(historyTab).toHaveClass('border-transparent');
 
       // Switch to history
       await user.click(historyTab);
-      expect(historyTab).toHaveClass('border-primary-500');
+      expect(historyTab).toHaveClass('border-brand-500');
       expect(currentTab).toHaveClass('border-transparent');
 
       // Switch back to current
       await user.click(currentTab);
-      expect(currentTab).toHaveClass('border-primary-500');
+      expect(currentTab).toHaveClass('border-brand-500');
       expect(historyTab).toHaveClass('border-transparent');
     });
   });

--- a/frontend/src/pages/admin/AdminTransactionHistoryPage.tsx
+++ b/frontend/src/pages/admin/AdminTransactionHistoryPage.tsx
@@ -57,7 +57,7 @@ export default function AdminTransactionHistoryPage() {
       <MainLayout title={t('admin.loyalty.transactionHistory')}>
         <div className="flex items-center justify-center min-h-96">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600 mx-auto" />
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-600 mx-auto" />
             <p className="mt-4 text-stone-600">{t('profile.loading')}</p>
           </div>
         </div>

--- a/frontend/src/pages/admin/NewMemberCouponSettings.tsx
+++ b/frontend/src/pages/admin/NewMemberCouponSettings.tsx
@@ -144,7 +144,7 @@ export default function NewMemberCouponSettings() {
       <MainLayout title={t('admin.newMemberCoupons.title')} showProfileBanner={false}>
         <div className="flex items-center justify-center py-12">
           <div className="text-center">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary-600 mx-auto" />
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-600 mx-auto" />
             <p className="mt-4 text-stone-600">{t('admin.newMemberCoupons.loading')}</p>
           </div>
         </div>
@@ -212,7 +212,7 @@ export default function NewMemberCouponSettings() {
                 id="couponSelect"
                 value={selectedCouponId}
                 onChange={(e) => setSelectedCouponId(e.target.value)}
-                className="block w-full px-3 py-2 border border-stone-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                className="block w-full px-3 py-2 border border-stone-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                 disabled={!isEnabled}
               >
                 <option value="">{t('admin.newMemberCoupons.selectCouponPlaceholder')}</option>
@@ -347,7 +347,7 @@ export default function NewMemberCouponSettings() {
                     id="pointsAmount"
                     value={pointsAmount}
                     onChange={(e) => setPointsAmount(e.target.value)}
-                    className="block w-full px-3 py-2 border border-stone-300 rounded-md shadow-sm focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                    className="block w-full px-3 py-2 border border-stone-300 rounded-md shadow-sm focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                     placeholder={t('admin.newMemberCoupons.pointsPlaceholder')}
                     min="1"
                     max="10000"
@@ -377,7 +377,7 @@ export default function NewMemberCouponSettings() {
                 type="button"
                 onClick={handleReset}
                 disabled={!hasChanged || isSaving}
-                className="inline-flex items-center px-4 py-2 border border-stone-300 rounded-md shadow-sm text-sm font-medium text-stone-700 bg-white hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="inline-flex items-center px-4 py-2 border border-stone-300 rounded-md shadow-sm text-sm font-medium text-stone-700 bg-white hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <FiX className="mr-2 h-4 w-4" />
                 {t('admin.newMemberCoupons.reset')}
@@ -394,7 +394,7 @@ export default function NewMemberCouponSettings() {
                   (isEnabled && couponStatus?.isExpired) ||
                   (pointsEnabled && (!pointsAmount || (parseInt(pointsAmount) < 1 || parseInt(pointsAmount) > 10000)))
                 }
-                className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isSaving ? (
                   <>

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -85,7 +85,7 @@ export default function LoginPage() {
             {t('common.or')}{' '}
             <Link
               to="/register"
-              className="font-medium text-primary-600 hover:text-primary-500"
+              className="font-medium text-brand-600 hover:text-brand-500"
             >
               {t('auth.createAccount')}
             </Link>
@@ -107,7 +107,7 @@ export default function LoginPage() {
                   type="email"
                   autoComplete="email"
                   data-testid="login-email"
-                  className="appearance-none rounded-none relative block w-full px-3 py-2 pl-10 border border-stone-300 placeholder-stone-500 text-stone-900 rounded-t-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm"
+                  className="appearance-none rounded-none relative block w-full px-3 py-2 pl-10 border border-stone-300 placeholder-stone-500 text-stone-900 rounded-t-md focus:outline-none focus:ring-brand-500 focus:border-brand-500 focus:z-10 sm:text-sm"
                   placeholder={t('auth.email')}
                 />
               </div>
@@ -129,7 +129,7 @@ export default function LoginPage() {
                   type={showPassword ? 'text' : 'password'}
                   autoComplete="current-password"
                   data-testid="login-password"
-                  className="appearance-none rounded-none relative block w-full px-3 py-2 pl-10 pr-10 border border-stone-300 placeholder-stone-500 text-stone-900 rounded-b-md focus:outline-none focus:ring-primary-500 focus:border-primary-500 focus:z-10 sm:text-sm"
+                  className="appearance-none rounded-none relative block w-full px-3 py-2 pl-10 pr-10 border border-stone-300 placeholder-stone-500 text-stone-900 rounded-b-md focus:outline-none focus:ring-brand-500 focus:border-brand-500 focus:z-10 sm:text-sm"
                   placeholder={t('auth.password')}
                 />
                 <button
@@ -156,7 +156,7 @@ export default function LoginPage() {
                 {...register('rememberMe')}
                 id="rememberMe"
                 type="checkbox"
-                className="h-4 w-4 text-primary-600 focus:ring-primary-500 border-stone-300 rounded"
+                className="h-4 w-4 text-brand-600 focus:ring-brand-500 border-stone-300 rounded"
               />
               <label htmlFor="rememberMe" className="ml-2 block text-sm text-stone-900">
                 {t('auth.rememberMe')}
@@ -165,7 +165,7 @@ export default function LoginPage() {
             <div className="text-sm">
               <Link
                 to="/reset-password"
-                className="font-medium text-primary-600 hover:text-primary-500"
+                className="font-medium text-brand-600 hover:text-brand-500"
               >
                 {t('auth.forgotPassword')}
               </Link>
@@ -177,7 +177,7 @@ export default function LoginPage() {
               type="submit"
               disabled={isLoading}
               data-testid="login-submit"
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? t('common.loading') : t('common.login')}
             </button>

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -58,7 +58,7 @@ export default function RegisterPage() {
             Or{' '}
             <Link
               to="/login"
-              className="font-medium text-primary-600 hover:text-primary-500"
+              className="font-medium text-brand-600 hover:text-brand-500"
             >
               sign in to your existing account
             </Link>
@@ -79,7 +79,7 @@ export default function RegisterPage() {
                     {...registerField('firstName')}
                     id="firstName"
                     type="text"
-                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                     placeholder={t('profile.firstNamePlaceholder')}
                   />
                 </div>
@@ -99,7 +99,7 @@ export default function RegisterPage() {
                     {...registerField('lastName')}
                     id="lastName"
                     type="text"
-                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                     placeholder={t('profile.lastNamePlaceholder')}
                   />
                 </div>
@@ -122,7 +122,7 @@ export default function RegisterPage() {
                   id="email"
                   type="email"
                   autoComplete="email"
-                  className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                  className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                   placeholder="john@example.com"
                 />
               </div>
@@ -143,7 +143,7 @@ export default function RegisterPage() {
                   {...registerField('phone')}
                   id="phone"
                   type="tel"
-                  className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                  className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                   placeholder="+1 (555) 123-4567"
                 />
               </div>
@@ -165,7 +165,7 @@ export default function RegisterPage() {
                   id="password"
                   type={showPassword ? 'text' : 'password'}
                   autoComplete="new-password"
-                  className="appearance-none block w-full px-3 py-2 pl-10 pr-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                  className="appearance-none block w-full px-3 py-2 pl-10 pr-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                   placeholder="••••••••"
                 />
                 <button
@@ -198,7 +198,7 @@ export default function RegisterPage() {
                   id="confirmPassword"
                   type={showConfirmPassword ? 'text' : 'password'}
                   autoComplete="new-password"
-                  className="appearance-none block w-full px-3 py-2 pl-10 pr-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                  className="appearance-none block w-full px-3 py-2 pl-10 pr-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                   placeholder="••••••••"
                 />
                 <button
@@ -223,7 +223,7 @@ export default function RegisterPage() {
             <button
               type="submit"
               disabled={isLoading}
-              className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? 'Creating account...' : 'Create account'}
             </button>

--- a/frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -96,7 +96,7 @@ export default function ResetPasswordPage() {
                     {...resetForm.register('password')}
                     id="password"
                     type="password"
-                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                     placeholder="••••••••"
                   />
                 </div>
@@ -119,7 +119,7 @@ export default function ResetPasswordPage() {
                     {...resetForm.register('confirmPassword')}
                     id="confirmPassword"
                     type="password"
-                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                     placeholder="••••••••"
                   />
                 </div>
@@ -135,7 +135,7 @@ export default function ResetPasswordPage() {
               <button
                 type="submit"
                 disabled={isLoading}
-                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isLoading ? 'Resetting...' : 'Reset password'}
               </button>
@@ -157,7 +157,7 @@ export default function ResetPasswordPage() {
             Or{' '}
             <Link
               to="/login"
-              className="font-medium text-primary-600 hover:text-primary-500"
+              className="font-medium text-brand-600 hover:text-brand-500"
             >
               return to sign in
             </Link>
@@ -193,7 +193,7 @@ export default function ResetPasswordPage() {
                   id="email"
                   type="email"
                   autoComplete="email"
-                  className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-primary-500 focus:border-primary-500 sm:text-sm"
+                  className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
                   placeholder="john@example.com"
                 />
               </div>
@@ -208,7 +208,7 @@ export default function ResetPasswordPage() {
               <button
                 type="submit"
                 disabled={isLoading}
-                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-primary-600 hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {isLoading ? 'Sending...' : 'Send reset link'}
               </button>

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -1,6 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Sarabun:wght@400;500;600;700&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+Thai:wght@100;200;300;400;500;600;700;800;900&display=swap');
-
+/* Sarabun is loaded once via <link> in index.html (weights 400/500/600/700). */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,39 +7,27 @@ export default {
   theme: {
     extend: {
       colors: {
-        // HF One brand burgundy — see /Users/nut/HF-erp/design/HF-ONE.md.
-        // 50/100/300/500/600/700/800 are exact spec tokens; 200/400/900/950
-        // are interpolated to keep the full Tailwind 11-step scale usable.
-        primary: {
-          50: '#FBEAEA',
-          100: '#F5C9C9',
-          200: '#E39898',
-          300: '#C76060',
-          400: '#A83333',
-          500: '#8B0000',
-          600: '#7A0000',
-          700: '#6B1212',
-          800: '#4F0E0E',
-          900: '#3A0A0A',
-          950: '#240606',
-        },
-        // Alias of `primary` under the spec's own name, so hardcoded
-        // `blue-*` classes can be retinted to `brand-*` directly.
+        // Brand crimson, derived from the hotel logo (sampled #D4272E).
+        // The action color sits at 600 so existing `bg-brand-600` /
+        // `hover:bg-brand-700` call sites read correctly. The dark end of
+        // the ramp converges onto the legacy HF One burgundy so dark
+        // surfaces and pressed states keep the estate's deep tones —
+        // see /Users/nut/HF-erp/design/HF-ONE.md (crimson is a sanctioned
+        // guest-app exception; primary action = brand-600).
         brand: {
-          50: '#FBEAEA',
-          100: '#F5C9C9',
-          200: '#E39898',
-          300: '#C76060',
-          400: '#A83333',
-          500: '#8B0000',
-          600: '#7A0000',
-          700: '#6B1212',
-          800: '#4F0E0E',
-          900: '#3A0A0A',
-          950: '#240606',
+          50: '#FDF1F1',
+          100: '#FADCDD',
+          200: '#F5B5B7',
+          300: '#EC8388',
+          400: '#E24E55',
+          500: '#DB343C',
+          600: '#D4272E', // primary action — 5.1:1 on white (AA)
+          700: '#AF1F25', // hover
+          800: '#8A1B1F', // pressed
+          900: '#6B1212', // legacy HF burgundy (dark accents)
+          950: '#4F0E0E', // legacy HF band burgundy
         },
-        // HF One gold — 100/300/500/600/700 are exact spec tokens;
-        // 50/200/400/800/900 are interpolated for scale completeness.
+        // HF One gold — tier "jewellery" only (Gold tier chips, highlights).
         gold: {
           50: '#FCF4E3',
           100: '#F6EACB',
@@ -52,10 +40,69 @@ export default {
           800: '#6E4E17',
           900: '#4A340F',
         },
+        // Warm surfaces (HF One: neutrals are warm, never slate/gray).
+        surface: {
+          page: '#FAF9F7',   // app background
+          card: '#FFFFFF',   // cards, panels
+          sunken: '#F4F1ED', // parchment wells, table headers
+        },
+        ink: {
+          DEFAULT: '#26221E', // primary text (warm near-black)
+          muted: '#7A7268',   // secondary text
+          faint: '#A8A29E',   // placeholders, disabled
+        },
+        hairline: {
+          DEFAULT: '#E8E4DF', // default borders
+          strong: '#CFC9C1',  // inputs, dividers that must read
+        },
+        // Warm near-black tile surfaces — design accents (hero, member card).
+        tile: {
+          DEFAULT: '#211D1A',
+          raised: '#2C2724',
+          border: '#3A342F',
+          text: '#F4F1ED',
+          muted: '#A8A199',
+        },
+        success: { 50: '#EAF4EE', 600: '#2F855A', 700: '#276749' },
+        warning: { 50: '#FBF3E4', 600: '#B7791F', 700: '#975A16' },
+        error: { 50: '#FBEBEB', 600: '#C53030', 700: '#9B2C2C' },
+        info: { 50: '#EBF1F7', 600: '#2C5282', 700: '#24436A' },
       },
       fontFamily: {
         sans: ['Sarabun', '"Noto Sans Thai"', 'system-ui', 'sans-serif'],
       },
+      // Named type scale. Display sizes carry weight 600 and slight negative
+      // tracking; body is 17px at 1.6 line-height (Thai vowel marks clip
+      // below ~1.5, so Apple's 1.47 is deliberately relaxed here).
+      fontSize: {
+        fine: ['0.75rem', { lineHeight: '1.5' }],                                                     // 12
+        caption: ['0.875rem', { lineHeight: '1.5' }],                                                 // 14
+        body: ['1.0625rem', { lineHeight: '1.6' }],                                                   // 17
+        title: ['1.375rem', { lineHeight: '1.45', letterSpacing: '-0.01em', fontWeight: '600' }],     // 22
+        display: ['1.75rem', { lineHeight: '1.35', letterSpacing: '-0.015em', fontWeight: '600' }],   // 28
+        'display-lg': ['2.125rem', { lineHeight: '1.3', letterSpacing: '-0.015em', fontWeight: '600' }], // 34
+        'display-xl': ['2.5rem', { lineHeight: '1.3', letterSpacing: '-0.02em', fontWeight: '600' }], // 40
+        hero: ['3.5rem', { lineHeight: '1.25', letterSpacing: '-0.02em', fontWeight: '600' }],        // 56
+      },
+      borderRadius: {
+        card: '1.125rem', // 18px — cards. Utility radius = stock rounded-lg (8px); CTAs = rounded-full.
+      },
+      spacing: {
+        5.5: '1.375rem', // 22px — pill button horizontal padding
+      },
+      maxWidth: {
+        text: '61.25rem', // 980px — prose, forms
+        page: '80rem',    // 1280px — guest grids, admin default
+        wide: '90rem',    // 1440px — widest admin tables
+      },
+    },
+    // Hard override (not extend): exactly two elevations exist. Legacy
+    // shadow-sm/md/lg/xl classes become silent no-ops — the near-flat look
+    // comes from hairline borders and surface-color changes instead.
+    boxShadow: {
+      none: 'none',
+      soft: '0 12px 32px rgb(38 34 30 / 0.16)', // imagery-like elements only (QR member card)
+      pop: '0 8px 24px rgb(38 34 30 / 0.14)',   // popovers / centered modals only
     },
   },
   plugins: [

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -51,7 +51,7 @@ export default defineConfig({
         name: 'Hotel Loyalty App',
         short_name: 'Loyalty',
         description: 'Hotel Loyalty Program Management',
-        theme_color: '#8B0000',
+        theme_color: '#FAF9F7',
         background_color: '#ffffff',
         display: 'standalone',
         start_url: '/',


### PR DESCRIPTION
## Summary

First PR of the UI overhaul train (Apple design grammar × HF brand, palette derived from the hotel logo — plan approved in-session). **Stacked on #290** (`feat/line-oa-pms-channel`); retarget to `main` after that merges.

- **Crimson brand ramp** built around the logo red `#D4272E` at `brand-600`, converging onto the legacy HF burgundy at the dark end; the duplicate `primary-*` alias is renamed away (125 sites incl. tests) and its config key deleted
- **New tokens**: warm surfaces (`surface.page/card/sunken`), `ink.*`, `hairline.*`, warm near-black `tile.*`, semantic status colors, a named type scale with baked weight/tracking (`text-body/title/display/-lg/-xl/hero`), `rounded-card` (18px), `max-w-text/page/wide`
- **Shadow system collapsed** to `{soft, pop}` via hard override — the ~300 legacy `shadow-*` call sites become no-ops (instant near-flat look), to be swept as pages migrate
- **Font loading fixed**: removes duplicate Sarabun `@import` + the 9-weight Noto Sans Thai payload
- **Design ratchet** (`scripts/check-design.cjs`, wired into `lint`): banned patterns fail only on count increases vs a committed baseline; `primary-alias` and `cool-grays` start as hard walls at 0
- `theme-color` → parchment `#FAF9F7` everywhere

## Test plan

- [x] `npm run lint` (incl. new ratchet) — 0 errors
- [x] `npm run typecheck`
- [x] `npm run test` — 55 files / 1987 tests green
- [x] `npm run build` — PWA build OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)