### PR TITLE
feat(frontend): UI overhaul PR2 — core primitives (Button/Card/Badge/Skeleton)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
         "react-i18next": "^16.5.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.15.0",
+        "tailwind-merge": "^3.6.0",
         "zod": "^4.1.13",
         "zustand": "^4.4.7"
       },
@@ -10742,6 +10743,16 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -43,6 +43,7 @@
     "react-i18next": "^16.5.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.15.0",
+    "tailwind-merge": "^3.6.0",
     "zod": "^4.1.13",
     "zustand": "^4.4.7"
   },

--- a/frontend/src/components/ui/Badge.tsx
+++ b/frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,41 @@
+import type { HTMLAttributes, ReactNode } from 'react';
+import { cn } from './cn';
+
+export type BadgeTone = 'neutral' | 'brand' | 'gold' | 'success' | 'warning' | 'error' | 'info';
+export type BadgeSize = 'sm' | 'md';
+
+export type BadgeProps = {
+  tone?: BadgeTone;
+  size?: BadgeSize;
+  className?: string;
+  children: ReactNode;
+} & HTMLAttributes<HTMLSpanElement>;
+
+const BASE_CLASSES = 'inline-flex items-center gap-1 rounded-full font-semibold whitespace-nowrap';
+
+const SIZE_CLASSES: Record<BadgeSize, string> = {
+  sm: 'px-2.5 py-0.5 text-fine',
+  md: 'px-3 py-1 text-caption',
+};
+
+const TONE_CLASSES: Record<BadgeTone, string> = {
+  neutral: 'bg-surface-sunken text-ink-muted',
+  brand: 'bg-brand-50 text-brand-700',
+  gold: 'bg-gold-100 text-gold-700',
+  success: 'bg-success-50 text-success-700',
+  warning: 'bg-warning-50 text-warning-700',
+  error: 'bg-error-50 text-error-700',
+  info: 'bg-info-50 text-info-700',
+};
+
+export function Badge({ tone = 'neutral', size = 'md', className, children, ...rest }: BadgeProps) {
+  return (
+    <span
+      data-tone={tone}
+      className={cn(BASE_CLASSES, SIZE_CLASSES[size], TONE_CLASSES[tone], className)}
+      {...rest}
+    >
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,95 @@
+import type { ComponentPropsWithoutRef, Ref } from 'react';
+import { cn } from './cn';
+
+export type ButtonVariant = 'primary' | 'secondary' | 'utility' | 'destructive' | 'ghost';
+export type ButtonSize = 'md' | 'sm' | 'icon';
+
+export type ButtonProps = ComponentPropsWithoutRef<'button'> & {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  loading?: boolean;
+  ref?: Ref<HTMLButtonElement>;
+};
+
+const BASE_CLASSES =
+  'inline-flex items-center justify-center gap-2 font-semibold transition select-none active:scale-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none';
+
+const VARIANT_CLASSES: Record<ButtonVariant, string> = {
+  primary: 'rounded-full bg-brand-600 text-white hover:bg-brand-700',
+  secondary: 'rounded-full border border-brand-600 text-brand-700 bg-transparent hover:bg-brand-50',
+  utility: 'rounded-lg bg-tile text-tile-text hover:bg-tile-raised',
+  destructive: 'rounded-full bg-error-600 text-white hover:bg-error-700',
+  ghost: 'rounded-full text-brand-700 hover:bg-brand-50',
+};
+
+const SIZE_CLASSES: Record<ButtonSize, string> = {
+  md: 'h-11 px-5.5 text-body',
+  sm: 'h-9 px-4 text-caption',
+  icon: 'h-11 w-11 p-0',
+};
+
+type ButtonVariantsOptions = {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  className?: string;
+};
+
+/**
+ * Returns the class string for a given variant/size combination without
+ * rendering a `<button>` — lets non-button elements (e.g. react-router
+ * `<Link>`) look like a button.
+ */
+export function buttonVariants({
+  variant = 'primary',
+  size = 'md',
+  className,
+}: ButtonVariantsOptions = {}): string {
+  return cn(BASE_CLASSES, VARIANT_CLASSES[variant], SIZE_CLASSES[size], className);
+}
+
+function ButtonSpinner() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="h-4 w-4 animate-spin"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  );
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  loading = false,
+  type = 'button',
+  className,
+  disabled,
+  children,
+  ref,
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      ref={ref}
+      type={type}
+      data-variant={variant}
+      data-size={size}
+      aria-busy={loading || undefined}
+      disabled={loading || disabled}
+      className={buttonVariants({ variant, size, className })}
+      {...rest}
+    >
+      {loading ? <ButtonSpinner /> : null}
+      {children}
+    </button>
+  );
+}

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -1,0 +1,49 @@
+import type { ElementType, HTMLAttributes, ReactNode } from 'react';
+import { cn } from './cn';
+
+export type CardSurface = 'card' | 'sunken' | 'tile';
+export type CardPadding = 'md' | 'lg' | 'none';
+export type CardElement = 'div' | 'section' | 'article';
+
+export type CardProps = {
+  surface?: CardSurface;
+  padding?: CardPadding;
+  as?: CardElement;
+  className?: string;
+  children: ReactNode;
+} & HTMLAttributes<HTMLElement>;
+
+const BASE_CLASSES = 'rounded-card border';
+
+// Flat, always — surfaces read via border + surface color only (no elevation).
+const SURFACE_CLASSES: Record<CardSurface, string> = {
+  card: 'bg-surface-card border-hairline',
+  sunken: 'bg-surface-sunken border-transparent',
+  tile: 'bg-tile text-tile-text border-tile-border',
+};
+
+const PADDING_CLASSES: Record<CardPadding, string> = {
+  md: 'p-6',
+  lg: 'p-8',
+  none: '',
+};
+
+export function Card({
+  surface = 'card',
+  padding = 'md',
+  as: Component = 'div',
+  className,
+  children,
+  ...rest
+}: CardProps) {
+  const Tag = Component as ElementType;
+  return (
+    <Tag
+      data-surface={surface}
+      className={cn(BASE_CLASSES, SURFACE_CLASSES[surface], PADDING_CLASSES[padding], className)}
+      {...rest}
+    >
+      {children}
+    </Tag>
+  );
+}

--- a/frontend/src/components/ui/README.md
+++ b/frontend/src/components/ui/README.md
@@ -1,0 +1,84 @@
+# UI primitives
+
+Core design-system building blocks: `Button`, `Card`, `Badge`, `Skeleton`,
+plus the `cn()` class-merge helper. Everything here composes the tokens
+from `tailwind.config.js` (PR1) — it does not introduce new colors, radii,
+shadows, or type sizes of its own.
+
+## Token grammar recap
+
+These rules are enforced by `scripts/check-design.cjs`, wired into
+`npm run lint`. New off-system styling fails CI; existing debt is
+grandfathered via `scripts/design-baseline.json` (never edit that file
+upward — only ratchet it down with `--update` as pages migrate).
+
+- **Color** — one accent (`brand-*`), warm neutrals only
+  (`surface.page/card/sunken`, `ink.*`, `hairline.*`, `tile.*`), plus the
+  semantic set `success/warning/error/info`. No `gray-`/`slate-`/`zinc-`/
+  `neutral-`, no hardcoded hex literals.
+- **Weight** — `font-semibold` (600) and `font-bold` (700) only.
+  `font-medium` (500) and `font-extrabold` (800) are banned; the ladder
+  doesn't include those steps.
+- **Radii** — `rounded-lg` (8px, utility surfaces), `rounded-card` (18px,
+  cards), `rounded-full` (pills, avatars). `rounded-md/xl/2xl/3xl` are
+  off-grammar.
+- **Shadows** — `shadow-soft` and `shadow-pop` are the only two
+  elevations (imagery/QR card, and popovers/centered modals,
+  respectively). Legacy `shadow`/`shadow-sm/md/lg/xl/2xl/inner` are
+  hard-overridden to no-ops — don't reach for them.
+- **Type** — the named scale only: `text-fine/caption/body/title/
+  display/display-lg/display-xl/hero`. Never `text-3xl`-style raw sizes.
+- **Spacing** — the base Tailwind scale plus `5.5` (22px, pill button
+  horizontal padding). Prefer the primitives below over hand-rolled
+  padding/radius/shadow combinations.
+
+## Primitives
+
+| Component  | Purpose                                   | Key props |
+|------------|--------------------------------------------|-----------|
+| `Button`   | Actions, in five variants + three sizes    | `variant`, `size`, `loading` |
+| `buttonVariants()` | Class string only — for non-`<button>` elements (e.g. `<Link>`) that must look like a button | `variant`, `size`, `className` |
+| `Card`     | Grouped content on `card`/`sunken`/`tile` surfaces | `surface`, `padding`, `as` |
+| `Badge`    | Small status/tier pill                     | `tone`, `size` |
+| `Skeleton` | Loading placeholder                        | `className` |
+
+Every primitive stamps a `data-*` attribute matching its variant prop
+(`data-variant`, `data-size`, `data-surface`, `data-tone`) so tests and
+downstream styling can hook off state without parsing class strings.
+
+`Card` and `Button` never render a shadow — flat surfaces read via
+border + surface-color changes only, per the grammar above.
+
+## Grid collapse conventions
+
+Use these breakpoints consistently so pages built from these primitives
+collapse the same way:
+
+- **Card grids** (dashboards, listing pages):
+  `grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`
+- **Stat tiles** (KPI rows):
+  `grid-cols-2 lg:grid-cols-4`
+- **Forms** (label/field pairs, settings panels):
+  `grid-cols-1 md:grid-cols-2`
+
+## Test doctrine
+
+Tests in `__tests__/` follow these rules:
+
+- Assert **roles and accessible names** (`getByRole('button', { name: ... })`),
+  not implementation details.
+- Assert **`data-variant` / `data-size` / `data-surface` / `data-tone`**
+  attributes to pin down variant behavior.
+- Assert **disabled state** (`toBeDisabled()`) and **`aria-busy`** when
+  `Button` is `loading`.
+- The `loading` spinner must be **invisible to the accessibility tree**
+  (`aria-hidden="true"`, no competing accessible name/role) — the
+  button's accessible name must still resolve to its children only.
+- **Do not assert raw Tailwind class strings** anywhere except the one
+  `buttonVariants()` merge sanity test, which exists specifically to
+  confirm the `tailwind-merge` integration resolves conflicting
+  utilities (e.g. a caller's `className` overriding a size's padding)
+  down to a single winner instead of emitting both.
+- Caller-supplied `className` passthrough is tested with a plain,
+  non-Tailwind marker class (e.g. `"promo-card-marker"`) — that's
+  testing prop wiring, not the design system's token grammar.

--- a/frontend/src/components/ui/Skeleton.tsx
+++ b/frontend/src/components/ui/Skeleton.tsx
@@ -1,0 +1,9 @@
+import { cn } from './cn';
+
+export type SkeletonProps = {
+  className?: string;
+};
+
+export function Skeleton({ className }: SkeletonProps) {
+  return <div aria-hidden="true" className={cn('animate-pulse rounded-lg bg-surface-sunken', className)} />;
+}

--- a/frontend/src/components/ui/__tests__/Badge.test.tsx
+++ b/frontend/src/components/ui/__tests__/Badge.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Badge } from '../Badge';
+import type { BadgeSize, BadgeTone } from '../Badge';
+
+describe('Badge', () => {
+  it('should render its children as visible text', () => {
+    render(<Badge>Gold tier</Badge>);
+
+    expect(screen.getByText('Gold tier')).toBeInTheDocument();
+  });
+
+  it('should render a <span> element', () => {
+    render(<Badge>Gold tier</Badge>);
+
+    expect(screen.getByText('Gold tier').tagName).toBe('SPAN');
+  });
+
+  it('should default to tone="neutral"', () => {
+    render(<Badge>Default</Badge>);
+
+    expect(screen.getByText('Default')).toHaveAttribute('data-tone', 'neutral');
+  });
+
+  const tones: BadgeTone[] = ['neutral', 'brand', 'gold', 'success', 'warning', 'error', 'info'];
+  it.each(tones)('should stamp data-tone="%s" when tone is set', (tone) => {
+    render(<Badge tone={tone}>{tone}</Badge>);
+
+    expect(screen.getByText(tone)).toHaveAttribute('data-tone', tone);
+  });
+
+  const sizes: BadgeSize[] = ['sm', 'md'];
+  it.each(sizes)('should render without error at size="%s"', (size) => {
+    render(<Badge size={size}>{size}</Badge>);
+
+    expect(screen.getByText(size)).toBeInTheDocument();
+  });
+
+  it('should merge a caller-supplied className onto the rendered element', () => {
+    render(<Badge className="badge-marker">Tagged</Badge>);
+
+    expect(screen.getByText('Tagged')).toHaveClass('badge-marker');
+  });
+
+  it('should forward arbitrary HTML attributes', () => {
+    render(<Badge data-testid="tier-badge">Gold</Badge>);
+
+    expect(screen.getByTestId('tier-badge')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ui/__tests__/Button.test.tsx
+++ b/frontend/src/components/ui/__tests__/Button.test.tsx
@@ -1,0 +1,142 @@
+import { createRef } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Button, buttonVariants } from '../Button';
+import type { ButtonSize, ButtonVariant } from '../Button';
+
+describe('Button', () => {
+  it('should render a button with an accessible name from its children', () => {
+    render(<Button>Save changes</Button>);
+
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+  });
+
+  it('should default to type="button" so it never submits a surrounding form', () => {
+    render(<Button>Click me</Button>);
+
+    expect(screen.getByRole('button', { name: 'Click me' })).toHaveAttribute('type', 'button');
+  });
+
+  it('should respect an explicit type override', () => {
+    render(<Button type="submit">Submit</Button>);
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toHaveAttribute('type', 'submit');
+  });
+
+  it('should default to the primary variant and md size', () => {
+    render(<Button>Default</Button>);
+
+    const button = screen.getByRole('button', { name: 'Default' });
+    expect(button).toHaveAttribute('data-variant', 'primary');
+    expect(button).toHaveAttribute('data-size', 'md');
+  });
+
+  const variants: ButtonVariant[] = ['primary', 'secondary', 'utility', 'destructive', 'ghost'];
+  it.each(variants)('should stamp data-variant="%s" when variant is set', (variant) => {
+    render(<Button variant={variant}>{variant}</Button>);
+
+    expect(screen.getByRole('button', { name: variant })).toHaveAttribute('data-variant', variant);
+  });
+
+  const sizes: ButtonSize[] = ['md', 'sm', 'icon'];
+  it.each(sizes)('should stamp data-size="%s" when size is set', (size) => {
+    render(<Button size={size}>{size}</Button>);
+
+    expect(screen.getByRole('button', { name: size })).toHaveAttribute('data-size', size);
+  });
+
+  it('should call onClick when activated', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<Button onClick={handleClick}>Go</Button>);
+
+    await user.click(screen.getByRole('button', { name: 'Go' }));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be disabled and not fire onClick when disabled is set', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Button disabled onClick={handleClick}>
+        Go
+      </Button>
+    );
+
+    const button = screen.getByRole('button', { name: 'Go' });
+    expect(button).toBeDisabled();
+
+    await user.click(button);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('should forward a ref to the underlying button element', () => {
+    const ref = createRef<HTMLButtonElement>();
+    render(<Button ref={ref}>Ref target</Button>);
+
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+    expect(ref.current).toBe(screen.getByRole('button', { name: 'Ref target' }));
+  });
+
+  describe('loading state', () => {
+    it('should set aria-busy and disable the button while loading', () => {
+      render(<Button loading>Saving</Button>);
+
+      const button = screen.getByRole('button', { name: 'Saving' });
+      expect(button).toHaveAttribute('aria-busy', 'true');
+      expect(button).toBeDisabled();
+    });
+
+    it('should not set aria-busy when not loading', () => {
+      render(<Button>Saving</Button>);
+
+      expect(screen.getByRole('button', { name: 'Saving' })).not.toHaveAttribute('aria-busy');
+    });
+
+    it('should render a spinner that is hidden from the accessibility tree', () => {
+      const { container } = render(<Button loading>Saving</Button>);
+
+      const spinner = container.querySelector('svg');
+      expect(spinner).toBeTruthy();
+      expect(spinner).toHaveAttribute('aria-hidden', 'true');
+      // The spinner must not introduce its own accessible name or role —
+      // the button's accessible name should still come from its children only.
+      expect(screen.queryByRole('img')).not.toBeInTheDocument();
+      expect(screen.getByRole('button')).toHaveAccessibleName('Saving');
+    });
+
+    it('should disable the button even if disabled=false is explicitly passed while loading', () => {
+      render(
+        <Button loading disabled={false}>
+          Saving
+        </Button>
+      );
+
+      expect(screen.getByRole('button', { name: 'Saving' })).toBeDisabled();
+    });
+  });
+
+  describe('buttonVariants', () => {
+    it('should return a class string usable outside of a <button> (e.g. react-router Link)', () => {
+      const classes = buttonVariants({ variant: 'secondary', size: 'sm' });
+
+      expect(typeof classes).toBe('string');
+      expect(classes.length).toBeGreaterThan(0);
+    });
+
+    it('should default to primary/md when called with no arguments', () => {
+      expect(buttonVariants()).toBe(buttonVariants({ variant: 'primary', size: 'md' }));
+    });
+
+    it('should let an incoming className win over a conflicting size utility (tailwind-merge sanity check)', () => {
+      const classes = buttonVariants({ size: 'md', className: 'px-10' });
+      const pxUtilities = classes.split(' ').filter((cls) => /^px-/.test(cls));
+
+      // size:"md" contributes `px-5.5`; the caller's `px-10` must win and the
+      // conflicting utility must not survive alongside it.
+      expect(pxUtilities).toEqual(['px-10']);
+    });
+  });
+});

--- a/frontend/src/components/ui/__tests__/Card.test.tsx
+++ b/frontend/src/components/ui/__tests__/Card.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Card } from '../Card';
+import type { CardSurface } from '../Card';
+
+describe('Card', () => {
+  it('should render its children', () => {
+    render(<Card>Card content</Card>);
+
+    expect(screen.getByText('Card content')).toBeInTheDocument();
+  });
+
+  it('should render a <div> by default', () => {
+    render(<Card>Content</Card>);
+
+    expect(screen.getByText('Content').tagName).toBe('DIV');
+  });
+
+  it('should render a <section> when as="section"', () => {
+    render(<Card as="section">Content</Card>);
+
+    expect(screen.getByText('Content').tagName).toBe('SECTION');
+  });
+
+  it('should render an <article> when as="article"', () => {
+    render(<Card as="article">Content</Card>);
+
+    expect(screen.getByText('Content').tagName).toBe('ARTICLE');
+  });
+
+  it('should default to data-surface="card"', () => {
+    render(<Card>Content</Card>);
+
+    expect(screen.getByText('Content')).toHaveAttribute('data-surface', 'card');
+  });
+
+  const surfaces: CardSurface[] = ['card', 'sunken', 'tile'];
+  it.each(surfaces)('should stamp data-surface="%s" when surface is set', (surface) => {
+    render(<Card surface={surface}>{surface}</Card>);
+
+    expect(screen.getByText(surface)).toHaveAttribute('data-surface', surface);
+  });
+
+  it('should forward arbitrary HTML attributes and event handlers', () => {
+    render(
+      <Card id="promo-card" data-testid="promo">
+        Content
+      </Card>
+    );
+
+    const card = screen.getByTestId('promo');
+    expect(card).toHaveAttribute('id', 'promo-card');
+  });
+
+  it('should merge a caller-supplied className onto the rendered element', () => {
+    render(<Card className="promo-card-marker">Content</Card>);
+
+    expect(screen.getByText('Content')).toHaveClass('promo-card-marker');
+  });
+});

--- a/frontend/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/frontend/src/components/ui/__tests__/Skeleton.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { Skeleton } from '../Skeleton';
+
+describe('Skeleton', () => {
+  it('should render a div hidden from the accessibility tree', () => {
+    const { container } = render(<Skeleton />);
+
+    const skeleton = container.firstChild as HTMLElement;
+    expect(skeleton.tagName).toBe('DIV');
+    expect(skeleton).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should expose no accessible role, since it is a decorative placeholder', () => {
+    const { container } = render(<Skeleton />);
+
+    // aria-hidden elements are pulled out of the accessibility tree entirely.
+    expect(container.querySelector('[role]')).not.toBeInTheDocument();
+  });
+
+  it('should merge a caller-supplied className onto the rendered element', () => {
+    const { container } = render(<Skeleton className="skeleton-marker" />);
+
+    const skeleton = container.firstChild as HTMLElement;
+    expect(skeleton).toHaveClass('skeleton-marker');
+  });
+});

--- a/frontend/src/components/ui/__tests__/cn.test.ts
+++ b/frontend/src/components/ui/__tests__/cn.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { cn } from '../cn';
+
+describe('cn', () => {
+  it('should join plain string arguments with a single space', () => {
+    expect(cn('foo', 'bar')).toBe('foo bar');
+  });
+
+  it('should drop falsy values (undefined, null, false, empty string)', () => {
+    expect(cn('foo', undefined, null, false, '', 'bar')).toBe('foo bar');
+  });
+
+  it('should include class names gated by a truthy condition', () => {
+    const isActive = true;
+    expect(cn('base', isActive && 'active')).toBe('base active');
+  });
+
+  it('should exclude class names gated by a falsy condition', () => {
+    const isActive = false;
+    expect(cn('base', isActive && 'active')).toBe('base');
+  });
+
+  it('should flatten arrays of class values', () => {
+    expect(cn(['foo', 'bar'], 'baz')).toBe('foo bar baz');
+  });
+
+  it('should return an empty string when given no meaningful input', () => {
+    expect(cn(undefined, null, false)).toBe('');
+  });
+});

--- a/frontend/src/components/ui/cn.ts
+++ b/frontend/src/components/ui/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -1,0 +1,13 @@
+export { cn } from './cn';
+
+export { Button, buttonVariants } from './Button';
+export type { ButtonProps, ButtonVariant, ButtonSize } from './Button';
+
+export { Card } from './Card';
+export type { CardProps, CardSurface, CardPadding, CardElement } from './Card';
+
+export { Badge } from './Badge';
+export type { BadgeProps, BadgeTone, BadgeSize } from './Badge';
+
+export { Skeleton } from './Skeleton';
+export type { SkeletonProps } from './Skeleton';


### PR DESCRIPTION
## Summary

Stacked on #291 (UI overhaul PR1 — crimson design tokens + type scale + ratchet). Adds the core design-system primitives that downstream page migrations will build on:

- `cn()` — `clsx` + `tailwind-merge` class-composition helper (new dep: `tailwind-merge`).
- `Button` — 5 variants (`primary`/`secondary`/`utility`/`destructive`/`ghost`) × 3 sizes (`md`/`sm`/`icon`), `loading` state (spinner + `aria-busy` + disabled). Also exports `buttonVariants()` so non-`<button>` elements (e.g. `react-router` `<Link>`) can look like a button without `asChild`/`Slot`.
- `Card` — `surface` (`card`/`sunken`/`tile`) × `padding` (`md`/`lg`/`none`), polymorphic `as` (`div`/`section`/`article`). Never renders a shadow.
- `Badge` — `tone` (`neutral`/`brand`/`gold`/`success`/`warning`/`error`/`info`) × `size` (`sm`/`md`).
- `Skeleton` — `aria-hidden` loading placeholder.

All five compose PR1's tokens only (`brand-*`, `surface.*`, `ink.*`, `hairline.*`, `tile.*`, semantic colors, the named type scale, `rounded-card`/`rounded-lg`/`rounded-full`, spacing `5.5`) — no new colors/radii/shadows/type sizes introduced. Every primitive stamps a `data-variant`/`data-size`/`data-surface`/`data-tone` attribute for tests and downstream styling to hook off state without parsing class strings.

`frontend/src/components/ui/README.md` recaps the token grammar, the grid-collapse conventions for card grids / stat tiles / forms, and the test doctrine below.

## Test plan

- [x] `cd frontend && npm run lint` — ESLint clean (0 errors; pre-existing warnings elsewhere untouched) + design ratchet (`scripts/check-design.cjs`) passes with **no baseline changes** (`design-baseline.json` untouched).
- [x] `npm run typecheck` — clean.
- [x] `npm run test` — **2042 passed** (60 files), up from the pre-existing 1987 (55 new tests added across `cn`/`Button`/`Card`/`Badge`/`Skeleton`); zero regressions.
- [x] `npm run build` — succeeds.
- [x] New tests assert roles/accessible names, `data-variant`/`data-size`/`data-surface`/`data-tone`, disabled state, `aria-busy` while loading, and that the loading spinner is excluded from the accessibility tree (`aria-hidden`, no competing role/name). Raw Tailwind class strings are asserted only in the one `buttonVariants()` merge-sanity test (confirms `tailwind-merge` resolves a conflicting `className` vs. a size's padding down to a single winner) — everywhere else, `className` passthrough is tested with a plain non-Tailwind marker class.

## Exported API

```ts
// Button.tsx
export type ButtonVariant = 'primary' | 'secondary' | 'utility' | 'destructive' | 'ghost';
export type ButtonSize = 'md' | 'sm' | 'icon';
export type ButtonProps = ComponentPropsWithoutRef<'button'> & {
  variant?: ButtonVariant;   // default 'primary'
  size?: ButtonSize;         // default 'md'
  loading?: boolean;
  ref?: Ref<HTMLButtonElement>;
};
export function buttonVariants(opts?: { variant?: ButtonVariant; size?: ButtonSize; className?: string }): string;
export function Button(props: ButtonProps): JSX.Element;

// Card.tsx
export type CardSurface = 'card' | 'sunken' | 'tile';
export type CardPadding = 'md' | 'lg' | 'none';
export type CardElement = 'div' | 'section' | 'article';
export type CardProps = {
  surface?: CardSurface;   // default 'card'
  padding?: CardPadding;   // default 'md'
  as?: CardElement;        // default 'div'
  className?: string;
  children: ReactNode;
} & HTMLAttributes<HTMLElement>;
export function Card(props: CardProps): JSX.Element;

// Badge.tsx
export type BadgeTone = 'neutral' | 'brand' | 'gold' | 'success' | 'warning' | 'error' | 'info';
export type BadgeSize = 'sm' | 'md';
export type BadgeProps = {
  tone?: BadgeTone;   // default 'neutral'
  size?: BadgeSize;   // default 'md'
  className?: string;
  children: ReactNode;
} & HTMLAttributes<HTMLSpanElement>;
export function Badge(props: BadgeProps): JSX.Element;

// Skeleton.tsx
export type SkeletonProps = { className?: string };
export function Skeleton(props: SkeletonProps): JSX.Element;

// cn.ts
export function cn(...inputs: ClassValue[]): string;
```

Barrel: `frontend/src/components/ui/index.ts` re-exports all of the above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)