### PR TITLE
feat(frontend): UI overhaul PR4 — Modal/Sheet primitive + ConfirmDialog rebuild

### DIFF
--- a/frontend/scripts/design-baseline.json
+++ b/frontend/scripts/design-baseline.json
@@ -2,9 +2,9 @@
   "primary-alias": 0,
   "cool-grays": 0,
   "font-extrabold": 4,
-  "font-medium": 550,
-  "legacy-shadows": 312,
-  "off-grammar-radii": 313,
+  "font-medium": 547,
+  "legacy-shadows": 301,
+  "off-grammar-radii": 310,
   "oversized-titles": 33,
   "hardcoded-hex": 82
 }

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react';
-import { createPortal } from 'react-dom';
+import { useRef } from 'react';
+import { Button, Modal } from '../ui';
 
 interface ConfirmDialogProps {
   isOpen: boolean;
@@ -24,106 +24,31 @@ export function ConfirmDialog({
 }: ConfirmDialogProps) {
   const confirmButtonRef = useRef<HTMLButtonElement>(null);
 
-  useEffect(() => {
-    if (isOpen) {
-      // Focus the cancel button by default for safety (prevents accidental confirmations)
-      confirmButtonRef.current?.focus();
-    }
-  }, [isOpen]);
-
-  useEffect(() => {
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape' && isOpen) {
-        onCancel();
-      }
-    };
-
-    document.addEventListener('keydown', handleEscape);
-    return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen, onCancel]);
-
-  if (!isOpen) {
-    return null;
-  }
-
-  const variantStyles = {
-    danger: 'bg-red-600 hover:bg-red-700 focus:ring-red-500',
-    warning: 'bg-yellow-600 hover:bg-yellow-700 focus:ring-yellow-500',
-    info: 'bg-brand-600 hover:bg-brand-700 focus:ring-brand-500'
-  };
-
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 overflow-y-auto"
-      aria-labelledby="modal-title"
-      role="dialog"
-      aria-modal="true"
-    >
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 bg-stone-500 bg-opacity-75 transition-opacity"
-        onClick={onCancel}
-      />
-
-      {/* Dialog */}
-      <div className="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-        <div className="relative transform overflow-hidden rounded-lg bg-white text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg">
-          <div className="bg-white px-4 pb-4 pt-5 sm:p-6 sm:pb-4">
-            <div className="sm:flex sm:items-start">
-              <div
-                className={`mx-auto flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full sm:mx-0 sm:h-10 sm:w-10 ${
-                  variant === 'danger' ? 'bg-red-100' : variant === 'warning' ? 'bg-yellow-100' : 'bg-brand-100'
-                }`}
-              >
-                <svg
-                  className={`h-6 w-6 ${
-                    variant === 'danger' ? 'text-red-600' : variant === 'warning' ? 'text-yellow-600' : 'text-brand-600'
-                  }`}
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth="1.5"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126zM12 15.75h.007v.008H12v-.008z"
-                  />
-                </svg>
-              </div>
-              <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
-                <h3 className="text-base font-semibold leading-6 text-stone-900" id="modal-title">
-                  {title}
-                </h3>
-                <div className="mt-2">
-                  <p className="text-sm text-stone-500">
-                    {message}
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div className="bg-stone-50 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
-            <button
-              type="button"
-              ref={confirmButtonRef}
-              className={`inline-flex w-full justify-center rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm sm:ml-3 sm:w-auto focus:outline-none focus:ring-2 focus:ring-offset-2 ${variantStyles[variant]}`}
-              onClick={onConfirm}
-            >
-              {confirmText}
-            </button>
-            <button
-              type="button"
-              className="mt-3 inline-flex w-full justify-center rounded-md bg-white px-3 py-2 text-sm font-semibold text-stone-900 shadow-sm ring-1 ring-inset ring-stone-300 hover:bg-stone-50 sm:mt-0 sm:w-auto"
-              onClick={onCancel}
-            >
-              {cancelText}
-            </button>
-          </div>
+  return (
+    <Modal
+      open={isOpen}
+      onClose={onCancel}
+      mobilePresentation="center"
+      size="sm"
+      title={title}
+      initialFocusRef={confirmButtonRef}
+      footer={
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="secondary" onClick={onCancel}>
+            {cancelText}
+          </Button>
+          <Button
+            type="button"
+            variant={variant === 'danger' ? 'destructive' : 'primary'}
+            ref={confirmButtonRef}
+            onClick={onConfirm}
+          >
+            {confirmText}
+          </Button>
         </div>
-      </div>
-    </div>,
-    document.body
+      }
+    >
+      <p>{message}</p>
+    </Modal>
   );
 }

--- a/frontend/src/components/common/__tests__/ConfirmDialog.test.tsx
+++ b/frontend/src/components/common/__tests__/ConfirmDialog.test.tsx
@@ -68,7 +68,10 @@ describe('ConfirmDialog', () => {
 
       const dialog = screen.getByRole('dialog');
       expect(dialog).toHaveAttribute('aria-modal', 'true');
-      expect(dialog).toHaveAttribute('aria-labelledby', 'modal-title');
+
+      const labelledBy = dialog.getAttribute('aria-labelledby');
+      expect(labelledBy).toBeTruthy();
+      expect(document.getElementById(labelledBy ?? '')).toHaveTextContent('Test Title');
     });
 
     it('should render via portal to document.body', () => {
@@ -128,7 +131,7 @@ describe('ConfirmDialog', () => {
       ).toBeInTheDocument();
     });
 
-    it('should display title with correct id for ARIA', () => {
+    it('should label the dialog with the title via aria-labelledby', () => {
       const mockOnConfirm = vi.fn();
       const mockOnCancel = vi.fn();
 
@@ -142,8 +145,11 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const title = screen.getByText('Test Title');
-      expect(title).toHaveAttribute('id', 'modal-title');
+      const dialog = screen.getByRole('dialog');
+      const labelledBy = dialog.getAttribute('aria-labelledby');
+      const titleElement = screen.getByText('Test Title');
+
+      expect(titleElement).toHaveAttribute('id', labelledBy);
     });
   });
 
@@ -162,7 +168,7 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      expect(screen.getByText('Confirm')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Confirm' })).toBeInTheDocument();
     });
 
     it('should render default cancel button text', () => {
@@ -179,7 +185,7 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      expect(screen.getByText('Cancel')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
     });
 
     it('should render custom confirm button text', () => {
@@ -197,8 +203,8 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      expect(screen.getByText('Delete Now')).toBeInTheDocument();
-      expect(screen.queryByText('Confirm')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Delete Now' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Confirm' })).not.toBeInTheDocument();
     });
 
     it('should render custom cancel button text', () => {
@@ -216,8 +222,8 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      expect(screen.getByText('Go Back')).toBeInTheDocument();
-      expect(screen.queryByText('Cancel')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Go Back' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Cancel' })).not.toBeInTheDocument();
     });
 
     it('should render both custom button texts', () => {
@@ -236,8 +242,8 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      expect(screen.getByText('Yes, Delete')).toBeInTheDocument();
-      expect(screen.getByText('No, Keep It')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Yes, Delete' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'No, Keep It' })).toBeInTheDocument();
     });
   });
 
@@ -257,7 +263,7 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const confirmButton = screen.getByText('Confirm');
+      const confirmButton = screen.getByRole('button', { name: 'Confirm' });
       await user.click(confirmButton);
 
       expect(mockOnConfirm).toHaveBeenCalledTimes(1);
@@ -279,7 +285,7 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const cancelButton = screen.getByText('Cancel');
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
       await user.click(cancelButton);
 
       expect(mockOnCancel).toHaveBeenCalledTimes(1);
@@ -301,8 +307,7 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      // Find the backdrop (the gray overlay)
-      const backdrop = document.querySelector('.bg-stone-500.bg-opacity-75') as HTMLElement;
+      const backdrop = screen.getByRole('dialog').parentElement as HTMLElement;
       expect(backdrop).toBeInTheDocument();
 
       await user.click(backdrop);
@@ -326,7 +331,7 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const confirmButton = screen.getByText('Confirm');
+      const confirmButton = screen.getByRole('button', { name: 'Confirm' });
       await user.click(confirmButton);
       await user.click(confirmButton);
       await user.click(confirmButton);
@@ -350,8 +355,8 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const confirmButton = screen.getByText('Confirm');
-      expect(confirmButton).toHaveClass('bg-yellow-600', 'hover:bg-yellow-700', 'focus:ring-yellow-500');
+      const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+      expect(confirmButton).toHaveAttribute('data-variant', 'primary');
     });
 
     it('should apply danger variant styling', () => {
@@ -369,8 +374,8 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const confirmButton = screen.getByText('Confirm');
-      expect(confirmButton).toHaveClass('bg-red-600', 'hover:bg-red-700', 'focus:ring-red-500');
+      const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+      expect(confirmButton).toHaveAttribute('data-variant', 'destructive');
     });
 
     it('should apply warning variant styling', () => {
@@ -388,8 +393,8 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const confirmButton = screen.getByText('Confirm');
-      expect(confirmButton).toHaveClass('bg-yellow-600', 'hover:bg-yellow-700', 'focus:ring-yellow-500');
+      const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+      expect(confirmButton).toHaveAttribute('data-variant', 'primary');
     });
 
     it('should apply info variant styling', () => {
@@ -407,65 +412,8 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const confirmButton = screen.getByText('Confirm');
-      expect(confirmButton).toHaveClass('bg-brand-600', 'hover:bg-brand-700', 'focus:ring-brand-500');
-    });
-
-    it('should apply danger icon background color', () => {
-      const mockOnConfirm = vi.fn();
-      const mockOnCancel = vi.fn();
-
-      render(
-        <ConfirmDialog
-          isOpen={true}
-          title="Test"
-          message="Test"
-          variant="danger"
-          onConfirm={mockOnConfirm}
-          onCancel={mockOnCancel}
-        />
-      );
-
-      const iconContainer = document.querySelector('.bg-red-100');
-      expect(iconContainer).toBeInTheDocument();
-    });
-
-    it('should apply warning icon background color', () => {
-      const mockOnConfirm = vi.fn();
-      const mockOnCancel = vi.fn();
-
-      render(
-        <ConfirmDialog
-          isOpen={true}
-          title="Test"
-          message="Test"
-          variant="warning"
-          onConfirm={mockOnConfirm}
-          onCancel={mockOnCancel}
-        />
-      );
-
-      const iconContainer = document.querySelector('.bg-yellow-100');
-      expect(iconContainer).toBeInTheDocument();
-    });
-
-    it('should apply info icon background color', () => {
-      const mockOnConfirm = vi.fn();
-      const mockOnCancel = vi.fn();
-
-      render(
-        <ConfirmDialog
-          isOpen={true}
-          title="Test"
-          message="Test"
-          variant="info"
-          onConfirm={mockOnConfirm}
-          onCancel={mockOnCancel}
-        />
-      );
-
-      const iconContainer = document.querySelector('.bg-brand-100');
-      expect(iconContainer).toBeInTheDocument();
+      const confirmButton = screen.getByRole('button', { name: 'Confirm' });
+      expect(confirmButton).toHaveAttribute('data-variant', 'primary');
     });
   });
 
@@ -495,7 +443,7 @@ describe('ConfirmDialog', () => {
       );
 
       await waitFor(() => {
-        const confirmButton = screen.getByText('Confirm');
+        const confirmButton = screen.getByRole('button', { name: 'Confirm' });
         expect(confirmButton).toHaveFocus();
       });
     });
@@ -515,7 +463,7 @@ describe('ConfirmDialog', () => {
       );
 
       await waitFor(() => {
-        const confirmButton = screen.getByText('Confirm');
+        const confirmButton = screen.getByRole('button', { name: 'Confirm' });
         expect(confirmButton).toHaveFocus();
       });
     });
@@ -600,7 +548,7 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const confirmButton = screen.getByText('Confirm');
+      const confirmButton = screen.getByRole('button', { name: 'Confirm' });
       confirmButton.focus();
       await user.keyboard('{Enter}');
 
@@ -622,7 +570,7 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const cancelButton = screen.getByText('Cancel');
+      const cancelButton = screen.getByRole('button', { name: 'Cancel' });
       cancelButton.focus();
       await user.keyboard('{Enter}');
 
@@ -721,11 +669,11 @@ describe('ConfirmDialog', () => {
 
       expect(screen.getByText('Delete Account')).toBeInTheDocument();
       expect(screen.getByText('This will permanently delete your account')).toBeInTheDocument();
-      expect(screen.getByText('Delete Permanently')).toBeInTheDocument();
-      expect(screen.getByText('Keep Account')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Delete Permanently' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Keep Account' })).toBeInTheDocument();
 
-      const confirmButton = screen.getByText('Delete Permanently');
-      expect(confirmButton).toHaveClass('bg-red-600');
+      const confirmButton = screen.getByRole('button', { name: 'Delete Permanently' });
+      expect(confirmButton).toHaveAttribute('data-variant', 'destructive');
     });
 
     it('should combine custom text with info variant', () => {
@@ -745,8 +693,8 @@ describe('ConfirmDialog', () => {
         />
       );
 
-      const confirmButton = screen.getByText('Update Now');
-      expect(confirmButton).toHaveClass('bg-brand-600');
+      const confirmButton = screen.getByRole('button', { name: 'Update Now' });
+      expect(confirmButton).toHaveAttribute('data-variant', 'primary');
     });
 
     it('should handle all props together', async () => {
@@ -770,8 +718,8 @@ describe('ConfirmDialog', () => {
       expect(screen.getByText('Confirm Logout')).toBeInTheDocument();
       expect(screen.getByText('You will be logged out of your account')).toBeInTheDocument();
 
-      const confirmButton = screen.getByText('Yes, Logout');
-      expect(confirmButton).toHaveClass('bg-yellow-600');
+      const confirmButton = screen.getByRole('button', { name: 'Yes, Logout' });
+      expect(confirmButton).toHaveAttribute('data-variant', 'primary');
 
       await user.click(confirmButton);
       expect(mockOnConfirm).toHaveBeenCalledTimes(1);
@@ -888,84 +836,7 @@ describe('ConfirmDialog', () => {
 
       // Buttons should still be clickable even with empty text
       const buttons = screen.getAllByRole('button');
-      expect(buttons).toHaveLength(2);
-    });
-  });
-
-  describe('Icon Display', () => {
-    it('should display warning icon', () => {
-      const mockOnConfirm = vi.fn();
-      const mockOnCancel = vi.fn();
-
-      render(
-        <ConfirmDialog
-          isOpen={true}
-          title="Test"
-          message="Test"
-          onConfirm={mockOnConfirm}
-          onCancel={mockOnCancel}
-        />
-      );
-
-      const icon = document.querySelector('svg[aria-hidden="true"]');
-      expect(icon).toBeInTheDocument();
-    });
-
-    it('should apply danger icon color', () => {
-      const mockOnConfirm = vi.fn();
-      const mockOnCancel = vi.fn();
-
-      render(
-        <ConfirmDialog
-          isOpen={true}
-          title="Test"
-          message="Test"
-          variant="danger"
-          onConfirm={mockOnConfirm}
-          onCancel={mockOnCancel}
-        />
-      );
-
-      const icon = document.querySelector('.text-red-600');
-      expect(icon).toBeInTheDocument();
-    });
-
-    it('should apply warning icon color', () => {
-      const mockOnConfirm = vi.fn();
-      const mockOnCancel = vi.fn();
-
-      render(
-        <ConfirmDialog
-          isOpen={true}
-          title="Test"
-          message="Test"
-          variant="warning"
-          onConfirm={mockOnConfirm}
-          onCancel={mockOnCancel}
-        />
-      );
-
-      const icon = document.querySelector('.text-yellow-600');
-      expect(icon).toBeInTheDocument();
-    });
-
-    it('should apply info icon color', () => {
-      const mockOnConfirm = vi.fn();
-      const mockOnCancel = vi.fn();
-
-      render(
-        <ConfirmDialog
-          isOpen={true}
-          title="Test"
-          message="Test"
-          variant="info"
-          onConfirm={mockOnConfirm}
-          onCancel={mockOnCancel}
-        />
-      );
-
-      const icon = document.querySelector('.text-brand-600');
-      expect(icon).toBeInTheDocument();
+      expect(buttons).toHaveLength(3); // header close button + confirm + cancel
     });
   });
 });

--- a/frontend/src/components/coupons/QRCodeModal.tsx
+++ b/frontend/src/components/coupons/QRCodeModal.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import QRCode from 'qrcode';
 import { logger } from '../../utils/logger';
 import { notify } from '../../utils/notificationManager';
+import { Modal } from '../ui';
 
 interface QRCodeModalProps {
   coupon: UserActiveCoupon;
@@ -57,26 +58,11 @@ const QRCodeModal: React.FC<QRCodeModalProps> = ({
     }
   };
 
+  const handleClose = onClose ?? (() => {});
 
   return (
-    <div className={`bg-white rounded-lg shadow-lg ${className}`}>
-      {/* Header */}
-      <div className="flex items-center justify-between p-4 border-b">
-        <h3 className="text-lg font-semibold text-stone-900">
-          {t('coupons.useCoupon')}
-        </h3>
-        {onClose && (
-          <button
-            onClick={onClose}
-            className="text-stone-400 hover:text-stone-600 text-xl font-bold"
-          >
-            ×
-          </button>
-        )}
-      </div>
-
-      {/* QR Code Content */}
-      <div className="p-6 text-center">
+    <Modal open onClose={handleClose} title={t('coupons.useCoupon')} size="sm">
+      <div data-testid="qr-code-content" className={`text-center ${className}`}>
         {/* Coupon Basic Info */}
         <div className="mb-6">
           <h4 className="text-xl font-bold text-stone-900 mb-2">
@@ -86,7 +72,7 @@ const QRCodeModal: React.FC<QRCodeModalProps> = ({
 
         {/* QR Code */}
         <div className="flex flex-col items-center mb-6" ref={qrCodeRef}>
-          <div className="bg-white p-6 rounded-lg shadow-inner border-2 border-stone-200 mb-4">
+          <div className="bg-white p-6 rounded-lg shadow-soft border-2 border-stone-200 mb-4">
             {/* QR Code Display */}
             <div className="w-64 h-64 flex items-center justify-center rounded-lg">
               {isGeneratingQR ? (
@@ -97,8 +83,8 @@ const QRCodeModal: React.FC<QRCodeModalProps> = ({
                   </div>
                 </div>
               ) : qrCodeDataURL ? (
-                <img 
-                  src={qrCodeDataURL} 
+                <img
+                  src={qrCodeDataURL}
                   alt={`QR Code for ${coupon.code}`}
                   className="w-full h-full object-contain rounded-lg"
                 />
@@ -112,7 +98,7 @@ const QRCodeModal: React.FC<QRCodeModalProps> = ({
               )}
             </div>
           </div>
-          
+
           {/* Coupon Code underneath */}
           <div className="text-center">
             <div className="text-sm text-stone-600 mb-1 font-medium">
@@ -164,7 +150,7 @@ const QRCodeModal: React.FC<QRCodeModalProps> = ({
           </button>
         </div>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/frontend/src/components/coupons/__tests__/QRCodeModal.test.tsx
+++ b/frontend/src/components/coupons/__tests__/QRCodeModal.test.tsx
@@ -17,6 +17,7 @@ const mockTranslate = vi.fn((key: string, defaultValue?: string) => {
     'coupons.letStaffScan': 'Let staff scan the code',
     'coupons.enjoyDiscount': 'Enjoy your discount',
     'common.important': 'Important',
+    'common.close': 'Close',
     'coupons.oneTimeUse': 'This coupon can only be used once',
     'coupons.copyCode': 'Copy Code',
     'coupons.couponCodeCopied': 'Coupon code copied!',
@@ -122,44 +123,45 @@ describe('QRCodeModal', () => {
       expect(container).toBeTruthy();
     });
 
-    it('should have proper container structure', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
+    it('should render the content wrapper with base classes', async () => {
+      render(<QRCodeModal coupon={mockCoupon} />);
 
-      // Wait for async QR code generation to complete
       await waitFor(() => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const card = container.firstChild as HTMLElement;
-      expect(card).toHaveClass('bg-white', 'rounded-lg', 'shadow-lg');
+      expect(screen.getByTestId('qr-code-content')).toHaveClass('text-center');
     });
 
-    it('should apply custom className', async () => {
-      const { container } = render(
-        <QRCodeModal coupon={mockCoupon} className="custom-modal-class" />
-      );
+    it('should apply custom className to the content wrapper', async () => {
+      render(<QRCodeModal coupon={mockCoupon} className="custom-modal-class" />);
 
-      // Wait for async QR code generation to complete
       await waitFor(() => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const card = container.firstChild as HTMLElement;
-      expect(card).toHaveClass('custom-modal-class');
+      expect(screen.getByTestId('qr-code-content')).toHaveClass('custom-modal-class');
     });
 
     it('should maintain base classes with custom className', async () => {
-      const { container } = render(
-        <QRCodeModal coupon={mockCoupon} className="custom-modal-class" />
-      );
+      render(<QRCodeModal coupon={mockCoupon} className="custom-modal-class" />);
 
-      // Wait for async QR code generation to complete
       await waitFor(() => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const card = container.firstChild as HTMLElement;
-      expect(card).toHaveClass('bg-white', 'rounded-lg', 'shadow-lg', 'custom-modal-class');
+      const content = screen.getByTestId('qr-code-content');
+      expect(content).toHaveClass('text-center', 'custom-modal-class');
+    });
+
+    it('should render inside a dialog', async () => {
+      render(<QRCodeModal coupon={mockCoupon} />);
+
+      await waitFor(() => {
+        expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
+      });
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
   });
 
@@ -182,53 +184,30 @@ describe('QRCodeModal', () => {
       });
 
       const heading = screen.getByText('Use Coupon');
-      expect(heading.tagName).toBe('H3');
+      expect(heading.tagName).toBe('H2');
     });
 
-    it('should style heading correctly', async () => {
+    it('should have a border below the header', async () => {
       render(<QRCodeModal coupon={mockCoupon} />);
 
       await waitFor(() => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const heading = screen.getByText('Use Coupon');
-      expect(heading).toHaveClass('text-lg', 'font-semibold', 'text-stone-900');
-    });
-
-    it('should have border at bottom of header', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
-
-      await waitFor(() => {
-        expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
-      });
-
-      const header = container.querySelector('.border-b');
+      const header = document.body.querySelector('.border-b');
       expect(header).toBeInTheDocument();
     });
   });
 
   describe('Close Button', () => {
-    it('should not display close button by default', async () => {
+    it('should always display the header close button', async () => {
       render(<QRCodeModal coupon={mockCoupon} />);
 
       await waitFor(() => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      expect(screen.queryByText('×')).not.toBeInTheDocument();
-    });
-
-    it('should display close button when onClose provided', async () => {
-      const onClose = vi.fn();
-
-      render(<QRCodeModal coupon={mockCoupon} onClose={onClose} />);
-
-      await waitFor(() => {
-        expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
-      });
-
-      expect(screen.getByText('×')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
     });
 
     it('should call onClose when close button clicked', async () => {
@@ -241,24 +220,10 @@ describe('QRCodeModal', () => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const closeButton = screen.getByText('×');
+      const closeButton = screen.getByRole('button', { name: 'Close' });
       await user.click(closeButton);
 
       expect(onClose).toHaveBeenCalledTimes(1);
-    });
-
-    it('should style close button correctly', async () => {
-      const onClose = vi.fn();
-
-      render(<QRCodeModal coupon={mockCoupon} onClose={onClose} />);
-
-      await waitFor(() => {
-        expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
-      });
-
-      const closeButton = screen.getByText('×');
-      expect(closeButton.tagName).toBe('BUTTON');
-      expect(closeButton).toHaveClass('text-stone-400', 'hover:text-stone-600', 'text-xl', 'font-bold');
     });
 
     it('should handle multiple close button clicks', async () => {
@@ -271,12 +236,25 @@ describe('QRCodeModal', () => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const closeButton = screen.getByText('×');
+      const closeButton = screen.getByRole('button', { name: 'Close' });
       await user.click(closeButton);
       await user.click(closeButton);
       await user.click(closeButton);
 
       expect(onClose).toHaveBeenCalledTimes(3);
+    });
+
+    it('should not throw when close button is clicked without onClose provided', async () => {
+      const user = userEvent.setup();
+
+      render(<QRCodeModal coupon={mockCoupon} />);
+
+      await waitFor(() => {
+        expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
+      });
+
+      const closeButton = screen.getByRole('button', { name: 'Close' });
+      await expect(user.click(closeButton)).resolves.not.toThrow();
     });
   });
 
@@ -504,20 +482,29 @@ describe('QRCodeModal', () => {
     });
 
     it('should style QR code image container correctly', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
+      render(<QRCodeModal coupon={mockCoupon} />);
 
       await waitFor(() => {
-        const qrContainer = container.querySelector('.w-64.h-64');
+        const qrContainer = document.body.querySelector('.w-64.h-64');
         expect(qrContainer).toBeInTheDocument();
       });
     });
 
     it('should have rounded border around QR code', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
+      render(<QRCodeModal coupon={mockCoupon} />);
 
       await waitFor(() => {
-        const qrWrapper = container.querySelector('.border-2.border-stone-200');
+        const qrWrapper = document.body.querySelector('.border-2.border-stone-200');
         expect(qrWrapper).toBeInTheDocument();
+      });
+    });
+
+    it('should sit on a pure white panel behind the QR image', async () => {
+      render(<QRCodeModal coupon={mockCoupon} />);
+
+      await waitFor(() => {
+        const qrWrapper = document.body.querySelector('.border-2.border-stone-200');
+        expect(qrWrapper).toHaveClass('bg-white', 'shadow-soft');
       });
     });
   });
@@ -592,36 +579,36 @@ describe('QRCodeModal', () => {
     });
 
     it('should display instructions in ordered list', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
+      render(<QRCodeModal coupon={mockCoupon} />);
 
       await waitFor(() => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const orderedList = container.querySelector('ol');
+      const orderedList = document.body.querySelector('ol');
       expect(orderedList).toBeInTheDocument();
     });
 
     it('should display instruction numbers', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
+      render(<QRCodeModal coupon={mockCoupon} />);
 
       await waitFor(() => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const numbers = container.querySelectorAll('.bg-brand-200.rounded-full');
+      const numbers = document.body.querySelectorAll('.bg-brand-200.rounded-full');
 
       expect(numbers.length).toBeGreaterThanOrEqual(3);
     });
 
     it('should style instructions section with blue background', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
+      render(<QRCodeModal coupon={mockCoupon} />);
 
       await waitFor(() => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const instructionsSection = container.querySelector('.bg-brand-50');
+      const instructionsSection = document.body.querySelector('.bg-brand-50');
       expect(instructionsSection).toBeInTheDocument();
     });
 
@@ -660,13 +647,13 @@ describe('QRCodeModal', () => {
     });
 
     it('should style notice with amber background', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
+      render(<QRCodeModal coupon={mockCoupon} />);
 
       await waitFor(() => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const noticeSection = container.querySelector('.bg-amber-50');
+      const noticeSection = document.body.querySelector('.bg-amber-50');
       expect(noticeSection).toBeInTheDocument();
     });
 
@@ -859,7 +846,7 @@ describe('QRCodeModal', () => {
       });
 
       const copyButton = screen.getByText('Copy Code');
-      const closeButton = screen.getByText('×');
+      const closeButton = screen.getByRole('button', { name: 'Close' });
 
       expect(copyButton.tagName).toBe('BUTTON');
       expect(closeButton.tagName).toBe('BUTTON');
@@ -876,7 +863,7 @@ describe('QRCodeModal', () => {
       const mainHeading = screen.getByText('Use Coupon');
       const couponHeading = screen.getByText('20% Off Your Purchase');
 
-      expect(mainHeading.tagName).toBe('H3');
+      expect(mainHeading.tagName).toBe('H2');
       expect(couponHeading.tagName).toBe('H4');
     });
 
@@ -942,7 +929,7 @@ describe('QRCodeModal', () => {
       expect(screen.getByText('SAVE-20%')).toBeInTheDocument();
     });
 
-    it('should handle undefined onClose prop', async () => {
+    it('should handle undefined onClose prop without crashing', async () => {
       const { container } = render(<QRCodeModal coupon={mockCoupon} />);
 
       await waitFor(() => {
@@ -950,7 +937,6 @@ describe('QRCodeModal', () => {
       });
 
       expect(container).toBeTruthy();
-      expect(screen.queryByText('×')).not.toBeInTheDocument();
     });
 
     it('should update when coupon prop changes completely', async () => {
@@ -978,19 +964,18 @@ describe('QRCodeModal', () => {
 
   describe('Layout and Styling', () => {
     it('should center QR code content', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
+      render(<QRCodeModal coupon={mockCoupon} />);
 
       // Wait for QR code generation to complete
       await waitFor(() => {
         expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
       });
 
-      const contentSection = container.querySelector('.text-center');
-      expect(contentSection).toBeInTheDocument();
+      expect(screen.getByTestId('qr-code-content')).toHaveClass('text-center');
     });
 
     it('should have proper spacing between sections', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
+      render(<QRCodeModal coupon={mockCoupon} />);
 
       // Wait for QR code generation to complete
       await waitFor(() => {
@@ -998,47 +983,8 @@ describe('QRCodeModal', () => {
       });
 
       // Check for margin classes
-      const sectionsWithMargin = container.querySelectorAll('.mb-6');
+      const sectionsWithMargin = document.body.querySelectorAll('.mb-6');
       expect(sectionsWithMargin.length).toBeGreaterThan(0);
-    });
-
-    it('should have rounded corners on modal', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
-
-      // Wait for QR code generation to complete
-      await waitFor(() => {
-        expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
-      });
-
-      const modal = container.firstChild as HTMLElement;
-      expect(modal).toHaveClass('rounded-lg');
-    });
-
-    it('should have shadow on modal', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
-
-      // Wait for QR code generation to complete
-      await waitFor(() => {
-        expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
-      });
-
-      const modal = container.firstChild as HTMLElement;
-      expect(modal).toHaveClass('shadow-lg');
-    });
-
-    it('should have proper padding', async () => {
-      const { container } = render(<QRCodeModal coupon={mockCoupon} />);
-
-      // Wait for QR code generation to complete
-      await waitFor(() => {
-        expect(screen.getByAltText('QR Code for SAVE20')).toBeInTheDocument();
-      });
-
-      const header = container.querySelector('.p-4');
-      const content = container.querySelector('.p-6');
-
-      expect(header).toBeInTheDocument();
-      expect(content).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/components/profile/EmailVerificationModal.tsx
+++ b/frontend/src/components/profile/EmailVerificationModal.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import { FiX, FiMail, FiRefreshCw, FiCheck } from 'react-icons/fi';
+import React, { useRef, useState, useEffect } from 'react';
+import { FiMail, FiRefreshCw, FiCheck } from 'react-icons/fi';
 import { useTranslation } from 'react-i18next';
 import { useMutation } from '@tanstack/react-query';
+import { Modal } from '../ui';
 
 interface EmailVerificationModalProps {
   isOpen: boolean;
@@ -22,6 +23,7 @@ export const EmailVerificationModal: React.FC<EmailVerificationModalProps> = ({
   const [code, setCode] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [resendSuccess, setResendSuccess] = useState(false);
+  const codeInputRef = useRef<HTMLInputElement>(null);
 
   const verifyMutation = useMutation({
     mutationFn: async (_data: { code: string }) => {
@@ -99,97 +101,81 @@ export const EmailVerificationModal: React.FC<EmailVerificationModalProps> = ({
     resendMutation.mutate();
   };
 
-  if (!isOpen) {
-    return null;
-  }
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div
-        className="bg-white rounded-lg shadow-xl w-full max-w-md mx-4 overflow-hidden"
-        data-testid="email-verification-modal"
-      >
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b">
-          <h2 className="text-lg font-semibold flex items-center gap-2">
-            <FiMail className="text-brand-500" />
-            {t('profile.verifyEmail', 'Verify Email')}
-          </h2>
-          <button
-            onClick={onClose}
-            className="p-1 hover:bg-stone-100 rounded-full transition-colors"
-            aria-label="Close"
-          >
-            <FiX size={20} />
-          </button>
+    <Modal
+      open={isOpen}
+      onClose={onClose}
+      size="sm"
+      initialFocusRef={codeInputRef}
+      title={
+        <span className="flex items-center gap-2">
+          <FiMail className="text-brand-500" />
+          {t('profile.verifyEmail', 'Verify Email')}
+        </span>
+      }
+    >
+      <form onSubmit={handleSubmit} data-testid="email-verification-modal">
+        <p className="text-stone-600 mb-4">
+          {t('profile.verificationCodeSent', 'A verification code has been sent to:')}
+        </p>
+        <p className="font-semibold text-stone-900 mb-6 break-all">{newEmail}</p>
+
+        <div className="mb-4">
+          <label htmlFor="verification-code" className="block text-sm font-semibold text-stone-700 mb-2">
+            {t('profile.enterCode', 'Enter verification code')}
+          </label>
+          <input
+            ref={codeInputRef}
+            id="verification-code"
+            type="text"
+            value={code}
+            onChange={handleCodeChange}
+            placeholder="XXXX-XXXX"
+            maxLength={9}
+            className="w-full px-4 py-3 text-center text-2xl font-mono tracking-widest border rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+            data-testid="verification-code-input"
+            autoComplete="off"
+          />
         </div>
 
-        {/* Content */}
-        <form onSubmit={handleSubmit} className="p-6">
-          <p className="text-stone-600 mb-4">
-            {t('profile.verificationCodeSent', 'A verification code has been sent to:')}
-          </p>
-          <p className="font-medium text-stone-900 mb-6 break-all">{newEmail}</p>
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm">{error}</div>
+        )}
 
-          <div className="mb-4">
-            <label htmlFor="verification-code" className="block text-sm font-medium text-stone-700 mb-2">
-              {t('profile.enterCode', 'Enter verification code')}
-            </label>
-            <input
-              id="verification-code"
-              type="text"
-              value={code}
-              onChange={handleCodeChange}
-              placeholder="XXXX-XXXX"
-              maxLength={9}
-              className="w-full px-4 py-3 text-center text-2xl font-mono tracking-widest border rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-              data-testid="verification-code-input"
-              autoComplete="off"
-              autoFocus
-            />
-          </div>
+        <button
+          type="submit"
+          disabled={verifyMutation.isPending || code.length < 9}
+          className="w-full py-3 px-4 bg-brand-600 text-white rounded-lg hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          data-testid="verify-button"
+        >
+          {verifyMutation.isPending ? t('common.verifying', 'Verifying...') : t('profile.verifyCode', 'Verify Code')}
+        </button>
 
-          {error && (
-            <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm">
-              {error}
+        <div className="mt-4 text-center">
+          {resendSuccess ? (
+            <div className="text-green-600 text-sm flex items-center justify-center gap-1" data-testid="resend-success">
+              <FiCheck size={14} />
+              {t('profile.codeResent', 'New code sent!')}
             </div>
+          ) : (
+            <button
+              type="button"
+              onClick={handleResend}
+              disabled={resendMutation.isPending}
+              className="text-brand-600 hover:text-brand-800 disabled:text-stone-400 disabled:cursor-not-allowed text-sm flex items-center justify-center gap-1 mx-auto"
+              data-testid="resend-code-button"
+            >
+              <FiRefreshCw className={resendMutation.isPending ? 'animate-spin' : ''} size={14} />
+              {t('profile.resendCode', 'Resend code')}
+            </button>
           )}
+        </div>
 
-          <button
-            type="submit"
-            disabled={verifyMutation.isPending || code.length < 9}
-            className="w-full py-3 px-4 bg-brand-600 text-white rounded-lg hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            data-testid="verify-button"
-          >
-            {verifyMutation.isPending ? t('common.verifying', 'Verifying...') : t('profile.verifyCode', 'Verify Code')}
-          </button>
-
-          <div className="mt-4 text-center">
-            {resendSuccess ? (
-              <div className="text-green-600 text-sm flex items-center justify-center gap-1" data-testid="resend-success">
-                <FiCheck size={14} />
-                {t('profile.codeResent', 'New code sent!')}
-              </div>
-            ) : (
-              <button
-                type="button"
-                onClick={handleResend}
-                disabled={resendMutation.isPending}
-                className="text-brand-600 hover:text-brand-800 disabled:text-stone-400 disabled:cursor-not-allowed text-sm flex items-center justify-center gap-1 mx-auto"
-                data-testid="resend-code-button"
-              >
-                <FiRefreshCw className={resendMutation.isPending ? 'animate-spin' : ''} size={14} />
-                {t('profile.resendCode', 'Resend code')}
-              </button>
-            )}
-          </div>
-
-          <p className="mt-4 text-xs text-stone-500 text-center">
-            {t('profile.codeExpiry', 'Code expires in 1 hour. Check your spam folder if you don\'t see it.')}
-          </p>
-        </form>
-      </div>
-    </div>
+        <p className="mt-4 text-xs text-stone-500 text-center">
+          {t('profile.codeExpiry', "Code expires in 1 hour. Check your spam folder if you don't see it.")}
+        </p>
+      </form>
+    </Modal>
   );
 };
 

--- a/frontend/src/components/profile/SettingsModal.tsx
+++ b/frontend/src/components/profile/SettingsModal.tsx
@@ -14,6 +14,7 @@ import { GenderField, OccupationField, DateOfBirthField } from './ProfileFormFie
 import { useMutation } from '@tanstack/react-query';
 import { userService } from '../../services/userService';
 import { logger } from '../../utils/logger';
+import { Modal } from '../ui';
 
 const profileSchema = z.object({
   email: z.string().email('Please enter a valid email address').optional().or(z.literal('')),
@@ -128,263 +129,235 @@ export default function SettingsModal({
     }
   };
 
-  if (!isOpen) {return null;}
-
   return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      <div className="flex items-center justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
-        {/* Backdrop */}
-        <div
-          className="fixed inset-0 bg-stone-500 bg-opacity-75 transition-opacity"
-          onClick={onClose}
-        />
+    <Modal open={isOpen} onClose={onClose} title={t('profile.editProfile')} size="md">
+      {/* Profile Picture Section */}
+      <div className="mb-6">
+        <h4 className="text-md font-medium text-stone-900 mb-4">Profile Picture</h4>
 
-        {/* Modal */}
-        <div className="inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
-          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-            {/* Header */}
-            <div className="flex items-center justify-between mb-6">
-              <h3 className="text-lg font-medium text-stone-900">
-                {t('profile.editProfile')}
-              </h3>
-              <button
-                onClick={onClose}
-                className="rounded-md bg-white text-stone-400 hover:text-stone-500 focus:outline-none focus:ring-2 focus:ring-brand-500"
-              >
-                <FiX className="h-6 w-6" />
-              </button>
-            </div>
-
-            {/* Profile Picture Section */}
-            <div className="mb-6">
-              <h4 className="text-md font-medium text-stone-900 mb-4">Profile Picture</h4>
-
-              <div className="flex items-center space-x-4 mb-4">
-                <div className="relative">
-                  <EmojiAvatar
-                    avatarUrl={profile?.avatarUrl}
-                    size="lg"
-                    className={updateEmojiAvatarMutation.isPending ? 'opacity-50' : ''}
-                  />
-                  {updateEmojiAvatarMutation.isPending && (
-                    <div className="absolute inset-0 flex items-center justify-center">
-                      <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-brand-600" />
-                    </div>
-                  )}
-                </div>
-
-                <div className="flex-1">
-                  <div className="flex flex-wrap gap-2 mb-2">
-                    <button
-                      onClick={() => setShowEmojiSelector(!showEmojiSelector)}
-                      disabled={updateEmojiAvatarMutation.isPending}
-                      className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-brand-700 bg-brand-100 hover:bg-brand-200 disabled:opacity-50"
-                    >
-                      <FiSmile className="mr-1 h-4 w-4" />
-                      Choose Emoji
-                    </button>
-
-                    <button
-                      onClick={() => fileInputRef.current?.click()}
-                      disabled={uploadingAvatar || updateEmojiAvatarMutation.isPending}
-                      className="inline-flex items-center px-3 py-2 border border-stone-300 text-sm leading-4 font-medium rounded-md text-stone-700 bg-white hover:bg-stone-50 disabled:opacity-50"
-                    >
-                      <FiCamera className="mr-1 h-4 w-4" />
-                      Upload Image
-                    </button>
-
-                    {profile?.avatarUrl && (
-                      <button
-                        onClick={onDeleteAvatar}
-                        disabled={uploadingAvatar || updateEmojiAvatarMutation.isPending}
-                        className="text-sm text-red-600 hover:text-red-700 disabled:opacity-50 px-2 py-1"
-                      >
-                        Remove
-                      </button>
-                    )}
-                  </div>
-
-                  <p className="text-xs text-stone-500">
-                    Choose an emoji or upload your own image for your profile picture
-                  </p>
-                </div>
-
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept="image/*"
-                  onChange={onAvatarUpload}
-                  className="hidden"
-                />
+        <div className="flex items-center space-x-4 mb-4">
+          <div className="relative">
+            <EmojiAvatar
+              avatarUrl={profile?.avatarUrl}
+              size="lg"
+              className={updateEmojiAvatarMutation.isPending ? 'opacity-50' : ''}
+            />
+            {updateEmojiAvatarMutation.isPending && (
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-brand-600" />
               </div>
+            )}
+          </div>
 
-              {/* Emoji Selector */}
-              {showEmojiSelector && (
-                <div className="border rounded-lg p-4 bg-stone-50">
-                  <div className="flex items-center justify-between mb-3">
-                    <span className="text-sm font-medium text-stone-700">Select an emoji:</span>
-                    <button
-                      onClick={() => setShowEmojiSelector(false)}
-                      className="text-stone-400 hover:text-stone-600"
-                    >
-                      <FiX className="h-4 w-4" />
-                    </button>
-                  </div>
-                  <EmojiSelectorInline
-                    currentEmoji={extractEmojiFromUrl(profile?.avatarUrl)}
-                    onSelect={handleEmojiSelect}
-                  />
-                </div>
+          <div className="flex-1">
+            <div className="flex flex-wrap gap-2 mb-2">
+              <button
+                onClick={() => setShowEmojiSelector(!showEmojiSelector)}
+                disabled={updateEmojiAvatarMutation.isPending}
+                className="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-brand-700 bg-brand-100 hover:bg-brand-200 disabled:opacity-50"
+              >
+                <FiSmile className="mr-1 h-4 w-4" />
+                Choose Emoji
+              </button>
+
+              <button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploadingAvatar || updateEmojiAvatarMutation.isPending}
+                className="inline-flex items-center px-3 py-2 border border-stone-300 text-sm leading-4 font-medium rounded-md text-stone-700 bg-white hover:bg-stone-50 disabled:opacity-50"
+              >
+                <FiCamera className="mr-1 h-4 w-4" />
+                Upload Image
+              </button>
+
+              {profile?.avatarUrl && (
+                <button
+                  onClick={onDeleteAvatar}
+                  disabled={uploadingAvatar || updateEmojiAvatarMutation.isPending}
+                  className="text-sm text-red-600 hover:text-red-700 disabled:opacity-50 px-2 py-1"
+                >
+                  Remove
+                </button>
               )}
             </div>
 
-            {/* Form */}
-            <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-4">
-              {/* Email Field */}
-              <div>
-                <label htmlFor="email" className="block text-sm font-medium text-stone-700">
-                  {t('profile.email')}
-                </label>
-                <div className="mt-1 relative">
-                  <div className={`absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none ${emailError ? 'text-red-400' : ''}`}>
-                    <FiMail className={`h-5 w-5 ${emailError ? 'text-red-400' : 'text-stone-400'}`} />
-                  </div>
-                  <input
-                    {...register('email')}
-                    id="email"
-                    type="email"
-                    disabled={isGoogleOAuthUser}
-                    className={`appearance-none block w-full px-3 py-2 pl-10 border rounded-md shadow-sm placeholder-stone-400 focus:outline-none sm:text-sm ${
-                      isGoogleOAuthUser
-                        ? 'bg-stone-100 cursor-not-allowed text-stone-500 border-stone-300'
-                        : emailError
-                        ? 'border-red-500 ring-1 ring-red-500 focus:ring-red-500 focus:border-red-500'
-                        : 'border-stone-300 focus:ring-brand-500 focus:border-brand-500'
-                    }`}
-                    placeholder={t('profile.emailPlaceholder')}
-                  />
-                </div>
-                {emailError && (
-                  <p className="mt-1 text-sm text-red-600">{emailError}</p>
-                )}
-                {errors.email && !emailError && (
-                  <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
-                )}
-                {isGoogleOAuthUser && (
-                  <p className="mt-1 text-sm text-stone-500">
-                    {t('profile.googleOAuthEmailLocked')}
-                  </p>
-                )}
-                {!emailError && !isGoogleOAuthUser && (
-                  <p className="mt-1 text-xs text-stone-500">
-                    {t('profile.emailHelpText')}
-                  </p>
-                )}
+            <p className="text-xs text-stone-500">
+              Choose an emoji or upload your own image for your profile picture
+            </p>
+          </div>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={onAvatarUpload}
+            className="hidden"
+          />
+        </div>
+
+        {/* Emoji Selector */}
+        {showEmojiSelector && (
+          <div className="border rounded-lg p-4 bg-stone-50">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-sm font-medium text-stone-700">Select an emoji:</span>
+              <button
+                onClick={() => setShowEmojiSelector(false)}
+                className="text-stone-400 hover:text-stone-600"
+              >
+                <FiX className="h-4 w-4" />
+              </button>
+            </div>
+            <EmojiSelectorInline
+              currentEmoji={extractEmojiFromUrl(profile?.avatarUrl)}
+              onSelect={handleEmojiSelect}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Form */}
+      <form onSubmit={handleSubmit(handleFormSubmit)} className="space-y-4">
+        {/* Email Field */}
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-stone-700">
+            {t('profile.email')}
+          </label>
+          <div className="mt-1 relative">
+            <div className={`absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none ${emailError ? 'text-red-400' : ''}`}>
+              <FiMail className={`h-5 w-5 ${emailError ? 'text-red-400' : 'text-stone-400'}`} />
+            </div>
+            <input
+              {...register('email')}
+              id="email"
+              type="email"
+              disabled={isGoogleOAuthUser}
+              className={`appearance-none block w-full px-3 py-2 pl-10 border rounded-md shadow-sm placeholder-stone-400 focus:outline-none sm:text-sm ${
+                isGoogleOAuthUser
+                  ? 'bg-stone-100 cursor-not-allowed text-stone-500 border-stone-300'
+                  : emailError
+                  ? 'border-red-500 ring-1 ring-red-500 focus:ring-red-500 focus:border-red-500'
+                  : 'border-stone-300 focus:ring-brand-500 focus:border-brand-500'
+              }`}
+              placeholder={t('profile.emailPlaceholder')}
+            />
+          </div>
+          {emailError && (
+            <p className="mt-1 text-sm text-red-600">{emailError}</p>
+          )}
+          {errors.email && !emailError && (
+            <p className="mt-1 text-sm text-red-600">{errors.email.message}</p>
+          )}
+          {isGoogleOAuthUser && (
+            <p className="mt-1 text-sm text-stone-500">
+              {t('profile.googleOAuthEmailLocked')}
+            </p>
+          )}
+          {!emailError && !isGoogleOAuthUser && (
+            <p className="mt-1 text-xs text-stone-500">
+              {t('profile.emailHelpText')}
+            </p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+          <div>
+            <label htmlFor="firstName" className="block text-sm font-medium text-stone-700">
+              {t('auth.firstName')}
+            </label>
+            <div className="mt-1 relative">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <FiUser className="h-5 w-5 text-stone-400" />
               </div>
-
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                <div>
-                  <label htmlFor="firstName" className="block text-sm font-medium text-stone-700">
-                    {t('auth.firstName')}
-                  </label>
-                  <div className="mt-1 relative">
-                    <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                      <FiUser className="h-5 w-5 text-stone-400" />
-                    </div>
-                    <input
-                      {...register('firstName')}
-                      id="firstName"
-                      type="text"
-                      className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
-                      placeholder={t('profile.firstNamePlaceholder')}
-                    />
-                  </div>
-                  {errors.firstName && (
-                    <p className="mt-1 text-sm text-red-600">{errors.firstName.message}</p>
-                  )}
-                </div>
-
-                <div>
-                  <label htmlFor="lastName" className="block text-sm font-medium text-stone-700">
-                    {t('auth.lastName')}
-                  </label>
-                  <div className="mt-1 relative">
-                    <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                      <FiUser className="h-5 w-5 text-stone-400" />
-                    </div>
-                    <input
-                      {...register('lastName')}
-                      id="lastName"
-                      type="text"
-                      className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
-                      placeholder={t('profile.lastNamePlaceholder')}
-                    />
-                  </div>
-                  {errors.lastName && (
-                    <p className="mt-1 text-sm text-red-600">{errors.lastName.message}</p>
-                  )}
-                </div>
-              </div>
-
-              <div>
-                <label htmlFor="phone" className="block text-sm font-medium text-stone-700">
-                  {t('auth.phone')}
-                </label>
-                <div className="mt-1 relative">
-                  <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                    <FiPhone className="h-5 w-5 text-stone-400" />
-                  </div>
-                  <input
-                    {...register('phone')}
-                    id="phone"
-                    type="tel"
-                    className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
-                    placeholder={t('profile.phonePlaceholder')}
-                  />
-                </div>
-                {errors.phone && (
-                  <p className="mt-1 text-sm text-red-600">{errors.phone.message}</p>
-                )}
-              </div>
-
-              <DateOfBirthField
-                register={register}
-                errors={errors}
-                isModal={false}
+              <input
+                {...register('firstName')}
+                id="firstName"
+                type="text"
+                className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+                placeholder={t('profile.firstNamePlaceholder')}
               />
+            </div>
+            {errors.firstName && (
+              <p className="mt-1 text-sm text-red-600">{errors.firstName.message}</p>
+            )}
+          </div>
 
-              <GenderField
-                register={register}
-                errors={errors}
-                isModal={false}
-              />
-
-              <OccupationField
-                register={register}
-                errors={errors}
-                isModal={false}
-              />
-
-              <div className="flex justify-end space-x-3 pt-4">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="px-4 py-2 border border-stone-300 rounded-md shadow-sm text-sm font-medium text-stone-700 bg-white hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500"
-                >
-                  {t('common.cancel')}
-                </button>
-                <button
-                  type="submit"
-                  disabled={isSaving}
-                  className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {isSaving ? t('common.saving') : t('common.save')}
-                </button>
+          <div>
+            <label htmlFor="lastName" className="block text-sm font-medium text-stone-700">
+              {t('auth.lastName')}
+            </label>
+            <div className="mt-1 relative">
+              <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+                <FiUser className="h-5 w-5 text-stone-400" />
               </div>
-            </form>
+              <input
+                {...register('lastName')}
+                id="lastName"
+                type="text"
+                className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+                placeholder={t('profile.lastNamePlaceholder')}
+              />
+            </div>
+            {errors.lastName && (
+              <p className="mt-1 text-sm text-red-600">{errors.lastName.message}</p>
+            )}
           </div>
         </div>
-      </div>
-    </div>
+
+        <div>
+          <label htmlFor="phone" className="block text-sm font-medium text-stone-700">
+            {t('auth.phone')}
+          </label>
+          <div className="mt-1 relative">
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <FiPhone className="h-5 w-5 text-stone-400" />
+            </div>
+            <input
+              {...register('phone')}
+              id="phone"
+              type="tel"
+              className="appearance-none block w-full px-3 py-2 pl-10 border border-stone-300 rounded-md shadow-sm placeholder-stone-400 focus:outline-none focus:ring-brand-500 focus:border-brand-500 sm:text-sm"
+              placeholder={t('profile.phonePlaceholder')}
+            />
+          </div>
+          {errors.phone && (
+            <p className="mt-1 text-sm text-red-600">{errors.phone.message}</p>
+          )}
+        </div>
+
+        <DateOfBirthField
+          register={register}
+          errors={errors}
+          isModal={false}
+        />
+
+        <GenderField
+          register={register}
+          errors={errors}
+          isModal={false}
+        />
+
+        <OccupationField
+          register={register}
+          errors={errors}
+          isModal={false}
+        />
+
+        <div className="flex justify-end space-x-3 pt-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 border border-stone-300 rounded-md shadow-sm text-sm font-medium text-stone-700 bg-white hover:bg-stone-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="submit"
+            disabled={isSaving}
+            className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-brand-600 hover:bg-brand-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSaving ? t('common.saving') : t('common.save')}
+          </button>
+        </div>
+      </form>
+    </Modal>
   );
 }

--- a/frontend/src/components/profile/__tests__/EmailVerificationModal.test.tsx
+++ b/frontend/src/components/profile/__tests__/EmailVerificationModal.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EmailVerificationModal } from '../EmailVerificationModal';
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = createTestQueryClient();
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+const mockTranslate = vi.fn((key: string, fallback?: string) => {
+  const translations: Record<string, string> = {
+    'profile.verifyEmail': 'Verify Email',
+    'profile.verificationCodeSent': 'A verification code has been sent to:',
+    'profile.enterCode': 'Enter verification code',
+    'profile.invalidCodeFormat': 'Please enter a valid code (XXXX-XXXX)',
+    'profile.verifyCode': 'Verify Code',
+    'common.verifying': 'Verifying...',
+    'profile.resendCode': 'Resend code',
+    'profile.codeResent': 'New code sent!',
+    'profile.codeExpiry': "Code expires in 1 hour. Check your spam folder if you don't see it.",
+    'common.close': 'Close',
+  };
+
+  return translations[key] ?? fallback ?? key;
+});
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: mockTranslate,
+  }),
+}));
+
+describe('EmailVerificationModal', () => {
+  const defaultProps = {
+    isOpen: true,
+    onClose: vi.fn(),
+    newEmail: 'new-email@example.com',
+    onVerified: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('should not render when isOpen is false', () => {
+      render(<EmailVerificationModal {...defaultProps} isOpen={false} />, { wrapper });
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('should render as a dialog when isOpen is true', () => {
+      render(<EmailVerificationModal {...defaultProps} />, { wrapper });
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('should render the title', () => {
+      render(<EmailVerificationModal {...defaultProps} />, { wrapper });
+
+      expect(screen.getByText('Verify Email')).toBeInTheDocument();
+    });
+
+    it('should render a close button with accessible name "Close" that calls onClose', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      render(<EmailVerificationModal {...defaultProps} onClose={onClose} />, { wrapper });
+
+      await user.click(screen.getByRole('button', { name: 'Close' }));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should render the newEmail address', () => {
+      render(<EmailVerificationModal {...defaultProps} newEmail="someone@example.com" />, { wrapper });
+
+      expect(screen.getByText('someone@example.com')).toBeInTheDocument();
+    });
+
+    it('should render the code input and submit button', () => {
+      render(<EmailVerificationModal {...defaultProps} />, { wrapper });
+
+      expect(screen.getByTestId('verification-code-input')).toBeInTheDocument();
+      expect(screen.getByTestId('verify-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('Code input formatting', () => {
+    it('should uppercase input and auto-insert a dash after 4 characters', async () => {
+      const user = userEvent.setup();
+      render(<EmailVerificationModal {...defaultProps} />, { wrapper });
+
+      const input = screen.getByTestId('verification-code-input') as HTMLInputElement;
+      await user.type(input, 'ab12cd34');
+
+      expect(input.value).toBe('AB12-CD34');
+    });
+
+    it('should strip non-alphanumeric characters', async () => {
+      const user = userEvent.setup();
+      render(<EmailVerificationModal {...defaultProps} />, { wrapper });
+
+      const input = screen.getByTestId('verification-code-input') as HTMLInputElement;
+      await user.type(input, 'ab-12!!cd34');
+
+      expect(input.value).toBe('AB12-CD34');
+    });
+
+    it('should disable the submit button until 9 characters are entered', async () => {
+      const user = userEvent.setup();
+      render(<EmailVerificationModal {...defaultProps} />, { wrapper });
+
+      const input = screen.getByTestId('verification-code-input') as HTMLInputElement;
+      const submitButton = screen.getByTestId('verify-button');
+
+      expect(submitButton).toBeDisabled();
+
+      await user.type(input, 'ab12cd34');
+
+      expect(submitButton).not.toBeDisabled();
+    });
+  });
+
+  describe('Submission', () => {
+    it('should show a validation error for an incomplete/invalid code format', async () => {
+      const user = userEvent.setup();
+      render(<EmailVerificationModal {...defaultProps} />, { wrapper });
+
+      const input = screen.getByTestId('verification-code-input');
+      await user.type(input, 'AB12CD3'); // 7 chars — incomplete, submit button stays disabled
+
+      // The submit button is disabled at this length, so exercise the form's
+      // own validation branch directly via a submit event (mirrors what a
+      // browser does on Enter-to-submit, bypassing the disabled button).
+      fireEvent.submit(screen.getByTestId('email-verification-modal'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Please enter a valid code (XXXX-XXXX)')).toBeInTheDocument();
+      });
+    });
+
+    it('should surface the "temporarily unavailable" error when submitting a valid-format code', async () => {
+      const user = userEvent.setup();
+      const onVerified = vi.fn();
+      render(<EmailVerificationModal {...defaultProps} onVerified={onVerified} />, { wrapper });
+
+      const input = screen.getByTestId('verification-code-input');
+      await user.type(input, 'ab12cd34');
+      await user.click(screen.getByTestId('verify-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Email verification is temporarily unavailable')).toBeInTheDocument();
+      });
+      expect(onVerified).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Resend', () => {
+    it('should surface the "temporarily unavailable" error when resend is clicked', async () => {
+      const user = userEvent.setup();
+      render(<EmailVerificationModal {...defaultProps} />, { wrapper });
+
+      await user.click(screen.getByTestId('resend-code-button'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Email verification is temporarily unavailable')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Dismissal', () => {
+    it('should call onClose when Escape is pressed', () => {
+      const onClose = vi.fn();
+      render(<EmailVerificationModal {...defaultProps} onClose={onClose} />, { wrapper });
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClose when the backdrop is clicked', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      render(<EmailVerificationModal {...defaultProps} onClose={onClose} />, { wrapper });
+
+      const backdrop = screen.getByRole('dialog').parentElement as HTMLElement;
+      await user.click(backdrop);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/frontend/src/components/profile/__tests__/SettingsModal.test.tsx
+++ b/frontend/src/components/profile/__tests__/SettingsModal.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable curly, @typescript-eslint/no-non-null-assertion -- Test file uses single-line conditionals and non-null assertions */
+/* eslint-disable @typescript-eslint/no-non-null-assertion -- Test file uses non-null assertions */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -37,6 +37,7 @@ const mockTranslate = vi.fn((key: string) => {
     'common.cancel': 'Cancel',
     'common.save': 'Save',
     'common.saving': 'Saving...',
+    'common.close': 'Close',
     'profile.dateOfBirth': 'Date of Birth',
     'profile.gender': 'Gender',
     'profile.occupation': 'Occupation',
@@ -185,9 +186,7 @@ describe('SettingsModal', () => {
     it('should render modal with backdrop', () => {
       render(<SettingsModal {...defaultProps} />, { wrapper });
 
-      const backdrop = document.querySelector('.bg-stone-500');
-      expect(backdrop).toBeInTheDocument();
-      expect(backdrop).toHaveClass('bg-opacity-75');
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     it('should render modal title', () => {
@@ -196,10 +195,10 @@ describe('SettingsModal', () => {
       expect(screen.getByText('Edit Profile')).toBeInTheDocument();
     });
 
-    it('should render close button with X icon', () => {
+    it('should render a close button', () => {
       render(<SettingsModal {...defaultProps} />, { wrapper });
 
-      expect(screen.getByTestId('x-icon')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
     });
   });
 
@@ -467,8 +466,7 @@ describe('SettingsModal', () => {
 
       expect(screen.getByTestId('emoji-selector')).toBeInTheDocument();
 
-      const closeButtons = screen.getAllByTestId('x-icon');
-      const selectorCloseButton = closeButtons[1]!;
+      const selectorCloseButton = screen.getByTestId('x-icon');
       await user.click(selectorCloseButton.parentElement!);
 
       await waitFor(() => {
@@ -693,8 +691,7 @@ describe('SettingsModal', () => {
       const onClose = vi.fn();
       render(<SettingsModal {...defaultProps} onClose={onClose} />, { wrapper });
 
-      const closeButton = screen.getByTestId('x-icon').parentElement;
-      if (!closeButton) throw new Error('Close button not found');
+      const closeButton = screen.getByRole('button', { name: 'Close' });
       await user.click(closeButton);
 
       expect(onClose).toHaveBeenCalled();
@@ -705,7 +702,7 @@ describe('SettingsModal', () => {
       const onClose = vi.fn();
       render(<SettingsModal {...defaultProps} onClose={onClose} />, { wrapper });
 
-      const backdrop = document.querySelector('.bg-stone-500') as HTMLElement;
+      const backdrop = screen.getByRole('dialog').parentElement as HTMLElement;
       await user.click(backdrop);
 
       expect(onClose).toHaveBeenCalled();

--- a/frontend/src/components/ui/Modal.tsx
+++ b/frontend/src/components/ui/Modal.tsx
@@ -1,0 +1,241 @@
+import type { MouseEvent, ReactNode, RefObject } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { Button } from './Button';
+import { cn } from './cn';
+
+export type ModalSize = 'sm' | 'md' | 'lg';
+export type ModalMobilePresentation = 'sheet' | 'center';
+
+export type ModalProps = {
+  open: boolean;
+  onClose: () => void;
+  /** Renders the header row; also wired to `aria-labelledby`. */
+  title?: ReactNode;
+  /** Desktop max-width: sm=max-w-md, md=max-w-lg, lg=max-w-2xl. */
+  size?: ModalSize;
+  /** Mobile layout below the `md` breakpoint. Defaults to 'sheet'. */
+  mobilePresentation?: ModalMobilePresentation;
+  /** Pinned action row rendered below the content. */
+  footer?: ReactNode;
+  /** Element to focus on open, before falling back to the first focusable child. */
+  initialFocusRef?: RefObject<HTMLElement | null>;
+  children: ReactNode;
+};
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+// Desktop max-width per size, kept as complete literal tokens (including the
+// `md:` responsive prefix for the sheet variant) so Tailwind's static content
+// scan can find them — building these via string interpolation at runtime
+// would hide the class names from the JIT compiler.
+const SHEET_MAX_WIDTH: Record<ModalSize, string> = {
+  sm: 'md:max-w-md',
+  md: 'md:max-w-lg',
+  lg: 'md:max-w-2xl',
+};
+
+const CENTER_MAX_WIDTH: Record<ModalSize, string> = {
+  sm: 'max-w-md',
+  md: 'max-w-lg',
+  lg: 'max-w-2xl',
+};
+
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) {
+    return [];
+  }
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+}
+
+function trapTabFocus(event: KeyboardEvent, container: HTMLElement | null) {
+  const focusable = getFocusableElements(container);
+  const first = focusable[0];
+  const last = focusable[focusable.length - 1];
+  if (!first || !last) {
+    event.preventDefault();
+    container?.focus();
+    return;
+  }
+  const activeElement = document.activeElement;
+  const focusHasLeftPanel = !container?.contains(activeElement);
+
+  const shouldWrapToLast = event.shiftKey && (activeElement === first || focusHasLeftPanel);
+  const shouldWrapToFirst = !event.shiftKey && (activeElement === last || focusHasLeftPanel);
+
+  if (shouldWrapToLast) {
+    event.preventDefault();
+    last.focus();
+  } else if (shouldWrapToFirst) {
+    event.preventDefault();
+    first.focus();
+  }
+}
+
+function CloseIcon() {
+  return (
+    <svg aria-hidden="true" className="h-5 w-5" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M6 6l12 12M18 6L6 18"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/**
+ * Shared Modal/Sheet primitive: portal + focus trap + scroll lock + Escape/
+ * backdrop dismissal. Presents as a bottom sheet on mobile (default) and a
+ * centered panel from `md` up; `mobilePresentation="center"` centers at
+ * every breakpoint.
+ */
+export function Modal({
+  open,
+  onClose,
+  title,
+  size = 'md',
+  mobilePresentation = 'sheet',
+  footer,
+  initialFocusRef,
+  children,
+}: ModalProps) {
+  const { t } = useTranslation();
+  const titleId = useId();
+  const panelRef = useRef<HTMLDivElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+  const [hasEntered, setHasEntered] = useState(false);
+
+  // Drives the entrance transition: mount at the "closed" position/opacity,
+  // then flip to "open" a tick later so the browser has something to
+  // interpolate between.
+  useEffect(() => {
+    if (!open) {
+      setHasEntered(false);
+      return undefined;
+    }
+    const timer = window.setTimeout(() => setHasEntered(true), 0);
+    return () => window.clearTimeout(timer);
+  }, [open]);
+
+  // Body scroll-lock while open; restored on close/unmount.
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [open]);
+
+  // Focus management: move focus in on open, trap Tab within the panel,
+  // close on Escape, and return focus to the trigger on close.
+  useEffect(() => {
+    if (!open) {
+      return undefined;
+    }
+
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    const focusTarget =
+      initialFocusRef?.current ?? getFocusableElements(panelRef.current)[0] ?? panelRef.current;
+    focusTarget?.focus();
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        onClose();
+        return;
+      }
+      if (event.key === 'Tab') {
+        trapTabFocus(event, panelRef.current);
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocusedRef.current?.focus();
+    };
+  }, [open, onClose, initialFocusRef]);
+
+  // Only the backdrop itself dismisses — a mousedown that bubbled up from
+  // the panel (e.g. the start of a text selection) must not close it.
+  const handleBackdropMouseDown = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (event.target === event.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  if (!open) {
+    return null;
+  }
+
+  const isSheet = mobilePresentation === 'sheet';
+  const enterClasses = isSheet
+    ? cn(
+        hasEntered ? 'translate-y-0' : 'translate-y-full',
+        hasEntered ? 'md:scale-100 md:opacity-100' : 'md:scale-95 md:opacity-0'
+      )
+    : cn(hasEntered ? 'scale-100 opacity-100' : 'scale-95 opacity-0');
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-ink/40 p-4"
+      onMouseDown={handleBackdropMouseDown}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title !== undefined ? titleId : undefined}
+        data-size={size}
+        data-presentation={mobilePresentation}
+        tabIndex={-1}
+        className={cn(
+          'flex max-h-[85vh] w-full flex-col bg-surface-card outline-none transition duration-200 ease-out motion-reduce:transition-none',
+          enterClasses,
+          isSheet
+            ? cn(
+                'fixed inset-x-0 bottom-0 rounded-t-card pb-[env(safe-area-inset-bottom)]',
+                'md:static md:inset-auto md:rounded-card md:shadow-pop',
+                SHEET_MAX_WIDTH[size]
+              )
+            : cn('rounded-card shadow-pop', CENTER_MAX_WIDTH[size])
+        )}
+      >
+        {isSheet && (
+          <div
+            aria-hidden="true"
+            className="mx-auto mt-2 h-1 w-10 shrink-0 rounded-full bg-hairline-strong md:hidden"
+          />
+        )}
+
+        {title !== undefined && (
+          <div className="flex shrink-0 items-center justify-between gap-4 border-b border-hairline px-6 py-4">
+            <h2 id={titleId} className="text-title">
+              {title}
+            </h2>
+            <Button variant="ghost" size="icon" aria-label={t('common.close', 'Close')} onClick={onClose}>
+              <CloseIcon />
+            </Button>
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto px-6 py-4">{children}</div>
+
+        {footer !== undefined && <div className="shrink-0 border-t border-hairline px-6 py-4">{footer}</div>}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/frontend/src/components/ui/__tests__/Modal.test.tsx
+++ b/frontend/src/components/ui/__tests__/Modal.test.tsx
@@ -1,0 +1,245 @@
+import type { ComponentProps } from 'react';
+import { useRef } from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Modal } from '../Modal';
+import type { ModalMobilePresentation, ModalSize } from '../Modal';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+type ModalTestProps = ComponentProps<typeof Modal>;
+
+function renderModal(overrides: Partial<ModalTestProps> = {}) {
+  const onClose = vi.fn();
+  const utils = render(
+    <Modal open onClose={onClose} title="Modal title" {...overrides}>
+      {overrides.children ?? <p>Body content</p>}
+    </Modal>
+  );
+  return { onClose, ...utils };
+}
+
+describe('Modal', () => {
+  describe('Rendering', () => {
+    it('should render nothing when closed', () => {
+      render(
+        <Modal open={false} onClose={vi.fn()} title="Title">
+          <p>Body</p>
+        </Modal>
+      );
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
+    it('should render the panel via a portal to document.body', () => {
+      const { container } = renderModal();
+
+      expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument();
+      expect(document.body.querySelector('[role="dialog"]')).toBeInTheDocument();
+    });
+
+    it('should render the footer when provided', () => {
+      renderModal({ footer: <button type="button">Save</button> });
+
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+    });
+
+    it('should not render a header when no title is given', () => {
+      render(
+        <Modal open onClose={vi.fn()}>
+          <button type="button">Only action</button>
+        </Modal>
+      );
+
+      expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('ARIA attributes', () => {
+    it('should mark the panel as a modal dialog labelled by the title', () => {
+      renderModal();
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+      const labelledBy = dialog.getAttribute('aria-labelledby') ?? '';
+      expect(labelledBy).not.toBe('');
+      expect(document.getElementById(labelledBy)).toHaveTextContent('Modal title');
+    });
+
+    it('should omit aria-labelledby when no title is given', () => {
+      render(
+        <Modal open onClose={vi.fn()}>
+          <p>Body</p>
+        </Modal>
+      );
+
+      expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-labelledby');
+    });
+
+    const sizes: ModalSize[] = ['sm', 'md', 'lg'];
+    it.each(sizes)('should stamp data-size="%s"', (size) => {
+      renderModal({ size });
+
+      expect(screen.getByRole('dialog')).toHaveAttribute('data-size', size);
+    });
+
+    const presentations: ModalMobilePresentation[] = ['sheet', 'center'];
+    it.each(presentations)('should stamp data-presentation="%s"', (mobilePresentation) => {
+      renderModal({ mobilePresentation });
+
+      expect(screen.getByRole('dialog')).toHaveAttribute('data-presentation', mobilePresentation);
+    });
+  });
+
+  describe('Dismissal', () => {
+    it('should call onClose when Escape is pressed', () => {
+      const { onClose } = renderModal();
+
+      fireEvent.keyDown(document, { key: 'Escape' });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClose when the backdrop is pressed but not when the panel is pressed', () => {
+      const { onClose } = renderModal();
+
+      const dialog = screen.getByRole('dialog');
+      fireEvent.mouseDown(dialog);
+      expect(onClose).not.toHaveBeenCalled();
+
+      const backdrop = dialog.parentElement as HTMLElement;
+      fireEvent.mouseDown(backdrop);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should call onClose when the header close button is clicked', async () => {
+      const user = userEvent.setup();
+      const { onClose } = renderModal();
+
+      await user.click(screen.getByRole('button', { name: 'Close' }));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Focus management', () => {
+    it('should focus the header close button on open by default', async () => {
+      renderModal();
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus());
+    });
+
+    it('should focus the first focusable child when there is no header', async () => {
+      render(
+        <Modal open onClose={vi.fn()}>
+          <button type="button">Only action</button>
+        </Modal>
+      );
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Only action' })).toHaveFocus());
+    });
+
+    it('should focus the panel itself when nothing inside is focusable', async () => {
+      render(
+        <Modal open onClose={vi.fn()}>
+          <p>No focusable content</p>
+        </Modal>
+      );
+
+      await waitFor(() => expect(screen.getByRole('dialog')).toHaveFocus());
+    });
+
+    it('should focus initialFocusRef when provided', async () => {
+      function Harness() {
+        const ref = useRef<HTMLButtonElement>(null);
+        return (
+          <Modal open onClose={vi.fn()} title="Title" initialFocusRef={ref}>
+            <button type="button">Not this one</button>
+            <button type="button" ref={ref}>
+              Focus me
+            </button>
+          </Modal>
+        );
+      }
+
+      render(<Harness />);
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Focus me' })).toHaveFocus());
+    });
+
+    it('should trap Tab focus within the panel', async () => {
+      const user = userEvent.setup();
+      render(
+        <Modal open onClose={vi.fn()} title="Title">
+          <button type="button">First inside</button>
+          <button type="button">Last inside</button>
+        </Modal>
+      );
+
+      const closeButton = screen.getByRole('button', { name: 'Close' });
+      const lastInside = screen.getByRole('button', { name: 'Last inside' });
+
+      await waitFor(() => expect(closeButton).toHaveFocus());
+
+      lastInside.focus();
+      await user.tab();
+      expect(closeButton).toHaveFocus();
+
+      await user.tab({ shift: true });
+      expect(lastInside).toHaveFocus();
+    });
+
+    it('should return focus to the previously focused element on close', async () => {
+      const trigger = document.createElement('button');
+      trigger.textContent = 'Trigger';
+      document.body.appendChild(trigger);
+      trigger.focus();
+      expect(trigger).toHaveFocus();
+
+      const onClose = vi.fn();
+      const { rerender } = render(
+        <Modal open onClose={onClose} title="Title">
+          <button type="button">Inside</button>
+        </Modal>
+      );
+
+      await waitFor(() => expect(trigger).not.toHaveFocus());
+
+      rerender(
+        <Modal open={false} onClose={onClose} title="Title">
+          <button type="button">Inside</button>
+        </Modal>
+      );
+
+      await waitFor(() => expect(trigger).toHaveFocus());
+
+      document.body.removeChild(trigger);
+    });
+  });
+
+  describe('Scroll lock', () => {
+    it('should lock body scroll while open and restore it on close', () => {
+      const { rerender } = render(
+        <Modal open onClose={vi.fn()} title="Title">
+          <p>Body</p>
+        </Modal>
+      );
+
+      expect(document.body.style.overflow).toBe('hidden');
+
+      rerender(
+        <Modal open={false} onClose={vi.fn()} title="Title">
+          <p>Body</p>
+        </Modal>
+      );
+
+      expect(document.body.style.overflow).not.toBe('hidden');
+    });
+  });
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -11,3 +11,6 @@ export type { BadgeProps, BadgeTone, BadgeSize } from './Badge';
 
 export { Skeleton } from './Skeleton';
 export type { SkeletonProps } from './Skeleton';
+
+export { Modal } from './Modal';
+export type { ModalProps, ModalSize, ModalMobilePresentation } from './Modal';


### PR DESCRIPTION
## Summary

PR4 of the UI-overhaul train, **stacked on #292** (`feat/ui-primitives` — design tokens + core primitives). Sibling of `feat/ui-forms` — a trivial `ui/index.ts` conflict is expected between the two (both append exports at the end of the file); resolve by keeping both export blocks.

### Modal primitive — `frontend/src/components/ui/Modal.tsx`

In-house (no new deps): `createPortal` to `document.body`, body scroll-lock, Escape closes, backdrop `mousedown` closes (backdrop only, not bubbled from the panel), focus trap with Tab/Shift+Tab cycling, focus moves in on open (`initialFocusRef` → first focusable → panel) and returns to the trigger on close, `role="dialog" aria-modal="true"` + `aria-labelledby` wired to the title.

```ts
type ModalProps = {
  open: boolean;
  onClose: () => void;
  title?: React.ReactNode;                  // header + aria-labelledby
  size?: 'sm' | 'md' | 'lg';                // max-w-md | max-w-lg | max-w-2xl
  mobilePresentation?: 'sheet' | 'center';  // default 'sheet'
  footer?: React.ReactNode;                 // pinned action row
  initialFocusRef?: React.RefObject<HTMLElement | null>;
  children: React.ReactNode;
};
```

Presentation: below `md` the default is a bottom sheet (`rounded-t-card`, grab handle, safe-area padding, slide-up transition); `md+` is a centered `rounded-card bg-surface-card shadow-pop` panel with fade/scale. `mobilePresentation="center"` centers at all sizes. `motion-reduce:transition-none`. Header close button uses the existing `common.close` i18n key (en/th/zh-CN already had it). Stamps `data-size` / `data-presentation`. Overlay `z-50 bg-ink/40` (below react-hot-toast).

### Conversions (public props unchanged, zero call-site changes)

- `common/ConfirmDialog` — rebuilt on `Modal` (center, sm) + `Button` (danger→`destructive`, warning/info→`primary`, cancel→`secondary`); confirm button still auto-focused via `initialFocusRef`. Decorative variant-tinted icon dropped (no primitive equivalent).
- `coupons/QRCodeModal` — QR stays on a pure-white (`bg-white`) inset block; banned `shadow-inner` → sanctioned `shadow-soft`. Known follow-up: `CouponWallet.tsx` still wraps it in its own now-redundant backdrop div (out of this PR's file scope).
- `profile/SettingsModal` — sheet on mobile, centered `md` on desktop; Save/Cancel stay inside the `<form>` (native submit preserved).
- `profile/EmailVerificationModal` — same conversion; gained its first test file.

### Design ratchet

Debt reduced and locked in (`design-baseline.json`): `font-medium` 550→547, `legacy-shadows` 312→301, `off-grammar-radii` 313→310.

## Test plan

- [x] `npm run lint` — 0 errors, design ratchet OK (touched files warning-free)
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 62 files, **2067/2067 passing** (Modal +21, ConfirmDialog 38 rewritten to behavior assertions, QRCodeModal 69 portal-aware, SettingsModal 62, EmailVerificationModal +14 new)
- [x] `npm run build` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)