### PR TITLE
feat(frontend): UI overhaul — page furniture primitives

### DIFF
--- a/frontend/src/components/ui/EmptyState.tsx
+++ b/frontend/src/components/ui/EmptyState.tsx
@@ -1,0 +1,27 @@
+import type { ComponentType, ReactNode } from 'react';
+import { cn } from './cn';
+
+export type EmptyStateIcon = ComponentType<{ className?: string; 'aria-hidden'?: boolean }>;
+
+export type EmptyStateProps = {
+  icon?: EmptyStateIcon;
+  title: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+};
+
+export function EmptyState({ icon: Icon, title, description, action, className }: EmptyStateProps) {
+  return (
+    <div className={cn('flex flex-col items-center py-12 text-center', className)}>
+      {Icon ? (
+        <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-surface-sunken">
+          <Icon className="h-6 w-6 text-ink-muted" aria-hidden />
+        </div>
+      ) : null}
+      <h2 className="text-title text-ink">{title}</h2>
+      {description ? <p className="mt-1 max-w-sm text-caption text-ink-muted">{description}</p> : null}
+      {action ? <div className="mt-4">{action}</div> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { FiChevronLeft } from 'react-icons/fi';
+import { cn } from './cn';
+
+export type PageHeaderDensity = 'guest' | 'admin';
+
+export type PageHeaderProps = {
+  title: string;
+  subtitle?: string;
+  backTo?: string;
+  actions?: ReactNode;
+  density?: PageHeaderDensity;
+  className?: string;
+};
+
+// guest pages lead with the larger display size; admin pages stay compact.
+const TITLE_CLASSES: Record<PageHeaderDensity, string> = {
+  guest: 'text-display',
+  admin: 'text-title',
+};
+
+export function PageHeader({
+  title,
+  subtitle,
+  backTo,
+  actions,
+  density = 'guest',
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      data-density={density}
+      className={cn('mb-6 flex flex-wrap items-start justify-between gap-4', className)}
+    >
+      <div className="flex items-start gap-3">
+        {backTo ? (
+          <Link
+            to={backTo}
+            aria-label="Back"
+            className="flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-full text-ink hover:bg-surface-sunken"
+          >
+            <FiChevronLeft className="h-5 w-5" aria-hidden="true" />
+          </Link>
+        ) : null}
+        <div>
+          <h1 className={cn('text-ink', TITLE_CLASSES[density])}>{title}</h1>
+          {subtitle ? <p className="text-caption text-ink-muted">{subtitle}</p> : null}
+        </div>
+      </div>
+      {actions ? <div className="flex flex-shrink-0 items-center gap-2">{actions}</div> : null}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/Section.tsx
+++ b/frontend/src/components/ui/Section.tsx
@@ -1,0 +1,57 @@
+import type { ElementType, HTMLAttributes, ReactNode } from 'react';
+import { cn } from './cn';
+
+export type SectionSurface = 'plain' | 'sunken' | 'tile';
+export type SectionWidth = 'text' | 'page';
+export type SectionSpacing = 'normal' | 'loose';
+export type SectionElement = 'section' | 'div';
+
+export type SectionProps = {
+  surface?: SectionSurface;
+  width?: SectionWidth;
+  spacing?: SectionSpacing;
+  as?: SectionElement;
+  className?: string;
+  innerClassName?: string;
+  children: ReactNode;
+} & Omit<HTMLAttributes<HTMLElement>, 'className'>;
+
+// plain is intentionally transparent — sections stack edge-to-edge and the
+// surface change itself is the divider between them (no borders).
+const SURFACE_CLASSES: Record<SectionSurface, string> = {
+  plain: '',
+  sunken: 'bg-surface-sunken',
+  tile: 'bg-tile text-tile-text',
+};
+
+const WIDTH_CLASSES: Record<SectionWidth, string> = {
+  text: 'max-w-text',
+  page: 'max-w-page',
+};
+
+const SPACING_CLASSES: Record<SectionSpacing, string> = {
+  normal: 'py-10',
+  loose: 'py-14 lg:py-20',
+};
+
+export function Section({
+  surface = 'plain',
+  width = 'page',
+  spacing = 'normal',
+  as: Component = 'section',
+  className,
+  innerClassName,
+  children,
+  ...rest
+}: SectionProps) {
+  const Tag = Component as ElementType;
+  return (
+    <Tag
+      data-surface={surface}
+      className={cn(SURFACE_CLASSES[surface], SPACING_CLASSES[spacing], className)}
+      {...rest}
+    >
+      <div className={cn('mx-auto px-4 sm:px-6', WIDTH_CLASSES[width], innerClassName)}>{children}</div>
+    </Tag>
+  );
+}

--- a/frontend/src/components/ui/TabNav.tsx
+++ b/frontend/src/components/ui/TabNav.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from 'react';
+import { NavLink } from 'react-router-dom';
+import { Badge } from './Badge';
+import { cn } from './cn';
+
+export type TabItem = {
+  value: string;
+  label: ReactNode;
+  count?: number;
+};
+
+export type TabLinkItem = {
+  to: string;
+  label: ReactNode;
+  count?: number;
+  end?: boolean;
+};
+
+type TabNavButtonProps = {
+  items: TabItem[];
+  value: string;
+  onChange: (value: string) => void;
+  'aria-label'?: string;
+  className?: string;
+};
+
+type TabNavLinkProps = {
+  linkItems: TabLinkItem[];
+  'aria-label'?: string;
+  className?: string;
+};
+
+export type TabNavProps = TabNavButtonProps | TabNavLinkProps;
+
+function isLinkMode(props: TabNavProps): props is TabNavLinkProps {
+  return 'linkItems' in props;
+}
+
+// Scrollable on mobile with the scrollbar itself hidden — overflow is still
+// reachable by touch/drag, just visually quiet.
+const SCROLL_CONTAINER_CLASSES =
+  'flex items-stretch gap-6 overflow-x-auto border-b border-hairline [scrollbar-width:none] [&::-webkit-scrollbar]:hidden';
+
+const TAB_BASE_CLASSES =
+  'relative flex min-h-11 items-center gap-2 whitespace-nowrap px-1 text-caption font-semibold transition-colors';
+
+const ACTIVE_TAB_CLASSES =
+  'text-brand-700 after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-brand-600';
+const INACTIVE_TAB_CLASSES = 'text-ink-muted hover:text-ink';
+
+function TabCount({ count }: { count?: number }) {
+  if (count === undefined) {
+    return null;
+  }
+  return (
+    <Badge tone="neutral" size="sm">
+      {count}
+    </Badge>
+  );
+}
+
+export function TabNav(props: TabNavProps) {
+  if (isLinkMode(props)) {
+    const { linkItems, className, ...rest } = props;
+    return (
+      <nav
+        data-mode="link"
+        aria-label={rest['aria-label']}
+        className={cn(SCROLL_CONTAINER_CLASSES, className)}
+      >
+        {linkItems.map((item) => (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            end={item.end}
+            className={({ isActive }) =>
+              cn(TAB_BASE_CLASSES, isActive ? ACTIVE_TAB_CLASSES : INACTIVE_TAB_CLASSES)
+            }
+          >
+            {item.label}
+            <TabCount count={item.count} />
+          </NavLink>
+        ))}
+      </nav>
+    );
+  }
+
+  const { items, value, onChange, className, ...rest } = props;
+  return (
+    <div
+      role="tablist"
+      data-mode="button"
+      aria-label={rest['aria-label']}
+      className={cn(SCROLL_CONTAINER_CLASSES, className)}
+    >
+      {items.map((item) => {
+        const isActive = item.value === value;
+        return (
+          <button
+            key={item.value}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            className={cn(TAB_BASE_CLASSES, isActive ? ACTIVE_TAB_CLASSES : INACTIVE_TAB_CLASSES)}
+            onClick={() => onChange(item.value)}
+          >
+            {item.label}
+            <TabCount count={item.count} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/ui/__tests__/EmptyState.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { FiInbox } from 'react-icons/fi';
+import { EmptyState } from '../EmptyState';
+
+describe('EmptyState', () => {
+  it('should render the title as a heading', () => {
+    render(<EmptyState title="No bookings yet" />);
+
+    expect(screen.getByRole('heading', { name: 'No bookings yet' })).toBeInTheDocument();
+  });
+
+  it('should render the description when provided', () => {
+    render(<EmptyState title="No bookings yet" description="Book your first stay to see it here." />);
+
+    expect(screen.getByText('Book your first stay to see it here.')).toBeInTheDocument();
+  });
+
+  it('should not render a description when omitted', () => {
+    render(<EmptyState title="No bookings yet" />);
+
+    expect(screen.queryByText('Book your first stay to see it here.')).not.toBeInTheDocument();
+  });
+
+  it('should render the icon hidden from the accessibility tree', () => {
+    const { container } = render(<EmptyState title="No bookings yet" icon={FiInbox} />);
+
+    const icon = container.querySelector('svg');
+    expect(icon).toBeTruthy();
+    expect(icon).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should not render an icon wrapper when icon is omitted', () => {
+    const { container } = render(<EmptyState title="No bookings yet" />);
+
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('should render the action slot', () => {
+    render(<EmptyState title="No bookings yet" action={<button>Book now</button>} />);
+
+    expect(screen.getByRole('button', { name: 'Book now' })).toBeInTheDocument();
+  });
+
+  it('should not render an action slot when omitted', () => {
+    render(<EmptyState title="No bookings yet" />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should merge a caller-supplied className onto the outer wrapper', () => {
+    const { container } = render(<EmptyState title="No bookings yet" className="promo-empty-marker" />);
+
+    expect(container.firstChild).toHaveClass('promo-empty-marker');
+  });
+});

--- a/frontend/src/components/ui/__tests__/PageHeader.test.tsx
+++ b/frontend/src/components/ui/__tests__/PageHeader.test.tsx
@@ -1,0 +1,71 @@
+import type { ReactElement } from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { PageHeader } from '../PageHeader';
+import type { PageHeaderDensity } from '../PageHeader';
+
+function renderPageHeader(ui: ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('PageHeader', () => {
+  it('should render the title as a heading', () => {
+    renderPageHeader(<PageHeader title="My bookings" />);
+
+    expect(screen.getByRole('heading', { name: 'My bookings' })).toBeInTheDocument();
+  });
+
+  it('should render the subtitle when provided', () => {
+    renderPageHeader(<PageHeader title="My bookings" subtitle="3 upcoming stays" />);
+
+    expect(screen.getByText('3 upcoming stays')).toBeInTheDocument();
+  });
+
+  it('should not render a subtitle when omitted', () => {
+    renderPageHeader(<PageHeader title="My bookings" />);
+
+    expect(screen.queryByText('3 upcoming stays')).not.toBeInTheDocument();
+  });
+
+  it('should default to data-density="guest"', () => {
+    const { container } = renderPageHeader(<PageHeader title="My bookings" />);
+
+    expect(container.firstChild).toHaveAttribute('data-density', 'guest');
+  });
+
+  const densities: PageHeaderDensity[] = ['guest', 'admin'];
+  it.each(densities)('should stamp data-density="%s" when density is set', (density) => {
+    const { container } = renderPageHeader(<PageHeader title="My bookings" density={density} />);
+
+    expect(container.firstChild).toHaveAttribute('data-density', density);
+  });
+
+  it('should not render a back link when backTo is omitted', () => {
+    renderPageHeader(<PageHeader title="My bookings" />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('should render an accessible back link pointing to backTo', () => {
+    renderPageHeader(<PageHeader title="Booking detail" backTo="/bookings" />);
+
+    const backLink = screen.getByRole('link');
+    expect(backLink).toHaveAttribute('href', '/bookings');
+    expect(backLink).toHaveAccessibleName();
+  });
+
+  it('should render the actions slot', () => {
+    renderPageHeader(<PageHeader title="My bookings" actions={<button>New booking</button>} />);
+
+    expect(screen.getByRole('button', { name: 'New booking' })).toBeInTheDocument();
+  });
+
+  it('should merge a caller-supplied className onto the outer wrapper', () => {
+    const { container } = renderPageHeader(
+      <PageHeader title="My bookings" className="promo-header-marker" />
+    );
+
+    expect(container.firstChild).toHaveClass('promo-header-marker');
+  });
+});

--- a/frontend/src/components/ui/__tests__/Section.test.tsx
+++ b/frontend/src/components/ui/__tests__/Section.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Section } from '../Section';
+import type { SectionSurface } from '../Section';
+
+describe('Section', () => {
+  it('should render its children', () => {
+    render(<Section>Section content</Section>);
+
+    expect(screen.getByText('Section content')).toBeInTheDocument();
+  });
+
+  it('should render a <section> element by default', () => {
+    render(<Section>Content</Section>);
+
+    expect(screen.getByText('Content').closest('[data-surface]')?.tagName).toBe('SECTION');
+  });
+
+  it('should render a <div> when as="div"', () => {
+    render(<Section as="div">Content</Section>);
+
+    expect(screen.getByText('Content').closest('[data-surface]')?.tagName).toBe('DIV');
+  });
+
+  it('should default to data-surface="plain"', () => {
+    const { container } = render(<Section>Content</Section>);
+
+    expect(container.firstChild).toHaveAttribute('data-surface', 'plain');
+  });
+
+  const surfaces: SectionSurface[] = ['plain', 'sunken', 'tile'];
+  it.each(surfaces)('should stamp data-surface="%s" when surface is set', (surface) => {
+    const { container } = render(<Section surface={surface}>{surface}</Section>);
+
+    expect(container.firstChild).toHaveAttribute('data-surface', surface);
+  });
+
+  it('should merge a caller-supplied className onto the outer wrapper', () => {
+    const { container } = render(<Section className="promo-section-marker">Content</Section>);
+
+    expect(container.firstChild).toHaveClass('promo-section-marker');
+  });
+
+  it('should merge a caller-supplied innerClassName onto the inner container', () => {
+    render(<Section innerClassName="promo-inner-marker">Content</Section>);
+
+    expect(screen.getByText('Content')).toHaveClass('promo-inner-marker');
+  });
+
+  it('should nest children inside an inner container within the outer wrapper', () => {
+    const { container } = render(<Section>Content</Section>);
+
+    const inner = screen.getByText('Content');
+    expect(inner).not.toBe(container.firstChild);
+    expect(container.firstChild).toContainElement(inner);
+  });
+});

--- a/frontend/src/components/ui/__tests__/TabNav.test.tsx
+++ b/frontend/src/components/ui/__tests__/TabNav.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { TabNav } from '../TabNav';
+import type { TabItem, TabLinkItem } from '../TabNav';
+
+describe('TabNav', () => {
+  describe('button mode', () => {
+    const items: TabItem[] = [
+      { value: 'active', label: 'Active', count: 3 },
+      { value: 'past', label: 'Past' },
+    ];
+
+    it('should render a tablist with a tab per item', () => {
+      render(<TabNav items={items} value="active" onChange={vi.fn()} />);
+
+      expect(screen.getByRole('tablist')).toBeInTheDocument();
+      expect(screen.getAllByRole('tab')).toHaveLength(2);
+    });
+
+    it('should stamp data-mode="button" on the tablist', () => {
+      render(<TabNav items={items} value="active" onChange={vi.fn()} />);
+
+      expect(screen.getByRole('tablist')).toHaveAttribute('data-mode', 'button');
+    });
+
+    it('should mark the selected tab with aria-selected="true"', () => {
+      render(<TabNav items={items} value="active" onChange={vi.fn()} />);
+
+      expect(screen.getByRole('tab', { name: /Active/ })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('should mark unselected tabs with aria-selected="false"', () => {
+      render(<TabNav items={items} value="active" onChange={vi.fn()} />);
+
+      expect(screen.getByRole('tab', { name: 'Past' })).toHaveAttribute('aria-selected', 'false');
+    });
+
+    it('should call onChange with the tab value when a tab is clicked', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<TabNav items={items} value="active" onChange={handleChange} />);
+
+      await user.click(screen.getByRole('tab', { name: 'Past' }));
+
+      expect(handleChange).toHaveBeenCalledTimes(1);
+      expect(handleChange).toHaveBeenCalledWith('past');
+    });
+
+    it('should support activating a tab via the keyboard', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(<TabNav items={items} value="active" onChange={handleChange} />);
+
+      screen.getByRole('tab', { name: 'Past' }).focus();
+      await user.keyboard('{Enter}');
+
+      expect(handleChange).toHaveBeenCalledWith('past');
+    });
+
+    it('should render an item count as a badge', () => {
+      render(<TabNav items={items} value="active" onChange={vi.fn()} />);
+
+      expect(screen.getByRole('tab', { name: /Active/ })).toHaveTextContent('3');
+    });
+
+    it('should not render a badge when count is omitted', () => {
+      render(<TabNav items={items} value="active" onChange={vi.fn()} />);
+
+      expect(screen.getByRole('tab', { name: 'Past' })).toHaveTextContent('Past');
+    });
+
+    it('should apply aria-label to the tablist', () => {
+      render(<TabNav items={items} value="active" onChange={vi.fn()} aria-label="Booking status" />);
+
+      expect(screen.getByRole('tablist', { name: 'Booking status' })).toBeInTheDocument();
+    });
+  });
+
+  describe('link mode', () => {
+    const linkItems: TabLinkItem[] = [
+      { to: '/bookings/upcoming', label: 'Upcoming', end: true },
+      { to: '/bookings/past', label: 'Past', count: 5 },
+    ];
+
+    function renderLinkNav() {
+      return render(
+        <MemoryRouter initialEntries={['/bookings/upcoming']}>
+          <TabNav linkItems={linkItems} />
+        </MemoryRouter>
+      );
+    }
+
+    it('should render an anchor per link item', () => {
+      renderLinkNav();
+
+      expect(screen.getAllByRole('link')).toHaveLength(2);
+    });
+
+    it('should stamp data-mode="link"', () => {
+      const { container } = renderLinkNav();
+
+      expect(container.querySelector('[data-mode="link"]')).toBeInTheDocument();
+    });
+
+    it('should mark the link matching the current route with aria-current="page"', () => {
+      renderLinkNav();
+
+      expect(screen.getByRole('link', { name: 'Upcoming' })).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('should not mark non-matching links with aria-current', () => {
+      renderLinkNav();
+
+      expect(screen.getByRole('link', { name: /Past/ })).not.toHaveAttribute('aria-current');
+    });
+
+    it('should render each link with its target href', () => {
+      renderLinkNav();
+
+      expect(screen.getByRole('link', { name: 'Upcoming' })).toHaveAttribute('href', '/bookings/upcoming');
+      expect(screen.getByRole('link', { name: /Past/ })).toHaveAttribute('href', '/bookings/past');
+    });
+
+    it('should render a link item count as a badge', () => {
+      renderLinkNav();
+
+      expect(screen.getByRole('link', { name: /Past/ })).toHaveTextContent('5');
+    });
+
+    it('should apply aria-label to the link nav', () => {
+      render(
+        <MemoryRouter initialEntries={['/bookings/upcoming']}>
+          <TabNav linkItems={linkItems} aria-label="Booking status" />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByRole('navigation', { name: 'Booking status' })).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -11,3 +11,8 @@ export type { BadgeProps, BadgeTone, BadgeSize } from './Badge';
 
 export { Skeleton } from './Skeleton';
 export type { SkeletonProps } from './Skeleton';
+
+export { PageHeader, type PageHeaderProps, type PageHeaderDensity } from './PageHeader';
+export { Section, type SectionProps, type SectionSurface, type SectionWidth, type SectionSpacing, type SectionElement } from './Section';
+export { TabNav, type TabNavProps, type TabItem, type TabLinkItem } from './TabNav';
+export { EmptyState, type EmptyStateProps, type EmptyStateIcon } from './EmptyState';


### PR DESCRIPTION
## Summary
- Adds four page-furniture primitives on top of the PR1 design tokens/core primitives: `PageHeader`, `Section`, `TabNav`, `EmptyState`.
- `TabNav` is the intended replacement for the app's `-mb-px flex space-x-8` underline tab strips (not yet migrated in this PR — primitives only).
- Follows the existing `ui/` conventions: `cn()` class merge, `data-*` attribute stamping (`data-density`, `data-surface`, `data-mode`), no new off-system styling (design ratchet passes with zero new violations).

Stacked on #292 (`feat/ui-primitives`). Sibling of `feat/ui-forms`, `feat/ui-modal`, and `feat/ui-shell` — all touch disjoint files under `frontend/src/components/ui/` except for shared appends to `ui/index.ts`.

## Test plan
- [x] `npm run lint` — 0 errors, design ratchet OK (no new banned patterns)
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 2086/2086 tests pass (64 files), including 44 new tests across the 4 primitives
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)