### PR TITLE
feat(frontend): UI overhaul — booking flow + my-bookings reskin (LIFF-safe)

### DIFF
--- a/frontend/scripts/design-baseline.json
+++ b/frontend/scripts/design-baseline.json
@@ -2,9 +2,9 @@
   "primary-alias": 0,
   "cool-grays": 0,
   "font-extrabold": 0,
-  "font-medium": 529,
-  "legacy-shadows": 276,
-  "off-grammar-radii": 295,
-  "oversized-titles": 26,
+  "font-medium": 479,
+  "legacy-shadows": 262,
+  "off-grammar-radii": 274,
+  "oversized-titles": 25,
   "hardcoded-hex": 129
 }

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1648,6 +1648,7 @@
     "uploadSlip": "Upload Transfer Slip",
     "uploadSlipDescription": "After payment, upload your transfer slip for verification",
     "dragDropSlip": "Drag and drop your slip here, or click to browse",
+    "browseFiles": "Browse files",
     "slipUploaded": "Slip Uploaded",
     "slipPreview": "Transfer Slip",
     "awaitingVerification": "Awaiting Verification",

--- a/frontend/src/i18n/locales/th/translation.json
+++ b/frontend/src/i18n/locales/th/translation.json
@@ -1686,6 +1686,7 @@
     "uploadSlip": "อัปโหลดสลิปโอนเงิน",
     "uploadSlipDescription": "หลังจากชำระเงินแล้ว อัปโหลดสลิปโอนเงินเพื่อยืนยัน",
     "dragDropSlip": "ลากและวางสลิปที่นี่ หรือคลิกเพื่อเลือกไฟล์",
+    "browseFiles": "เลือกไฟล์",
     "slipUploaded": "อัปโหลดสลิปแล้ว",
     "slipPreview": "สลิปโอนเงิน",
     "awaitingVerification": "รอการตรวจสอบ",

--- a/frontend/src/i18n/locales/zh-CN/translation.json
+++ b/frontend/src/i18n/locales/zh-CN/translation.json
@@ -1082,6 +1082,7 @@
     "guestDetailsRequired": "请填写入住人姓名和电话号码"
   },
   "payment": {
+    "browseFiles": "浏览文件",
     "balanceDueAtCheckin": "入住时应付余额",
     "holdExpiresIn": "请在 {{time}} 内付款——房间将为您保留至该时间",
     "holdExpired": "付款时间已过，房间保留已释放。请重新预订。",

--- a/frontend/src/pages/BookingPage.tsx
+++ b/frontend/src/pages/BookingPage.tsx
@@ -5,7 +5,8 @@ import { FiCalendar, FiUsers, FiCheck, FiUpload, FiX, FiCheckCircle, FiClock, Fi
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import QRCode from 'qrcode';
 import clsx from 'clsx';
-import MainLayout from '../components/layout/MainLayout';
+import AppShell from '../components/layout/AppShell';
+import { Button, Card, Badge, Input, Select, FormField } from '../components/ui';
 import { bookingService } from '../services/bookingService';
 import {
   channelBookingService,
@@ -32,6 +33,12 @@ interface BookingStep {
 }
 
 type SlipStatus = 'pending' | 'uploaded' | 'verified' | 'failed';
+
+// Fixed action bar pinned above the guest tab bar's space (hidden via
+// AppShell's `hideTabBar` on this flow) so the primary action always sits in
+// the LIFF webview's thumb zone.
+const STICKY_CTA_CLASSES =
+  'fixed inset-x-0 bottom-0 z-30 flex items-center justify-between gap-4 border-t border-hairline bg-surface-card/85 px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur-md';
 
 function formatCountdown(msLeft: number): string {
   const totalSeconds = Math.max(0, Math.floor(msLeft / 1000));
@@ -288,135 +295,128 @@ export default function BookingPage() {
   ];
 
   return (
-    <MainLayout title={t('booking.title')}>
-      {/* Progress Steps */}
-      <div className="mb-8">
-        <div className="flex items-center justify-center">
-          {steps.map((step, index) => (
-            <div key={step.number} className="flex items-center">
-              <div
-                className={clsx('flex items-center justify-center w-10 h-10 rounded-full', {
-                  'bg-brand-600 text-white': currentStep === step.number,
-                  'bg-green-500 text-white': currentStep !== step.number && step.completed,
-                  'bg-stone-200 text-stone-600': currentStep !== step.number && !step.completed,
-                })}
+    <AppShell variant="guest" title={t('booking.title')} hideTabBar>
+      {/* Progress Steps — compact numbered pills connected by hairlines */}
+      <ol className="mb-8 flex items-center justify-center" aria-label={t('booking.title')}>
+        {steps.map((step, index) => {
+          const isCurrent = currentStep === step.number;
+          const isDone = !isCurrent && step.completed;
+          return (
+            <li key={step.number} className="flex items-center">
+              <span
+                aria-current={isCurrent ? 'step' : undefined}
+                aria-label={step.title}
+                className={clsx(
+                  'flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-caption font-semibold',
+                  isCurrent && 'bg-brand-600 text-white',
+                  isDone && 'bg-brand-50 text-brand-700',
+                  !isCurrent && !isDone && 'bg-surface-sunken text-ink-muted',
+                )}
               >
-                {step.completed ? <FiCheck className="w-5 h-5" /> : step.number}
-              </div>
-              <span className={clsx('ml-2', currentStep === step.number ? 'font-semibold' : 'text-stone-500')}>
-                {step.title}
+                {isDone ? <FiCheck className="h-4 w-4" aria-hidden="true" /> : step.number}
               </span>
               {index < steps.length - 1 && (
-                <div className={clsx('w-16 h-1 mx-4', step.completed ? 'bg-green-500' : 'bg-stone-200')} />
+                <span
+                  aria-hidden="true"
+                  className={clsx('mx-2 h-px w-8', isDone ? 'bg-brand-600' : 'bg-hairline')}
+                />
               )}
-            </div>
-          ))}
-        </div>
-      </div>
+            </li>
+          );
+        })}
+      </ol>
 
       {/* Step 1: Property, dates, guests */}
       {currentStep === 1 && (
-        <div className="bg-white rounded-lg shadow p-6 max-w-md mx-auto">
-          <h2 className="text-xl font-semibold mb-6 flex items-center">
-            <FiCalendar className="mr-2" />
-            {t('booking.selectDates')}
-          </h2>
+        <div className="pb-28">
+          <Card className="mx-auto max-w-md">
+            <h2 className="mb-6 flex items-center gap-2 text-title text-ink">
+              <FiCalendar className="h-5 w-5" aria-hidden="true" />
+              {t('booking.selectDates')}
+            </h2>
 
-          <div className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-stone-700 mb-2">
-                {t('booking.selectProperty')}
-              </label>
-              <div className="grid grid-cols-1 gap-3">
-                {PROPERTIES.map((p) => (
-                  <label
-                    key={p}
-                    className={clsx('flex items-center p-3 border-2 rounded-lg cursor-pointer transition-colors',
-                      property === p ? 'border-brand-500 bg-brand-50' : 'border-stone-200 hover:border-stone-300'
-                    )}
-                  >
-                    <input
-                      type="radio"
-                      name="property"
-                      value={p}
-                      checked={property === p}
-                      onChange={() => setProperty(p)}
-                      className="h-4 w-4 border-hairline-strong text-brand-600 focus:ring-brand-600"
-                      data-testid={`property-${p}`}
-                    />
-                    <FiMapPin className="ml-3 mr-2 text-brand-600 flex-shrink-0" />
-                    <span className="font-medium">{t(`property.${p}`)}</span>
-                  </label>
-                ))}
+            <div className="space-y-4">
+              <div>
+                <span className="mb-2 block text-caption font-semibold text-ink">
+                  {t('booking.selectProperty')}
+                </span>
+                <div className="grid grid-cols-1 gap-3">
+                  {PROPERTIES.map((p) => (
+                    <label
+                      key={p}
+                      className={clsx('flex min-h-11 cursor-pointer items-center gap-3 rounded-card border p-4 transition-colors',
+                        property === p ? 'border-brand-600 ring-1 ring-brand-600 bg-brand-50' : 'border-hairline hover:border-hairline-strong'
+                      )}
+                    >
+                      <input
+                        type="radio"
+                        name="property"
+                        value={p}
+                        checked={property === p}
+                        onChange={() => setProperty(p)}
+                        className="sr-only"
+                        data-testid={`property-${p}`}
+                      />
+                      <FiMapPin className="h-5 w-5 flex-shrink-0 text-brand-600" aria-hidden="true" />
+                      <span className="text-body font-semibold text-ink">{t(`property.${p}`)}</span>
+                    </label>
+                  ))}
+                </div>
               </div>
+
+              <FormField label={t('booking.checkIn')} htmlFor="check-in-date">
+                <Input
+                  type="date"
+                  value={checkIn}
+                  min={today}
+                  onChange={(e) => {
+                    setCheckIn(e.target.value);
+                    if (checkOut && e.target.value >= checkOut) {
+                      setCheckOut('');
+                    }
+                  }}
+                  data-testid="check-in-date"
+                />
+              </FormField>
+
+              <FormField label={t('booking.checkOut')} htmlFor="check-out-date">
+                <Input
+                  type="date"
+                  value={checkOut}
+                  min={minCheckOut}
+                  onChange={(e) => setCheckOut(e.target.value)}
+                  disabled={!checkIn}
+                  data-testid="check-out-date"
+                />
+              </FormField>
+
+              <FormField label={t('booking.numberOfGuests')} htmlFor="num-guests">
+                <Select
+                  value={numGuests}
+                  onChange={(e) => setNumGuests(parseInt(e.target.value))}
+                  data-testid="num-guests"
+                >
+                  {[1, 2, 3, 4].map((n) => (
+                    <option key={n} value={n}>
+                      {n} {n === 1 ? t('booking.guest') : t('booking.guests')}
+                    </option>
+                  ))}
+                </Select>
+              </FormField>
             </div>
+          </Card>
 
-            <div>
-              <label className="block text-sm font-medium text-stone-700 mb-1">
-                {t('booking.checkIn')}
-              </label>
-              <input
-                type="date"
-                value={checkIn}
-                min={today}
-                onChange={(e) => {
-                  setCheckIn(e.target.value);
-                  if (checkOut && e.target.value >= checkOut) {
-                    setCheckOut('');
-                  }
-                }}
-                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500"
-                data-testid="check-in-date"
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-stone-700 mb-1">
-                {t('booking.checkOut')}
-              </label>
-              <input
-                type="date"
-                value={checkOut}
-                min={minCheckOut}
-                onChange={(e) => setCheckOut(e.target.value)}
-                disabled={!checkIn}
-                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500 disabled:bg-stone-100"
-                data-testid="check-out-date"
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-stone-700 mb-1">
-                {t('booking.numberOfGuests')}
-              </label>
-              <select
-                value={numGuests}
-                onChange={(e) => setNumGuests(parseInt(e.target.value))}
-                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500"
-                data-testid="num-guests"
-              >
-                {[1, 2, 3, 4].map((n) => (
-                  <option key={n} value={n}>
-                    {n} {n === 1 ? t('booking.guest') : t('booking.guests')}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {nights > 0 && (
-              <p className="text-sm text-stone-600">
-                {t('booking.nightsSelected', { count: nights })}
-              </p>
-            )}
-
-            <button
+          <div className={STICKY_CTA_CLASSES}>
+            <span className="text-body font-semibold text-ink">
+              {nights > 0 ? t('booking.nightsSelected', { count: nights }) : null}
+            </span>
+            <Button
               onClick={handleDateSubmit}
               disabled={!property || !checkIn || !checkOut || nights <= 0}
-              className="w-full py-2 px-4 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:bg-stone-300 disabled:cursor-not-allowed"
               data-testid="continue-to-rooms"
             >
               {t('common.continue')}
-            </button>
+            </Button>
           </div>
         </div>
       )}
@@ -424,20 +424,21 @@ export default function BookingPage() {
       {/* Step 2: Select Room Type */}
       {currentStep === 2 && (
         <div>
-          <div className="flex items-center justify-between mb-6">
-            <h2 className="text-xl font-semibold">
+          <div className="mb-6 flex items-center justify-between">
+            <h2 className="text-title text-ink">
               {t('booking.availableRooms')}
             </h2>
             <button
+              type="button"
               onClick={() => setCurrentStep(1)}
-              className="text-brand-600 hover:underline"
+              className="text-caption font-semibold text-brand-700 hover:underline"
             >
               {t('booking.changeDates')}
             </button>
           </div>
 
-          <p className="text-stone-600 mb-4">
-            {property && <span className="font-medium">{t(`property.${property}`)} · </span>}
+          <p className="mb-4 text-caption text-ink-muted">
+            {property && <span className="font-semibold text-ink">{t(`property.${property}`)} · </span>}
             {t('booking.stayDates', {
               checkIn: new Date(checkIn).toLocaleDateString(),
               checkOut: new Date(checkOut).toLocaleDateString(),
@@ -447,73 +448,89 @@ export default function BookingPage() {
 
           {isLoadingRoomTypes ? (
             <div className="flex justify-center py-12">
-              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-600" />
+              <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-brand-600" />
             </div>
           ) : roomTypes?.length === 0 ? (
-            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center">
-              <p className="text-yellow-800">{t('booking.noRoomsAvailable')}</p>
-            </div>
+            <Card surface="sunken" className="text-center">
+              <p className="text-warning-700">{t('booking.noRoomsAvailable')}</p>
+            </Card>
           ) : (
             <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-              {roomTypes?.map((roomType) => (
-                <div
-                  key={roomType.room_type_id}
-                  className={clsx('bg-white rounded-lg shadow overflow-hidden',
-                    roomType.available_count === 0 ? 'opacity-50' : 'hover:shadow-lg cursor-pointer'
-                  )}
-                  onClick={() => roomType.available_count > 0 && handleRoomTypeSelect(roomType.room_type_id)}
-                  data-testid={`room-type-${roomType.room_type_id}`}
-                >
-                  {/* Room Image */}
-                  {roomType.photo_url ? (
-                    <img
-                      src={roomType.photo_url}
-                      alt={roomType.name}
-                      className="w-full h-48 object-cover"
+              {roomTypes?.map((roomType) => {
+                const isSoldOut = roomType.available_count === 0;
+                const isSelected = selectedRoomTypeId === roomType.room_type_id;
+                return (
+                  <label
+                    key={roomType.room_type_id}
+                    className={clsx(
+                      'flex flex-col overflow-hidden rounded-card border bg-surface-card transition-colors',
+                      isSoldOut
+                        ? 'cursor-not-allowed border-hairline opacity-50'
+                        : clsx(
+                            'cursor-pointer',
+                            isSelected ? 'border-brand-600 ring-1 ring-brand-600 bg-brand-50' : 'border-hairline hover:border-hairline-strong'
+                          )
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name="roomType"
+                      value={roomType.room_type_id}
+                      checked={isSelected}
+                      disabled={isSoldOut}
+                      onChange={() => handleRoomTypeSelect(roomType.room_type_id)}
+                      className="sr-only"
+                      data-testid={`room-type-${roomType.room_type_id}`}
                     />
-                  ) : (
-                    <div className="w-full h-48 bg-stone-200 flex items-center justify-center">
-                      <span className="text-stone-400">{t('booking.noImage')}</span>
-                    </div>
-                  )}
 
-                  <div className="p-4">
-                    <h3 className="text-lg font-semibold">{roomType.name}</h3>
-                    {roomType.description && (
-                      <p className="text-stone-600 text-sm mt-1 line-clamp-2">{roomType.description}</p>
+                    {/* Room Image */}
+                    {roomType.photo_url ? (
+                      <img
+                        src={roomType.photo_url}
+                        alt={roomType.name}
+                        className="h-48 w-full object-cover"
+                      />
+                    ) : (
+                      <div className="flex h-48 w-full items-center justify-center bg-surface-sunken">
+                        <span className="text-caption text-ink-faint">{t('booking.noImage')}</span>
+                      </div>
                     )}
 
-                    {/* Price and Availability */}
-                    <div className="mt-4 pt-4 border-t">
-                      <div className="flex items-center justify-between">
-                        <div>
-                          <span className="text-2xl font-bold text-brand-600">
-                            ฿{roomType.nightly_price.toLocaleString()}
-                          </span>
-                          <span className="text-stone-500 text-sm">/{t('booking.night')}</span>
-                        </div>
-                        <div className="text-right">
-                          <div className="text-lg font-semibold">
-                            ฿{(roomType.nightly_price * nights).toLocaleString()}
-                          </div>
-                          <div className="text-sm text-stone-500">
-                            {t('booking.totalForNights', { nights })}
-                          </div>
-                        </div>
-                      </div>
-
-                      <div className={clsx('mt-2 text-sm',
-                        roomType.available_count === 0 ? 'text-red-600' : 'text-green-600'
+                    <div className="p-4">
+                      <h3 className="text-title text-ink">{roomType.name}</h3>
+                      {roomType.description && (
+                        <p className="mt-1 line-clamp-2 text-caption text-ink-muted">{roomType.description}</p>
                       )}
-                      >
-                        {roomType.available_count === 0
-                          ? t('booking.soldOut')
-                          : t('booking.roomsLeft', { count: roomType.available_count })}
+
+                      {/* Price and Availability */}
+                      <div className="mt-4 border-t border-hairline pt-4">
+                        <div className="flex items-center justify-between">
+                          <div>
+                            <span className="text-title text-ink">
+                              ฿{roomType.nightly_price.toLocaleString()}
+                            </span>
+                            <span className="text-caption text-ink-muted">/{t('booking.night')}</span>
+                          </div>
+                          <div className="text-right">
+                            <div className="text-body font-semibold text-ink">
+                              ฿{(roomType.nightly_price * nights).toLocaleString()}
+                            </div>
+                            <div className="text-fine text-ink-muted">
+                              {t('booking.totalForNights', { nights })}
+                            </div>
+                          </div>
+                        </div>
+
+                        <Badge tone={isSoldOut ? 'error' : 'success'} size="sm" className="mt-2">
+                          {isSoldOut
+                            ? t('booking.soldOut')
+                            : t('booking.roomsLeft', { count: roomType.available_count })}
+                        </Badge>
                       </div>
                     </div>
-                  </div>
-                </div>
-              ))}
+                  </label>
+                );
+              })}
             </div>
           )}
         </div>
@@ -521,209 +538,196 @@ export default function BookingPage() {
 
       {/* Step 3: Confirm Booking */}
       {currentStep === 3 && selectedRoomType && (
-        <div className="max-w-2xl mx-auto">
-          <div className="flex items-center justify-between mb-6">
-            <h2 className="text-xl font-semibold">{t('booking.confirmBooking')}</h2>
-            <button
-              onClick={() => setCurrentStep(2)}
-              className="text-brand-600 hover:underline"
-            >
-              {t('booking.changeRoom')}
-            </button>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6 space-y-6">
-            {/* Booking Summary */}
-            <div className="border-b pb-6">
-              <h3 className="font-semibold text-lg mb-4">{t('booking.bookingSummary')}</h3>
-
-              <div className="grid grid-cols-2 gap-4 text-sm">
-                <div>
-                  <span className="text-stone-500">{t('booking.property')}:</span>
-                  <span className="ml-2 font-medium">{property ? t(`property.${property}`) : ''}</span>
-                </div>
-                <div>
-                  <span className="text-stone-500">{t('booking.roomType')}:</span>
-                  <span className="ml-2 font-medium">{selectedRoomType.name}</span>
-                </div>
-                <div>
-                  <span className="text-stone-500">{t('booking.checkIn')}:</span>
-                  <span className="ml-2 font-medium">{new Date(checkIn).toLocaleDateString()}</span>
-                </div>
-                <div>
-                  <span className="text-stone-500">{t('booking.checkOut')}:</span>
-                  <span className="ml-2 font-medium">{new Date(checkOut).toLocaleDateString()}</span>
-                </div>
-                <div>
-                  <span className="text-stone-500">{t('booking.nights')}:</span>
-                  <span className="ml-2 font-medium">{nights}</span>
-                </div>
-                <div>
-                  <span className="text-stone-500">{t('booking.numberOfGuests')}:</span>
-                  <span className="ml-2 font-medium">{numGuests}</span>
-                </div>
-              </div>
+        <div className="pb-28">
+          <div className="mx-auto max-w-2xl">
+            <div className="mb-6 flex items-center justify-between">
+              <h2 className="text-title text-ink">{t('booking.confirmBooking')}</h2>
+              <button
+                type="button"
+                onClick={() => setCurrentStep(2)}
+                className="text-caption font-semibold text-brand-700 hover:underline"
+              >
+                {t('booking.changeRoom')}
+              </button>
             </div>
 
-            {/* Guest Details */}
-            <div className="border-b pb-6">
-              <h3 className="font-semibold text-lg mb-4 flex items-center">
-                <FiUsers className="mr-2" />
-                {t('booking.guestDetails')}
-              </h3>
+            <Card className="space-y-6">
+              {/* Booking Summary */}
+              <div className="border-b border-hairline pb-6">
+                <h3 className="mb-4 text-title text-ink">{t('booking.bookingSummary')}</h3>
 
-              <div className="space-y-4">
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('booking.guestName')}
-                  </label>
-                  <input
-                    type="text"
+                <div className="grid grid-cols-2 gap-4 text-caption">
+                  <div>
+                    <span className="text-ink-muted">{t('booking.property')}:</span>
+                    <span className="ml-2 font-semibold text-ink">{property ? t(`property.${property}`) : ''}</span>
+                  </div>
+                  <div>
+                    <span className="text-ink-muted">{t('booking.roomType')}:</span>
+                    <span className="ml-2 font-semibold text-ink">{selectedRoomType.name}</span>
+                  </div>
+                  <div>
+                    <span className="text-ink-muted">{t('booking.checkIn')}:</span>
+                    <span className="ml-2 font-semibold text-ink">{new Date(checkIn).toLocaleDateString()}</span>
+                  </div>
+                  <div>
+                    <span className="text-ink-muted">{t('booking.checkOut')}:</span>
+                    <span className="ml-2 font-semibold text-ink">{new Date(checkOut).toLocaleDateString()}</span>
+                  </div>
+                  <div>
+                    <span className="text-ink-muted">{t('booking.nights')}:</span>
+                    <span className="ml-2 font-semibold text-ink">{nights}</span>
+                  </div>
+                  <div>
+                    <span className="text-ink-muted">{t('booking.numberOfGuests')}:</span>
+                    <span className="ml-2 font-semibold text-ink">{numGuests}</span>
+                  </div>
+                </div>
+              </div>
+
+              {/* Guest Details */}
+              <div className="space-y-4 border-b border-hairline pb-6">
+                <h3 className="flex items-center gap-2 text-title text-ink">
+                  <FiUsers className="h-5 w-5" aria-hidden="true" />
+                  {t('booking.guestDetails')}
+                </h3>
+
+                <FormField label={t('booking.guestName')} htmlFor="guest-name">
+                  <Input
                     value={guestName}
                     onChange={(e) => setGuestName(e.target.value)}
-                    className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500"
                     data-testid="guest-name"
                   />
-                </div>
+                </FormField>
 
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('booking.guestPhone')}
-                  </label>
-                  <input
+                <FormField label={t('booking.guestPhone')} htmlFor="guest-phone">
+                  <Input
                     type="tel"
                     value={guestPhone}
                     onChange={(e) => setGuestPhone(e.target.value)}
                     placeholder={t('booking.guestPhonePlaceholder')}
-                    className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500"
                     data-testid="guest-phone"
                   />
-                </div>
+                </FormField>
               </div>
-            </div>
 
-            {/* Payment option (50% deposit or full) */}
-            <div className="border-b pb-6">
-              <h3 className="font-semibold text-lg mb-4">{t('payment.selectPaymentType')}</h3>
+              {/* Payment option (50% deposit or full) */}
+              <div className="border-b border-hairline pb-6">
+                <h3 className="mb-4 text-title text-ink">{t('payment.selectPaymentType')}</h3>
 
-              <div className="space-y-3">
-                <label
-                  className={clsx('flex items-start p-4 border-2 rounded-lg cursor-pointer transition-colors',
-                    paymentOption === 'deposit50' ? 'border-brand-500 bg-brand-50' : 'border-stone-200 hover:border-stone-300'
-                  )}
-                >
-                  <input
-                    type="radio"
-                    name="paymentOption"
-                    value="deposit50"
-                    checked={paymentOption === 'deposit50'}
-                    onChange={() => setPaymentOption('deposit50')}
-                    className="mt-1 h-4 w-4 border-hairline-strong text-brand-600 focus:ring-brand-600"
-                  />
-                  <div className="ml-3 flex-1">
-                    <div className="flex justify-between items-center">
-                      <span className="font-medium">{t('payment.deposit')}</span>
-                      <span className="text-lg font-bold text-brand-600">
-                        ฿{depositAmount.toLocaleString('th-TH')}
-                      </span>
+                <div className="space-y-3">
+                  <label
+                    className={clsx('flex min-h-11 cursor-pointer items-start gap-3 rounded-card border p-4 transition-colors',
+                      paymentOption === 'deposit50' ? 'border-brand-600 ring-1 ring-brand-600 bg-brand-50' : 'border-hairline hover:border-hairline-strong'
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name="paymentOption"
+                      value="deposit50"
+                      checked={paymentOption === 'deposit50'}
+                      onChange={() => setPaymentOption('deposit50')}
+                      className="sr-only"
+                    />
+                    <div className="flex-1">
+                      <div className="flex items-center justify-between">
+                        <span className="text-body font-semibold text-ink">{t('payment.deposit')}</span>
+                        <span className="text-title text-brand-600">
+                          ฿{depositAmount.toLocaleString('th-TH')}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-caption text-ink-muted">{t('payment.depositDescription')}</p>
                     </div>
-                    <p className="text-sm text-stone-500 mt-1">{t('payment.depositDescription')}</p>
-                  </div>
-                </label>
+                  </label>
 
-                <label
-                  className={clsx('flex items-start p-4 border-2 rounded-lg cursor-pointer transition-colors',
-                    paymentOption === 'full' ? 'border-brand-500 bg-brand-50' : 'border-stone-200 hover:border-stone-300'
-                  )}
-                >
-                  <input
-                    type="radio"
-                    name="paymentOption"
-                    value="full"
-                    checked={paymentOption === 'full'}
-                    onChange={() => setPaymentOption('full')}
-                    className="mt-1 h-4 w-4 border-hairline-strong text-brand-600 focus:ring-brand-600"
-                  />
-                  <div className="ml-3 flex-1">
-                    <div className="flex justify-between items-center">
-                      <span className="font-medium">{t('payment.payInFull')}</span>
-                      <span className="text-lg font-bold text-brand-600">
-                        ฿{totalPrice.toLocaleString('th-TH')}
-                      </span>
+                  <label
+                    className={clsx('flex min-h-11 cursor-pointer items-start gap-3 rounded-card border p-4 transition-colors',
+                      paymentOption === 'full' ? 'border-brand-600 ring-1 ring-brand-600 bg-brand-50' : 'border-hairline hover:border-hairline-strong'
+                    )}
+                  >
+                    <input
+                      type="radio"
+                      name="paymentOption"
+                      value="full"
+                      checked={paymentOption === 'full'}
+                      onChange={() => setPaymentOption('full')}
+                      className="sr-only"
+                    />
+                    <div className="flex-1">
+                      <div className="flex items-center justify-between">
+                        <span className="text-body font-semibold text-ink">{t('payment.payInFull')}</span>
+                        <span className="text-title text-brand-600">
+                          ฿{totalPrice.toLocaleString('th-TH')}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-caption text-ink-muted">{t('payment.payInFullDescription')}</p>
                     </div>
-                    <p className="text-sm text-stone-500 mt-1">{t('payment.payInFullDescription')}</p>
+                  </label>
+                </div>
+              </div>
+
+              {/* Price Details */}
+              <div>
+                <h3 className="mb-4 text-title text-ink">{t('booking.priceDetails')}</h3>
+
+                <div className="space-y-2 text-caption">
+                  <div className="flex justify-between text-ink-muted">
+                    <span>
+                      ฿{selectedRoomType.nightly_price.toLocaleString()} x {nights} {nights === 1 ? t('booking.night') : t('booking.nights')}
+                    </span>
+                    <span>฿{totalPrice.toLocaleString()}</span>
                   </div>
-                </label>
-              </div>
-            </div>
-
-            {/* Price Details */}
-            <div className="border-b pb-6">
-              <h3 className="font-semibold text-lg mb-4">{t('booking.priceDetails')}</h3>
-
-              <div className="space-y-2 text-sm">
-                <div className="flex justify-between">
-                  <span>
-                    ฿{selectedRoomType.nightly_price.toLocaleString()} x {nights} {nights === 1 ? t('booking.night') : t('booking.nights')}
-                  </span>
-                  <span>฿{totalPrice.toLocaleString()}</span>
-                </div>
-                <div className="flex justify-between font-semibold text-lg pt-2 border-t">
-                  <span>{t('booking.total')}</span>
-                  <span className="text-brand-600">฿{totalPrice.toLocaleString()}</span>
-                </div>
-                <div className="flex justify-between text-sm text-stone-600">
-                  <span>{t('payment.amountToPay')}</span>
-                  <span>฿{amountDueNow.toLocaleString()}</span>
+                  <div className="flex justify-between border-t border-hairline pt-2 text-body font-semibold text-ink">
+                    <span>{t('booking.total')}</span>
+                    <span className="text-brand-600">฿{totalPrice.toLocaleString()}</span>
+                  </div>
+                  <div className="flex justify-between text-ink-muted">
+                    <span>{t('payment.amountToPay')}</span>
+                    <span>฿{amountDueNow.toLocaleString()}</span>
+                  </div>
                 </div>
               </div>
-            </div>
+            </Card>
+          </div>
 
-            {/* Submit Button */}
-            <button
+          <div className={STICKY_CTA_CLASSES}>
+            <span className="text-body font-semibold text-ink">฿{totalPrice.toLocaleString()}</span>
+            <Button
               onClick={handleBookingSubmit}
-              disabled={createBookingMutation.isPending || !guestName.trim() || !guestPhone.trim()}
-              className="w-full py-3 px-4 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:bg-stone-300 disabled:cursor-not-allowed font-semibold"
+              loading={createBookingMutation.isPending}
+              disabled={!guestName.trim() || !guestPhone.trim()}
               data-testid="confirm-booking"
             >
-              {createBookingMutation.isPending ? (
-                <span className="flex items-center justify-center">
-                  <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2" />
-                  {t('booking.processing')}
-                </span>
-              ) : (
-                t('booking.confirmAndBook')
-              )}
-            </button>
+              {t('booking.confirmAndBook')}
+            </Button>
           </div>
         </div>
       )}
 
       {/* Step 4: Payment */}
       {currentStep === 4 && createdBooking && (
-        <div className="max-w-2xl mx-auto">
-          <div className="flex items-center justify-between mb-6">
-            <h2 className="text-xl font-semibold">{t('payment.title')}</h2>
+        <div className={clsx('mx-auto max-w-2xl', !holdExpired && 'pb-28')}>
+          <div className="mb-6 flex items-center justify-between">
+            <h2 className="text-title text-ink">{t('payment.title')}</h2>
           </div>
 
-          <div className="bg-white rounded-lg shadow p-6 space-y-6">
+          <Card className="space-y-6">
             {/* Amount summary */}
-            <div className="p-4 bg-brand-50 border-2 border-brand-200 rounded-lg space-y-2">
-              <div className="flex justify-between items-center">
+            <div className="space-y-2 rounded-lg border border-brand-200 bg-brand-50 p-4">
+              <div className="flex items-center justify-between">
                 <div>
-                  <p className="font-medium">
+                  <p className="font-semibold text-ink">
                     {paymentOption === 'deposit50' ? t('payment.deposit') : t('payment.payInFull')}
                   </p>
-                  <p className="text-sm text-stone-500">{t('payment.amountToPay')}</p>
+                  <p className="text-caption text-ink-muted">{t('payment.amountToPay')}</p>
                 </div>
-                <p className="text-2xl font-bold text-brand-600" data-testid="amount-due-now">
+                <p className="text-display text-brand-600" data-testid="amount-due-now">
                   ฿{createdBooking.amount_due_now.toLocaleString('th-TH')}
                 </p>
               </div>
               {createdBooking.balance_due_at_checkin > 0 && (
-                <div className="flex justify-between items-center text-sm border-t border-brand-200 pt-2">
-                  <span className="text-stone-600">{t('payment.balanceDueAtCheckin')}</span>
-                  <span className="font-semibold" data-testid="balance-due">
+                <div className="flex items-center justify-between border-t border-brand-200 pt-2 text-caption">
+                  <span className="text-ink-muted">{t('payment.balanceDueAtCheckin')}</span>
+                  <span className="font-semibold text-ink" data-testid="balance-due">
                     ฿{createdBooking.balance_due_at_checkin.toLocaleString('th-TH')}
                   </span>
                 </div>
@@ -732,74 +736,79 @@ export default function BookingPage() {
 
             {/* Hold expiry countdown */}
             {holdMsLeft !== null && !holdExpired && slipStatus === 'pending' && (
-              <div className="flex items-center justify-center gap-2 text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-lg p-3" data-testid="hold-countdown">
-                <FiClock className="w-4 h-4" />
+              <Badge
+                tone="warning"
+                size="md"
+                className="w-full justify-center gap-2 py-3"
+                data-testid="hold-countdown"
+              >
+                <FiClock className="h-4 w-4" aria-hidden="true" />
                 <span>{t('payment.holdExpiresIn', { time: formatCountdown(holdMsLeft) })}</span>
-              </div>
+              </Badge>
             )}
 
             {holdExpired ? (
-              <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center space-y-4" data-testid="hold-expired">
-                <FiAlertCircle className="w-8 h-8 text-red-500 mx-auto" />
-                <p className="font-medium text-red-800">{t('payment.holdExpired')}</p>
-                <button
-                  onClick={restartBooking}
-                  className="py-2 px-6 bg-brand-600 text-white rounded-md hover:bg-brand-700"
-                >
-                  {t('payment.startOver')}
-                </button>
+              <div
+                className="space-y-4 rounded-card border border-error-600 bg-error-50 p-6 text-center"
+                data-testid="hold-expired"
+              >
+                <FiAlertCircle className="mx-auto h-8 w-8 text-error-600" aria-hidden="true" />
+                <p className="font-semibold text-error-700">{t('payment.holdExpired')}</p>
+                <Button onClick={restartBooking}>{t('payment.startOver')}</Button>
               </div>
             ) : (
               <>
-                {/* Per-property PromptPay QR */}
-                <div className="border-b pb-6">
-                  <h3 className="font-semibold text-lg mb-4">{t('payment.scanQRCode')}</h3>
+                {/* Per-property PromptPay QR — pure white panel, imagery elevation */}
+                <div className="border-b border-hairline pb-6">
+                  <h3 className="mb-4 text-title text-ink">{t('payment.scanQRCode')}</h3>
 
-                  <div className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm space-y-4">
+                  <div className="space-y-4 rounded-lg bg-white p-4 shadow-soft">
                     {qrDataUrl ? (
                       <img
                         src={qrDataUrl}
                         alt="PromptPay QR Code"
-                        className="w-full max-w-xs mx-auto"
+                        className="mx-auto w-full max-w-xs"
                         data-testid="promptpay-qr"
                       />
                     ) : (
                       <div
-                        className="flex items-center justify-center h-48"
+                        className="flex h-48 items-center justify-center"
                         data-testid="qr-loading"
                       >
-                        <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-brand-600" />
+                        <div className="h-10 w-10 animate-spin rounded-full border-b-2 border-brand-600" />
                       </div>
                     )}
 
-                    <p className="text-sm text-stone-600 text-center">
+                    <p className="text-center text-caption text-ink-muted">
                       {t('payment.scanInstructions')}
                     </p>
-                    <p className="text-xs text-stone-500 text-center">
+                    <p className="text-center text-fine text-ink-faint">
                       {t('payment.propertyAccount', { property: t(`property.${availability?.property ?? 'hf'}`) })}
                     </p>
                   </div>
                 </div>
 
                 {/* Slip Upload Section */}
-                <div className="pb-6">
-                  <h3 className="font-semibold text-lg mb-4">{t('payment.uploadSlip')}</h3>
-                  <p className="text-sm text-stone-600 mb-4">{t('payment.uploadSlipDescription')}</p>
+                <div>
+                  <h3 className="mb-4 text-title text-ink">{t('payment.uploadSlip')}</h3>
+                  <p className="mb-4 text-caption text-ink-muted">{t('payment.uploadSlipDescription')}</p>
 
                   {slipStatus === 'pending' && !slipPreview && (
                     <div
-                      className={clsx('border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors',
-                        isDragging ? 'border-brand-500 bg-brand-50' : 'border-stone-300 hover:border-brand-400'
+                      className={clsx('rounded-card border-2 border-dashed bg-surface-sunken p-8 text-center transition-colors',
+                        isDragging ? 'border-brand-600' : 'border-hairline-strong hover:border-brand-600'
                       )}
                       onDragOver={handleDragOver}
                       onDragLeave={handleDragLeave}
                       onDrop={handleDrop}
-                      onClick={() => fileInputRef.current?.click()}
                       data-testid="slip-dropzone"
                     >
-                      <FiUpload className="w-12 h-12 text-stone-400 mx-auto mb-3" />
-                      <p className="text-stone-600 mb-2">{t('payment.dragDropSlip')}</p>
-                      <p className="text-xs text-stone-400">JPG, PNG (max 10MB)</p>
+                      <FiUpload className="mx-auto mb-3 h-12 w-12 text-ink-faint" aria-hidden="true" />
+                      <p className="mb-2 text-body text-ink-muted">{t('payment.dragDropSlip')}</p>
+                      <p className="mb-4 text-fine text-ink-faint">JPG, PNG (max 10MB)</p>
+                      <Button type="button" variant="secondary" onClick={() => fileInputRef.current?.click()}>
+                        {t('payment.browseFiles')}
+                      </Button>
                       <input
                         ref={fileInputRef}
                         type="file"
@@ -812,113 +821,104 @@ export default function BookingPage() {
                   )}
 
                   {slipPreview && slipStatus === 'pending' && (
-                    <div className="relative border rounded-lg overflow-hidden">
+                    <div className="relative overflow-hidden rounded-card border border-hairline">
                       <img
                         src={slipPreview}
                         alt="Transfer slip preview"
-                        className="w-full max-h-64 object-contain bg-stone-100"
+                        className="max-h-64 w-full bg-surface-sunken object-contain"
                       />
-                      <button
+                      <Button
+                        variant="destructive"
+                        size="icon"
                         onClick={removeSlip}
-                        className="absolute top-2 right-2 p-2 bg-red-500 text-white rounded-full hover:bg-red-600"
+                        className="absolute right-2 top-2"
                         data-testid="remove-slip"
+                        aria-label={t('common.close', 'Close')}
                       >
-                        <FiX className="w-4 h-4" />
-                      </button>
+                        <FiX className="h-4 w-4" aria-hidden="true" />
+                      </Button>
                     </div>
                   )}
 
                   {slipStatus === 'uploaded' && (
                     <div className="space-y-4">
                       {slipPreview && (
-                        <div className="relative border rounded-lg overflow-hidden">
+                        <div className="overflow-hidden rounded-card border border-hairline">
                           <img
                             src={slipPreview}
                             alt="Uploaded slip"
-                            className="w-full max-h-64 object-contain bg-stone-100"
+                            className="max-h-64 w-full bg-surface-sunken object-contain"
                           />
                         </div>
                       )}
 
-                      <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 flex items-center">
-                        <FiClock className="w-6 h-6 text-yellow-500 mr-3" />
-                        <div>
-                          <p className="font-medium text-yellow-800">{t('payment.slipUploaded')}</p>
-                          <p className="text-sm text-yellow-600">{t('payment.awaitingVerification')}</p>
-                        </div>
-                      </div>
+                      <Badge tone="warning" size="md" className="w-full gap-3 py-4">
+                        <FiClock className="h-6 w-6 flex-shrink-0" aria-hidden="true" />
+                        <span className="flex flex-col text-left">
+                          <span className="font-semibold">{t('payment.slipUploaded')}</span>
+                          <span className="font-normal">{t('payment.awaitingVerification')}</span>
+                        </span>
+                      </Badge>
 
-                      <button
+                      <Button
+                        variant="secondary"
+                        className="w-full"
                         onClick={() => navigate(`/my-bookings?openBooking=${createdBooking.booking_id}&tab=payment`)}
-                        className="w-full py-2 text-brand-600 border border-brand-300 rounded-lg hover:bg-brand-50 transition-colors"
                       >
                         {t('payment.changeSlip')}
-                      </button>
+                      </Button>
                     </div>
                   )}
 
                   {slipStatus === 'verified' && (
-                    <div className="bg-green-50 border border-green-200 rounded-lg p-4 flex items-center">
-                      <FiCheckCircle className="w-6 h-6 text-green-500 mr-3" />
-                      <div>
-                        <p className="font-medium text-green-800">{t('payment.verified')}</p>
-                      </div>
-                    </div>
+                    <Badge tone="success" size="md" className="w-full gap-3 py-4">
+                      <FiCheckCircle className="h-6 w-6 flex-shrink-0" aria-hidden="true" />
+                      <span className="font-semibold">{t('payment.verified')}</span>
+                    </Badge>
                   )}
 
                   {slipStatus === 'failed' && (
-                    <div className="bg-red-50 border border-red-200 rounded-lg p-4 flex items-center">
-                      <FiAlertCircle className="w-6 h-6 text-red-500 mr-3" />
-                      <div>
-                        <p className="font-medium text-red-800">{t('payment.verificationFailed')}</p>
-                      </div>
-                    </div>
-                  )}
-                </div>
-
-                {/* Action Buttons */}
-                <div className="flex gap-4">
-                  <button
-                    onClick={handleSkipPayment}
-                    className="flex-1 py-3 px-4 border border-stone-300 text-stone-700 rounded-md hover:bg-stone-50"
-                    data-testid="skip-payment"
-                  >
-                    {t('payment.payLater')}
-                  </button>
-
-                  {slipPreview && slipStatus === 'pending' && (
-                    <button
-                      onClick={handleSlipUpload}
-                      disabled={isUploading}
-                      className="flex-1 py-3 px-4 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:bg-stone-300 disabled:cursor-not-allowed font-semibold"
-                      data-testid="submit-slip"
-                    >
-                      {isUploading ? (
-                        <span className="flex items-center justify-center">
-                          <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2" />
-                          {t('common.processing')}
-                        </span>
-                      ) : (
-                        t('payment.submitSlip')
-                      )}
-                    </button>
-                  )}
-
-                  {(slipStatus === 'uploaded' || slipStatus === 'verified') && (
-                    <button
-                      onClick={() => navigate('/my-bookings')}
-                      className="flex-1 py-3 px-4 bg-brand-600 text-white rounded-md hover:bg-brand-700 font-semibold"
-                      data-testid="view-bookings"
-                    >
-                      {t('booking.myBookings')}
-                    </button>
+                    <Badge tone="error" size="md" className="w-full gap-3 py-4">
+                      <FiAlertCircle className="h-6 w-6 flex-shrink-0" aria-hidden="true" />
+                      <span className="font-semibold">{t('payment.verificationFailed')}</span>
+                    </Badge>
                   )}
                 </div>
               </>
             )}
+          </Card>
+        </div>
+      )}
+
+      {/* Step 4 action bar — thumb-zone, mirrors steps 1 & 3 */}
+      {currentStep === 4 && createdBooking && !holdExpired && (
+        <div className={STICKY_CTA_CLASSES}>
+          <span className="text-body font-semibold text-ink">
+            ฿{createdBooking.amount_due_now.toLocaleString('th-TH')}
+          </span>
+          <div className="flex items-center gap-3">
+            <Button variant="secondary" onClick={handleSkipPayment} data-testid="skip-payment">
+              {t('payment.payLater')}
+            </Button>
+
+            {slipPreview && slipStatus === 'pending' && (
+              <Button
+                loading={isUploading}
+                onClick={handleSlipUpload}
+                data-testid="submit-slip"
+              >
+                {t('payment.submitSlip')}
+              </Button>
+            )}
+
+            {(slipStatus === 'uploaded' || slipStatus === 'verified') && (
+              <Button onClick={() => navigate('/my-bookings')} data-testid="view-bookings">
+                {t('booking.myBookings')}
+              </Button>
+            )}
           </div>
         </div>
       )}
-    </MainLayout>
+    </AppShell>
   );
 }

--- a/frontend/src/pages/MyBookingsPage.tsx
+++ b/frontend/src/pages/MyBookingsPage.tsx
@@ -2,7 +2,21 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { FiCalendar, FiUsers, FiStar, FiAlertCircle, FiPlus, FiChevronRight, FiX, FiUpload, FiCheckCircle, FiClock, FiDollarSign, FiDownload } from 'react-icons/fi';
-import MainLayout from '../components/layout/MainLayout';
+import AppShell from '../components/layout/AppShell';
+import {
+  Button,
+  buttonVariants,
+  Card,
+  Badge,
+  Modal,
+  TabNav,
+  EmptyState,
+  PageHeader,
+  FormField,
+  Textarea,
+  type BadgeTone,
+  type TabItem,
+} from '../components/ui';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import clsx from 'clsx';
 import toast from 'react-hot-toast';
@@ -13,31 +27,50 @@ import kbankLogo from '../assets/kbank-logo.png';
 
 type BookingStatus = 'confirmed' | 'cancelled' | 'completed';
 type BookingTab = 'current' | 'history';
+type StatusGlyphName = 'clock' | 'check' | 'alert';
 
-const statusColors: Record<BookingStatus | 'cancelledByAdmin', { bg: string; text: string }> = {
-  confirmed: { bg: 'bg-green-100', text: 'text-green-800' },
-  cancelled: { bg: 'bg-red-100', text: 'text-red-800' },
-  completed: { bg: 'bg-brand-100', text: 'text-brand-800' },
-  cancelledByAdmin: { bg: 'bg-amber-100', text: 'text-amber-800' },
+// The four status-color records this page has always kept at the top of the
+// file — now mapping each API status value to a design-system Badge tone
+// (+ optional glyph) instead of a bespoke bg/text class pair. Semantics are
+// unchanged: same states, same grouping, just routed through the shared
+// token grammar.
+const STATUS_BADGE_TONE: Record<BookingStatus | 'cancelledByAdmin', BadgeTone> = {
+  confirmed: 'success',
+  cancelled: 'error',
+  completed: 'brand',
+  cancelledByAdmin: 'warning',
 };
 
-const paymentStatusColors: Record<string, { bg: string; text: string }> = {
-  deposit: { bg: 'bg-orange-100', text: 'text-orange-800' },
-  full: { bg: 'bg-green-100', text: 'text-green-800' },
+const PAYMENT_TYPE_BADGE_TONE: Record<string, BadgeTone> = {
+  deposit: 'warning',
+  full: 'success',
 };
 
-const slipOkStatusColors: Record<string, { bg: string; text: string; icon: 'clock' | 'check' | 'alert' }> = {
-  pending: { bg: 'bg-yellow-100', text: 'text-yellow-800', icon: 'clock' },
-  verified: { bg: 'bg-green-100', text: 'text-green-800', icon: 'check' },
-  failed: { bg: 'bg-red-100', text: 'text-red-800', icon: 'alert' },
-  quota_exceeded: { bg: 'bg-orange-100', text: 'text-orange-800', icon: 'alert' },
+const SLIP_OK_STATUS: Record<string, { tone: BadgeTone; icon: StatusGlyphName }> = {
+  pending: { tone: 'warning', icon: 'clock' },
+  verified: { tone: 'success', icon: 'check' },
+  failed: { tone: 'error', icon: 'alert' },
+  quota_exceeded: { tone: 'warning', icon: 'alert' },
 };
 
-const adminStatusColors: Record<string, { bg: string; text: string; icon: 'clock' | 'check' | 'alert' }> = {
-  pending: { bg: 'bg-yellow-100', text: 'text-yellow-800', icon: 'clock' },
-  verified: { bg: 'bg-green-100', text: 'text-green-800', icon: 'check' },
-  needs_action: { bg: 'bg-red-100', text: 'text-red-800', icon: 'alert' },
+const ADMIN_STATUS: Record<string, { tone: BadgeTone; icon: StatusGlyphName }> = {
+  pending: { tone: 'warning', icon: 'clock' },
+  verified: { tone: 'success', icon: 'check' },
+  needs_action: { tone: 'error', icon: 'alert' },
 };
+
+function StatusGlyph({ icon }: { icon?: StatusGlyphName }) {
+  if (icon === 'check') {
+    return <FiCheckCircle className="h-3 w-3" aria-hidden="true" />;
+  }
+  if (icon === 'clock') {
+    return <FiClock className="h-3 w-3" aria-hidden="true" />;
+  }
+  if (icon === 'alert') {
+    return <FiAlertCircle className="h-3 w-3" aria-hidden="true" />;
+  }
+  return null;
+}
 
 export default function MyBookingsPage() {
   const { t } = useTranslation();
@@ -58,6 +91,15 @@ export default function MyBookingsPage() {
   const [isUploading, setIsUploading] = useState(false);
   const [showBankDetails, setShowBankDetails] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Modals default their initial focus to the first focusable descendant,
+  // which would otherwise be each modal's own icon-only close button —
+  // landing default focus on a dismiss control is bad UX (and, combined
+  // with keyboard-triggered opens, can even race a still-in-flight Enter
+  // keypress into an accidental immediate close). Point initial focus at
+  // the heading instead.
+  const detailsModalHeadingRef = useRef<HTMLHeadingElement>(null);
+  const slipUploadModalHeadingRef = useRef<HTMLHeadingElement>(null);
 
   // QR code URL - use env variable or fallback to bundled image
   const promptPayQRUrl = import.meta.env.VITE_PROMPTPAY_QR_IMAGE_URL ?? companyQRCode;
@@ -304,764 +346,655 @@ export default function MyBookingsPage() {
 
   if (isLoading) {
     return (
-      <MainLayout title={t('booking.myBookings')}>
+      <AppShell variant="guest" title={t('booking.myBookings')}>
         <div className="flex justify-center py-12">
           <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-600" />
         </div>
-      </MainLayout>
+      </AppShell>
     );
   }
 
+  const tabItems: TabItem[] = [
+    { value: 'current', label: `${t('booking.currentBookings')} (${currentBookings.length})` },
+    { value: 'history', label: `${t('booking.bookingHistory')} (${historyBookings.length})` },
+  ];
+
   return (
-    <MainLayout title={t('booking.myBookings')}>
-      {/* Header with Book Button */}
-      <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold">{t('booking.myBookings')}</h2>
-        <Link
-          to="/booking"
-          className="inline-flex items-center px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700"
-          data-testid="new-booking-button"
-        >
-          <FiPlus className="mr-2" />
-          {t('booking.bookRoom')}
-        </Link>
+    <AppShell variant="guest" title={t('booking.myBookings')}>
+      <PageHeader
+        title={t('booking.myBookings')}
+        actions={
+          <Link to="/booking" className={buttonVariants({ size: 'sm' })} data-testid="new-booking-button">
+            <FiPlus className="h-4 w-4" aria-hidden="true" />
+            {t('booking.bookRoom')}
+          </Link>
+        }
+      />
+
+      <div className="mb-6">
+        <TabNav
+          items={tabItems}
+          value={activeTab}
+          onChange={(value) => setActiveTab(value as BookingTab)}
+          aria-label={t('booking.myBookings')}
+        />
       </div>
 
-      {/* Tabs */}
-      <div className="border-b border-stone-200 mb-6">
-        <nav className="-mb-px flex space-x-8">
-          <button
-            onClick={() => setActiveTab('current')}
-            className={clsx('py-2 px-1 border-b-2 font-medium text-sm',
-              activeTab === 'current'
-                ? 'border-brand-500 text-brand-600'
-                : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
-            )}
-            data-testid="tab-current"
-          >
-            {t('booking.currentBookings')} ({currentBookings.length})
-          </button>
-          <button
-            onClick={() => setActiveTab('history')}
-            className={clsx('py-2 px-1 border-b-2 font-medium text-sm',
-              activeTab === 'history'
-                ? 'border-brand-500 text-brand-600'
-                : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
-            )}
-            data-testid="tab-history"
-          >
-            {t('booking.bookingHistory')} ({historyBookings.length})
-          </button>
-        </nav>
-      </div>
-
-      {/* Empty State */}
       {displayedBookings.length === 0 ? (
-        <div className="bg-white rounded-lg shadow p-8 text-center">
-          <FiCalendar className="w-16 h-16 text-stone-300 mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-stone-900 mb-2">
-            {activeTab === 'current' ? t('booking.noCurrentBookings') : t('booking.noBookingHistory')}
-          </h3>
-          <p className="text-stone-500 mb-6">
-            {activeTab === 'current'
+        <EmptyState
+          icon={FiCalendar}
+          title={activeTab === 'current' ? t('booking.noCurrentBookings') : t('booking.noBookingHistory')}
+          description={
+            activeTab === 'current'
               ? t('booking.noCurrentBookingsDescription')
-              : t('booking.noBookingHistoryDescription')}
-          </p>
-          {activeTab === 'current' && (
-            <Link
-              to="/booking"
-              className="inline-flex items-center px-6 py-3 bg-brand-600 text-white rounded-md hover:bg-brand-700"
-            >
-              <FiPlus className="mr-2" />
-              {t('booking.bookYourFirstRoom')}
-            </Link>
-          )}
-        </div>
+              : t('booking.noBookingHistoryDescription')
+          }
+          action={
+            activeTab === 'current' ? (
+              <Link to="/booking" className={buttonVariants()}>
+                <FiPlus className="h-4 w-4" aria-hidden="true" />
+                {t('booking.bookYourFirstRoom')}
+              </Link>
+            ) : undefined
+          }
+        />
       ) : (
         <div className="space-y-4">
-          {displayedBookings.map((booking) => (
-            <div
-              key={booking.id}
-              className="bg-white rounded-lg shadow overflow-hidden cursor-pointer hover:shadow-md transition-shadow"
-              data-testid={`booking-card-${booking.id}`}
-              onClick={() => handleCardClick(booking as Booking)}
-              role="button"
-              tabIndex={0}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  handleCardClick(booking as Booking);
-                }
-              }}
-            >
-              <div className="p-6">
-                <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
-                  {/* Booking Details */}
-                  <div className="flex-1">
-                    <div className="flex items-center gap-3 mb-3 flex-wrap">
-                      <h3 className="text-lg font-semibold">{booking.roomTypeName}</h3>
-                      {(() => {
-                        const displayStatus = getDisplayStatus(booking as Booking);
-                        return (
-                          <span className={`px-2 py-1 rounded-full text-xs font-medium ${statusColors[displayStatus.key]?.bg} ${statusColors[displayStatus.key]?.text}`}>
-                            {t(displayStatus.translationKey)}
-                          </span>
-                        );
-                      })()}
-                      {/* Payment Type Badge */}
-                      {(booking as Booking).paymentType && (
-                        <span className={`px-2 py-1 rounded-full text-xs font-medium ${paymentStatusColors[(booking as Booking).paymentType as string]?.bg} ${paymentStatusColors[(booking as Booking).paymentType as string]?.text}`}>
-                          <FiDollarSign className="inline w-3 h-3 mr-1" />
-                          {(booking as Booking).paymentType === 'deposit' ? t('payment.deposit') : t('payment.payInFull')}
-                        </span>
-                      )}
-                      {/* SlipOK Status Badge */}
-                      {(booking as Booking).slipOkStatus && (
-                        <span className={`px-2 py-1 rounded-full text-xs font-medium ${slipOkStatusColors[(booking as Booking).slipOkStatus as string]?.bg} ${slipOkStatusColors[(booking as Booking).slipOkStatus as string]?.text}`}>
-                          {slipOkStatusColors[(booking as Booking).slipOkStatus as string]?.icon === 'check' && <FiCheckCircle className="inline w-3 h-3 mr-1" />}
-                          {slipOkStatusColors[(booking as Booking).slipOkStatus as string]?.icon === 'clock' && <FiClock className="inline w-3 h-3 mr-1" />}
-                          {slipOkStatusColors[(booking as Booking).slipOkStatus as string]?.icon === 'alert' && <FiAlertCircle className="inline w-3 h-3 mr-1" />}
-                          {t(`payment.slipok.${(booking as Booking).slipOkStatus}`)}
-                        </span>
-                      )}
-                      {/* Admin Status Badge */}
-                      {(booking as Booking).adminVerificationStatus && (
-                        <span className={`px-2 py-1 rounded-full text-xs font-medium ${adminStatusColors[(booking as Booking).adminVerificationStatus as string]?.bg} ${adminStatusColors[(booking as Booking).adminVerificationStatus as string]?.text}`}>
-                          {adminStatusColors[(booking as Booking).adminVerificationStatus as string]?.icon === 'check' && <FiCheckCircle className="inline w-3 h-3 mr-1" />}
-                          {adminStatusColors[(booking as Booking).adminVerificationStatus as string]?.icon === 'clock' && <FiClock className="inline w-3 h-3 mr-1" />}
-                          {adminStatusColors[(booking as Booking).adminVerificationStatus as string]?.icon === 'alert' && <FiAlertCircle className="inline w-3 h-3 mr-1" />}
-                          {t(`payment.admin.${(booking as Booking).adminVerificationStatus}`)}
-                        </span>
-                      )}
-                    </div>
-
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-stone-600">
-                      <div className="flex items-center">
-                        <FiCalendar className="mr-2 text-stone-400" />
-                        <div>
-                          <span className="font-medium">{t('booking.checkIn')}:</span>{' '}
-                          {new Date(booking.checkInDate).toLocaleDateString()}
-                        </div>
+          {displayedBookings.map((rawBooking) => {
+            const booking = rawBooking as Booking;
+            const displayStatus = getDisplayStatus(booking);
+            return (
+              <Card
+                key={booking.id}
+                padding="none"
+                data-testid={`booking-card-${booking.id}`}
+                onClick={() => handleCardClick(booking)}
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    handleCardClick(booking);
+                  }
+                }}
+                className="cursor-pointer overflow-hidden transition-colors hover:border-hairline-strong"
+              >
+                <div className="p-6">
+                  <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+                    {/* Booking Details */}
+                    <div className="flex-1">
+                      <div className="mb-3 flex flex-wrap items-center gap-2">
+                        <h3 className="text-title text-ink">{booking.roomTypeName}</h3>
+                        <Badge tone={STATUS_BADGE_TONE[displayStatus.key]} size="sm">
+                          {t(displayStatus.translationKey)}
+                        </Badge>
+                        {/* Payment Type Badge */}
+                        {booking.paymentType && (
+                          <Badge tone={PAYMENT_TYPE_BADGE_TONE[booking.paymentType] ?? 'neutral'} size="sm">
+                            <FiDollarSign className="h-3 w-3" aria-hidden="true" />
+                            {booking.paymentType === 'deposit' ? t('payment.deposit') : t('payment.payInFull')}
+                          </Badge>
+                        )}
+                        {/* SlipOK Status Badge */}
+                        {booking.slipOkStatus && (
+                          <Badge tone={SLIP_OK_STATUS[booking.slipOkStatus]?.tone ?? 'neutral'} size="sm">
+                            <StatusGlyph icon={SLIP_OK_STATUS[booking.slipOkStatus]?.icon} />
+                            {t(`payment.slipok.${booking.slipOkStatus}`)}
+                          </Badge>
+                        )}
+                        {/* Admin Status Badge */}
+                        {booking.adminVerificationStatus && (
+                          <Badge tone={ADMIN_STATUS[booking.adminVerificationStatus]?.tone ?? 'neutral'} size="sm">
+                            <StatusGlyph icon={ADMIN_STATUS[booking.adminVerificationStatus]?.icon} />
+                            {t(`payment.admin.${booking.adminVerificationStatus}`)}
+                          </Badge>
+                        )}
                       </div>
 
-                      <div className="flex items-center">
-                        <FiCalendar className="mr-2 text-stone-400" />
-                        <div>
-                          <span className="font-medium">{t('booking.checkOut')}:</span>{' '}
-                          {new Date(booking.checkOutDate).toLocaleDateString()}
+                      <div className="grid grid-cols-1 gap-4 text-caption text-ink-muted md:grid-cols-2">
+                        <div className="flex items-center">
+                          <FiCalendar className="mr-2 h-4 w-4 text-ink-faint" aria-hidden="true" />
+                          <div>
+                            <span className="font-semibold text-ink">{t('booking.checkIn')}:</span>{' '}
+                            {new Date(booking.checkInDate).toLocaleDateString()}
+                          </div>
+                        </div>
+
+                        <div className="flex items-center">
+                          <FiCalendar className="mr-2 h-4 w-4 text-ink-faint" aria-hidden="true" />
+                          <div>
+                            <span className="font-semibold text-ink">{t('booking.checkOut')}:</span>{' '}
+                            {new Date(booking.checkOutDate).toLocaleDateString()}
+                          </div>
                         </div>
                       </div>
                     </div>
-                  </div>
 
-                  {/* Price, Upload Button and Chevron */}
-                  <div className="flex items-center gap-3">
-                    <div className="text-right">
-                      <div className="text-2xl font-bold text-brand-600">
-                        ฿{Number(booking.totalPrice).toLocaleString()}
-                      </div>
-                      <div className="text-sm text-stone-500">
-                        {calculateNights(booking.checkInDate, booking.checkOutDate)} {t('booking.nights')}
-                      </div>
-                      {/* Payment amount if exists */}
-                      {(booking as Booking).paymentAmount && (
-                        <div className="text-sm text-green-600 font-medium">
-                          {t('payment.paid')}: ฿{((booking as Booking).paymentAmount ?? 0).toLocaleString('th-TH')}
+                    {/* Price, Upload Button and Chevron */}
+                    <div className="flex items-center gap-3">
+                      <div className="text-right">
+                        <div className="text-title text-brand-600">
+                          ฿{Number(booking.totalPrice).toLocaleString()}
                         </div>
-                      )}
+                        <div className="text-caption text-ink-muted">
+                          {calculateNights(booking.checkInDate, booking.checkOutDate)} {t('booking.nights')}
+                        </div>
+                        {/* Payment amount if exists */}
+                        {booking.paymentAmount && (
+                          <div className="text-caption font-semibold text-success-700">
+                            {t('payment.paid')}: ฿{(booking.paymentAmount ?? 0).toLocaleString('th-TH')}
+                          </div>
+                        )}
+                      </div>
+                      <FiChevronRight className="h-5 w-5 text-ink-faint" aria-hidden="true" />
                     </div>
-                    <FiChevronRight className="text-stone-400 text-xl" />
                   </div>
                 </div>
-              </div>
 
-              {/* Booking Footer */}
-              <div className="bg-stone-50 px-6 py-3 text-sm text-stone-500 flex items-center justify-between">
-                <span>{t('booking.bookedOn')}: {new Date(booking.createdAt).toLocaleDateString()}</span>
-                <span className="text-brand-600">{t('booking.clickForDetails')}</span>
-              </div>
-            </div>
-          ))}
+                {/* Booking Footer */}
+                <div className="flex items-center justify-between border-t border-hairline bg-surface-sunken px-6 py-3 text-caption text-ink-muted">
+                  <span>{t('booking.bookedOn')}: {new Date(booking.createdAt).toLocaleDateString()}</span>
+                  <span className="text-brand-700">{t('booking.clickForDetails')}</span>
+                </div>
+              </Card>
+            );
+          })}
         </div>
       )}
 
       {/* Booking Details Modal */}
-      {selectedBooking && (
-        <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-          onClick={() => setSelectedBooking(null)}
-          data-testid="booking-details-modal-backdrop"
-        >
-          <div
-            className="bg-white rounded-lg max-w-lg w-full max-h-[90vh] overflow-y-auto"
-            onClick={(e) => e.stopPropagation()}
-            data-testid="booking-details-modal"
-          >
-            {/* Modal Header */}
-            <div className="flex items-center justify-between p-6 border-b">
-              <div className="flex items-center gap-3">
-                <h3 className="text-xl font-semibold">{selectedBooking.roomTypeName}</h3>
-                {(() => {
-                  const displayStatus = getDisplayStatus(selectedBooking);
-                  return (
-                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${statusColors[displayStatus.key]?.bg} ${statusColors[displayStatus.key]?.text}`}>
-                      {t(displayStatus.translationKey)}
-                    </span>
-                  );
-                })()}
-              </div>
-              <button
-                onClick={() => setSelectedBooking(null)}
-                className="text-stone-400 hover:text-stone-600"
-                data-testid="booking-details-close"
-              >
-                <FiX className="text-2xl" />
-              </button>
-            </div>
-
-            {/* Modal Body */}
-            <div className="p-6 space-y-6">
-              {/* Dates Section */}
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <div className="text-sm text-stone-500 mb-1">{t('booking.checkIn')}</div>
-                  <div className="font-semibold flex items-center">
-                    <FiCalendar className="mr-2 text-brand-600" />
-                    {new Date(selectedBooking.checkInDate).toLocaleDateString()}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-sm text-stone-500 mb-1">{t('booking.checkOut')}</div>
-                  <div className="font-semibold flex items-center">
-                    <FiCalendar className="mr-2 text-brand-600" />
-                    {new Date(selectedBooking.checkOutDate).toLocaleDateString()}
-                  </div>
-                </div>
-              </div>
-
-              {/* Nights Count */}
-              <div className="text-center py-3 bg-stone-50 rounded-lg" data-testid="booking-nights-count">
-                <span className="text-lg font-semibold text-brand-600">
-                  {calculateNights(selectedBooking.checkInDate, selectedBooking.checkOutDate)}
-                </span>{' '}
-                <span className="text-stone-600">
-                  {calculateNights(selectedBooking.checkInDate, selectedBooking.checkOutDate) === 1
-                    ? t('booking.night')
-                    : t('booking.nights')}
-                </span>
-              </div>
-
-              {/* Details Grid */}
-              <div className="grid grid-cols-2 gap-4">
-                <div className="flex items-center">
-                  <FiUsers className="mr-2 text-stone-400" />
-                  <div>
-                    <div className="text-sm text-stone-500">{t('booking.guests')}</div>
-                    <div className="font-semibold">
-                      {selectedBooking.numGuests} {selectedBooking.numGuests === 1 ? t('booking.guest') : t('booking.guests')}
-                    </div>
-                  </div>
-                </div>
-                <div className="flex items-center">
-                  <FiStar className="mr-2 text-yellow-500" />
-                  <div>
-                    <div className="text-sm text-stone-500">{t('booking.pointsEarned')}</div>
-                    <div className={`font-semibold ${selectedBooking.status === 'cancelled' ? 'text-stone-400' : 'text-yellow-600'}`}>
-                      {selectedBooking.status === 'cancelled' ? (
-                        '-'
-                      ) : (
-                        <>{selectedBooking.pointsEarned.toLocaleString()} {t('loyalty.points')}</>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {/* Total Price */}
-              <div className="text-center py-4 bg-brand-50 rounded-lg">
-                <div className="text-sm text-stone-500 mb-1">{t('booking.totalPrice')}</div>
-                <div className="text-3xl font-bold text-brand-600">
-                  ฿{Number(selectedBooking.totalPrice).toLocaleString()}
-                </div>
-              </div>
-
-              {/* Payment Button - Only show if no slips uploaded yet */}
-              {canUploadSlip(selectedBooking) && !hasSlips(selectedBooking) && (
-                <button
-                  onClick={() => {
-                    setSelectedBooking(null);
-                    handleUploadSlipClick(selectedBooking.id);
-                  }}
-                  className="w-full py-2 px-4 bg-brand-600 text-white rounded-md hover:bg-brand-700 text-center"
-                >
-                  {t('payment.title')}
-                </button>
-              )}
-
-              {/* Uploaded Slips Display (Multi-slip support) */}
-              {hasSlips(selectedBooking) && (
-                <div className="border-t pt-4">
-                  <h4 className="font-medium mb-3">{t('payment.uploadedSlips')}</h4>
-                  <div className="space-y-3">
-                    {/* Slip Grid */}
-                    <div className="grid grid-cols-2 gap-3">
-                      {selectedBooking.slips?.map((slip, index) => (
-                        <div key={slip.id} className="relative group">
-                          <img
-                            src={slip.slipUrl}
-                            alt={`${t('payment.slipPreview')} ${index + 1}`}
-                            className="w-full h-32 object-cover rounded-lg border cursor-pointer hover:opacity-90 transition-opacity"
-                            onClick={() => window.open(slip.slipUrl, '_blank')}
-                          />
-                          {/* Status badge overlay */}
-                          <div className="absolute bottom-1 right-1">
-                            {slip.slipokStatus && (
-                              <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs ${slipOkStatusColors[slip.slipokStatus]?.bg} ${slipOkStatusColors[slip.slipokStatus]?.text}`}>
-                                {slipOkStatusColors[slip.slipokStatus]?.icon === 'check' && <FiCheckCircle className="w-3 h-3" />}
-                                {slipOkStatusColors[slip.slipokStatus]?.icon === 'clock' && <FiClock className="w-3 h-3" />}
-                                {slipOkStatusColors[slip.slipokStatus]?.icon === 'alert' && <FiAlertCircle className="w-3 h-3" />}
-                              </span>
-                            )}
-                          </div>
-                          {/* Upload time tooltip */}
-                          <div className="absolute top-1 left-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                            <span className="text-xs bg-black/70 text-white px-1.5 py-0.5 rounded">
-                              {new Date(slip.uploadedAt).toLocaleDateString()}
-                            </span>
-                          </div>
-                        </div>
-                      ))}
-                    </div>
-
-                    {/* Upload More Button */}
-                    {canUploadSlip(selectedBooking) && (
-                      <button
-                        onClick={() => handleUploadSlipClick(selectedBooking.id)}
-                        className="flex items-center gap-2 px-3 py-2 text-sm text-brand-600 hover:bg-brand-50 rounded-lg border border-brand-200 transition-colors"
-                      >
-                        <FiPlus className="w-4 h-4" />
-                        {t('payment.uploadMore')}
-                      </button>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* Notes */}
-              {selectedBooking.notes && (
-                <div className="p-4 bg-stone-50 rounded-lg">
-                  <div className="text-sm font-medium text-stone-700 mb-1">{t('booking.notes')}</div>
-                  <div className="text-stone-600">{selectedBooking.notes}</div>
-                </div>
-              )}
-
-              {/* Cancellation Info */}
-              {selectedBooking.status === 'cancelled' && (
-                <div className={`p-4 border rounded-lg ${selectedBooking.cancelledByAdmin ? 'bg-amber-50 border-amber-200' : 'bg-red-50 border-red-200'}`}>
-                  <div className="flex items-start">
-                    <FiAlertCircle className={`mr-2 mt-0.5 flex-shrink-0 ${selectedBooking.cancelledByAdmin ? 'text-amber-500' : 'text-red-500'}`} />
-                    <div>
-                      {selectedBooking.cancelledByAdmin && (
-                        <div className="text-sm font-medium text-amber-800 mb-2">
-                          {t('booking.cancelledByAdmin')}
-                        </div>
-                      )}
-                      {selectedBooking.cancellationReason && (
-                        <>
-                          <div className={`text-sm font-medium ${selectedBooking.cancelledByAdmin ? 'text-amber-800' : 'text-red-800'}`}>
-                            {t('booking.cancellationReason')}
-                          </div>
-                          <div className={selectedBooking.cancelledByAdmin ? 'text-amber-600' : 'text-red-600'}>
-                            {selectedBooking.cancellationReason}
-                          </div>
-                        </>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {/* Booked On */}
-              <div className="text-center text-sm text-stone-500">
-                {t('booking.bookedOn')}: {new Date(selectedBooking.createdAt).toLocaleDateString()}
-              </div>
-            </div>
-
-            {/* Modal Footer */}
-            <div className="flex justify-end gap-3 p-6 border-t bg-stone-50">
-              <button
-                onClick={() => setSelectedBooking(null)}
-                className="px-4 py-2 text-stone-600 border border-stone-300 rounded-md hover:bg-stone-100"
-              >
+      <Modal
+        open={!!selectedBooking}
+        onClose={() => setSelectedBooking(null)}
+        initialFocusRef={detailsModalHeadingRef}
+        footer={
+          selectedBooking && (
+            <div className="flex justify-end gap-3">
+              <Button variant="secondary" onClick={() => setSelectedBooking(null)}>
                 {t('common.close')}
-              </button>
+              </Button>
               {canCancel(selectedBooking) && (
-                <button
+                <Button
+                  variant="destructive"
                   onClick={() => handleCancelClick(selectedBooking.id)}
-                  className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700"
                   data-testid="booking-details-cancel"
                 >
                   {t('booking.cancelBooking')}
-                </button>
+                </Button>
               )}
             </div>
-          </div>
-        </div>
-      )}
-
-      {/* Cancel Modal */}
-      {showCancelModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-md w-full p-6" data-testid="cancel-modal">
-            <h3 className="text-lg font-semibold mb-4">{t('booking.cancelBookingTitle')}</h3>
-            <p className="text-stone-600 mb-4">{t('booking.cancelBookingConfirm')}</p>
-
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-stone-700 mb-1">
-                {t('booking.cancelReason')} ({t('common.optional')})
-              </label>
-              <textarea
-                value={cancelReason}
-                onChange={(e) => setCancelReason(e.target.value)}
-                rows={3}
-                placeholder={t('booking.cancelReasonPlaceholder')}
-                className="w-full px-3 py-2 border border-stone-300 rounded-md focus:ring-brand-500 focus:border-brand-500"
-                data-testid="cancel-reason-input"
-              />
-            </div>
-
-            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 mb-4">
-              <p className="text-sm text-yellow-800">
-                <FiAlertCircle className="inline mr-1" />
-                {t('booking.cancelWarning')}
-              </p>
-            </div>
-
-            <div className="flex justify-end gap-3">
+          )
+        }
+      >
+        {selectedBooking && (
+          <div className="space-y-6">
+            {/* Custom header (kept distinct from Modal's own title slot so the
+                icon-only close button stays name-less, matching the footer's
+                text "Close" button as the only accessible-name match). */}
+            <div className="mb-2 flex items-center justify-between border-b border-hairline pb-4">
+              <div className="flex items-center gap-3">
+                <h3 ref={detailsModalHeadingRef} tabIndex={-1} className="text-title text-ink outline-none">
+                  {selectedBooking.roomTypeName}
+                </h3>
+                <Badge tone={STATUS_BADGE_TONE[getDisplayStatus(selectedBooking).key]} size="sm">
+                  {t(getDisplayStatus(selectedBooking).translationKey)}
+                </Badge>
+              </div>
               <button
-                onClick={() => {
-                  setShowCancelModal(false);
-                  setSelectedBookingId(null);
-                  setCancelReason('');
-                }}
-                className="px-4 py-2 text-stone-600 border border-stone-300 rounded-md hover:bg-stone-50"
-                data-testid="cancel-modal-close"
+                type="button"
+                onClick={() => setSelectedBooking(null)}
+                className="text-ink-faint hover:text-ink"
+                data-testid="booking-details-close"
               >
-                {t('common.close')}
-              </button>
-              <button
-                onClick={handleConfirmCancel}
-                disabled={cancelBookingMutation.isPending}
-                className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:bg-stone-300"
-                data-testid="confirm-cancel-button"
-              >
-                {cancelBookingMutation.isPending ? (
-                  <span className="flex items-center">
-                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
-                    {t('common.processing')}
-                  </span>
-                ) : (
-                  t('booking.confirmCancel')
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Slip Upload Modal */}
-      {showSlipUploadModal && slipUploadBooking && (
-        <div
-          className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4"
-          onClick={closeSlipUploadModal}
-          data-testid="slip-upload-modal-backdrop"
-        >
-          <div
-            className="bg-white rounded-lg max-w-lg w-full max-h-[90vh] overflow-y-auto"
-            onClick={(e) => e.stopPropagation()}
-            data-testid="slip-upload-modal"
-          >
-            {/* Modal Header */}
-            <div className="flex items-center justify-between p-6 border-b">
-              <h3 className="text-xl font-semibold">{t('payment.uploadSlip')}</h3>
-              <button
-                onClick={closeSlipUploadModal}
-                className="text-stone-400 hover:text-stone-600"
-                data-testid="slip-upload-modal-close"
-              >
-                <FiX className="text-2xl" />
+                <FiX className="h-6 w-6" aria-hidden="true" />
               </button>
             </div>
 
-            {/* Modal Body */}
-            <div className="p-6 space-y-6">
-              {/* Booking Summary */}
-              <div className="bg-stone-50 rounded-lg p-4">
-                <h4 className="font-medium mb-2">{slipUploadBooking.roomTypeName}</h4>
-                <div className="text-sm text-stone-600 grid grid-cols-2 gap-2">
-                  <div>{t('booking.checkIn')}: {new Date(slipUploadBooking.checkInDate).toLocaleDateString()}</div>
-                  <div>{t('booking.checkOut')}: {new Date(slipUploadBooking.checkOutDate).toLocaleDateString()}</div>
-                </div>
-                <div className="mt-2 text-lg font-bold text-brand-600">
-                  ฿{Number(slipUploadBooking.totalPrice).toLocaleString('th-TH')}
+            {/* Dates Section */}
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <div className="mb-1 text-caption text-ink-muted">{t('booking.checkIn')}</div>
+                <div className="flex items-center font-semibold text-ink">
+                  <FiCalendar className="mr-2 h-4 w-4 text-brand-600" aria-hidden="true" />
+                  {new Date(selectedBooking.checkInDate).toLocaleDateString()}
                 </div>
               </div>
+              <div>
+                <div className="mb-1 text-caption text-ink-muted">{t('booking.checkOut')}</div>
+                <div className="flex items-center font-semibold text-ink">
+                  <FiCalendar className="mr-2 h-4 w-4 text-brand-600" aria-hidden="true" />
+                  {new Date(selectedBooking.checkOutDate).toLocaleDateString()}
+                </div>
+              </div>
+            </div>
 
-              {/* Existing Slips Section - Only show if booking has slips */}
-              {hasSlips(slipUploadBooking) && (
+            {/* Nights Count */}
+            <div className="rounded-lg bg-surface-sunken py-3 text-center" data-testid="booking-nights-count">
+              <span className="text-body font-semibold text-brand-600">
+                {calculateNights(selectedBooking.checkInDate, selectedBooking.checkOutDate)}
+              </span>{' '}
+              <span className="text-ink-muted">
+                {calculateNights(selectedBooking.checkInDate, selectedBooking.checkOutDate) === 1
+                  ? t('booking.night')
+                  : t('booking.nights')}
+              </span>
+            </div>
+
+            {/* Details Grid */}
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex items-center">
+                <FiUsers className="mr-2 h-4 w-4 text-ink-faint" aria-hidden="true" />
                 <div>
-                  <h4 className="font-medium mb-3">{t('payment.yourSlips')}</h4>
+                  <div className="text-caption text-ink-muted">{t('booking.guests')}</div>
+                  <div className="font-semibold text-ink">
+                    {selectedBooking.numGuests} {selectedBooking.numGuests === 1 ? t('booking.guest') : t('booking.guests')}
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center">
+                <FiStar className="mr-2 h-4 w-4 text-gold-600" aria-hidden="true" />
+                <div>
+                  <div className="text-caption text-ink-muted">{t('booking.pointsEarned')}</div>
+                  <div className={clsx('font-semibold', selectedBooking.status === 'cancelled' ? 'text-ink-faint' : 'text-gold-700')}>
+                    {selectedBooking.status === 'cancelled' ? (
+                      '-'
+                    ) : (
+                      <>{selectedBooking.pointsEarned.toLocaleString()} {t('loyalty.points')}</>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Total Price */}
+            <div className="rounded-lg bg-brand-50 py-4 text-center">
+              <div className="mb-1 text-caption text-ink-muted">{t('booking.totalPrice')}</div>
+              <div className="text-display text-brand-600">
+                ฿{Number(selectedBooking.totalPrice).toLocaleString()}
+              </div>
+            </div>
+
+            {/* Payment Button - Only show if no slips uploaded yet */}
+            {canUploadSlip(selectedBooking) && !hasSlips(selectedBooking) && (
+              <Button
+                className="w-full"
+                onClick={() => {
+                  setSelectedBooking(null);
+                  handleUploadSlipClick(selectedBooking.id);
+                }}
+              >
+                {t('payment.title')}
+              </Button>
+            )}
+
+            {/* Uploaded Slips Display (Multi-slip support) */}
+            {hasSlips(selectedBooking) && (
+              <div className="border-t border-hairline pt-4">
+                <h4 className="mb-3 font-semibold text-ink">{t('payment.uploadedSlips')}</h4>
+                <div className="space-y-3">
+                  {/* Slip Grid */}
                   <div className="grid grid-cols-2 gap-3">
-                    {slipUploadBooking.slips?.map((slip, index) => (
-                      <div key={slip.id} className="relative group">
+                    {selectedBooking.slips?.map((slip, index) => (
+                      <div key={slip.id} className="group relative">
                         <img
                           src={slip.slipUrl}
                           alt={`${t('payment.slipPreview')} ${index + 1}`}
-                          className="w-full h-32 object-cover rounded-lg border cursor-pointer hover:opacity-90 transition-opacity"
+                          className="h-32 w-full cursor-pointer rounded-lg border border-hairline object-cover transition-opacity hover:opacity-90"
                           onClick={() => window.open(slip.slipUrl, '_blank')}
                         />
                         {/* Status badge overlay */}
                         <div className="absolute bottom-1 right-1">
                           {slip.slipokStatus && (
-                            <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs ${slipOkStatusColors[slip.slipokStatus]?.bg} ${slipOkStatusColors[slip.slipokStatus]?.text}`}>
-                              {slipOkStatusColors[slip.slipokStatus]?.icon === 'check' && <FiCheckCircle className="w-3 h-3" />}
-                              {slipOkStatusColors[slip.slipokStatus]?.icon === 'clock' && <FiClock className="w-3 h-3" />}
-                              {slipOkStatusColors[slip.slipokStatus]?.icon === 'alert' && <FiAlertCircle className="w-3 h-3" />}
-                            </span>
+                            <Badge tone={SLIP_OK_STATUS[slip.slipokStatus]?.tone ?? 'neutral'} size="sm">
+                              <StatusGlyph icon={SLIP_OK_STATUS[slip.slipokStatus]?.icon} />
+                            </Badge>
                           )}
                         </div>
-                        {/* Remove button - only show for non-verified slips */}
-                        {slip.adminStatus !== 'verified' && (
-                          <button
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleRemoveSlip(slip.id);
-                            }}
-                            className="absolute top-1 right-1 p-1.5 bg-red-500 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-600"
-                            title={t('payment.removeSlip')}
-                          >
-                            <FiX className="w-3 h-3" />
-                          </button>
-                        )}
+                        {/* Upload time tooltip */}
+                        <div className="absolute left-1 top-1 opacity-0 transition-opacity group-hover:opacity-100">
+                          <span className="rounded bg-tile/90 px-1.5 py-0.5 text-fine text-tile-text">
+                            {new Date(slip.uploadedAt).toLocaleDateString()}
+                          </span>
+                        </div>
                       </div>
                     ))}
                   </div>
-                </div>
-              )}
 
-              {/* Bank/QR Section - Show directly if no slips, or toggle if slips exist */}
-              {hasSlips(slipUploadBooking) ? (
-                <>
-                  {/* Toggle button for bank details */}
-                  <button
-                    onClick={() => setShowBankDetails(!showBankDetails)}
-                    className="w-full py-2 text-sm text-brand-600 hover:text-brand-700 border border-brand-200 rounded-lg hover:bg-brand-50 transition-colors"
-                  >
-                    {showBankDetails ? t('payment.hideBankDetails') : t('payment.showBankDetails')}
-                  </button>
-
-                  {/* Collapsible bank/QR section */}
-                  {showBankDetails && (
-                    <>
-                      {/* Bank Transfer Option */}
-                      <div className="text-center">
-                        <h4 className="font-medium mb-3">{t('payment.bankTransfer')}</h4>
-                        <div
-                          className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm text-left space-y-2 cursor-pointer hover:border-brand-300 transition-colors"
-                          onClick={() => {
-                            navigator.clipboard.writeText('0461430473');
-                            toast.success(t('payment.copied'));
-                          }}
-                        >
-                          <div className="flex justify-between items-center">
-                            <span className="text-stone-500">{t('payment.bankName')}</span>
-                            <div className="flex items-center gap-2">
-                              <img src={kbankLogo} alt="KBank" className="h-6" />
-                              <span className="font-medium">กสิกรไทย</span>
-                            </div>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-stone-500">{t('payment.accountName')}</span>
-                            <span className="font-medium">บจก. สายชล เฮอริเทจ</span>
-                          </div>
-                          <div className="flex justify-between items-center">
-                            <span className="text-stone-500">{t('payment.accountNumber')}</span>
-                            <span className="font-medium font-mono">046-1-43047-3</span>
-                          </div>
-                          <p className="text-xs text-stone-400 text-center">{t('payment.clickToCopy')}</p>
-                        </div>
-                      </div>
-
-                      {/* Divider with "or" */}
-                      <div className="flex items-center gap-3">
-                        <div className="flex-1 border-t border-stone-200" />
-                        <span className="text-sm text-stone-400">{t('payment.or')}</span>
-                        <div className="flex-1 border-t border-stone-200" />
-                      </div>
-
-                      {/* QR Code Display */}
-                      <div className="text-center">
-                        <h4 className="font-medium mb-3">{t('payment.scanQRCode')}</h4>
-                        <div className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm">
-                          <img
-                            src={promptPayQRUrl}
-                            alt="PromptPay QR Code"
-                            className="w-full object-contain"
-                            onError={(e) => {
-                              (e.target as HTMLImageElement).src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"%3E%3Crect fill="%23f3f4f6" width="160" height="160"/%3E%3Ctext x="80" y="80" text-anchor="middle" dy=".3em" fill="%239ca3af" font-size="12"%3EQR Code%3C/text%3E%3C/svg%3E';
-                            }}
-                          />
-                          <a
-                            href={promptPayQRUrl}
-                            download="promptpay-qr.png"
-                            className="inline-flex items-center justify-center gap-2 mt-3 w-full py-2 text-sm text-stone-500 hover:text-brand-600 transition-colors"
-                          >
-                            <FiDownload className="w-4 h-4" />
-                            {t('payment.downloadQR')}
-                          </a>
-                        </div>
-                      </div>
-                    </>
+                  {/* Upload More Button */}
+                  {canUploadSlip(selectedBooking) && (
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => handleUploadSlipClick(selectedBooking.id)}
+                    >
+                      <FiPlus className="h-4 w-4" aria-hidden="true" />
+                      {t('payment.uploadMore')}
+                    </Button>
                   )}
-                </>
-              ) : (
-                <>
-                  {/* Bank Transfer Option */}
-                  <div className="text-center">
-                    <h4 className="font-medium mb-3">{t('payment.bankTransfer')}</h4>
-                    <div
-                      className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm text-left space-y-2 cursor-pointer hover:border-brand-300 transition-colors"
-                      onClick={() => {
-                        navigator.clipboard.writeText('0461430473');
-                        toast.success(t('payment.copied'));
-                      }}
-                    >
-                      <div className="flex justify-between items-center">
-                        <span className="text-stone-500">{t('payment.bankName')}</span>
-                        <div className="flex items-center gap-2">
-                          <img src={kbankLogo} alt="KBank" className="h-6" />
-                          <span className="font-medium">กสิกรไทย</span>
-                        </div>
-                      </div>
-                      <div className="flex justify-between">
-                        <span className="text-stone-500">{t('payment.accountName')}</span>
-                        <span className="font-medium">บจก. สายชล เฮอริเทจ</span>
-                      </div>
-                      <div className="flex justify-between items-center">
-                        <span className="text-stone-500">{t('payment.accountNumber')}</span>
-                        <span className="font-medium font-mono">046-1-43047-3</span>
-                      </div>
-                      <p className="text-xs text-stone-400 text-center">{t('payment.clickToCopy')}</p>
-                    </div>
-                  </div>
+                </div>
+              </div>
+            )}
 
-                  {/* Divider with "or" */}
-                  <div className="flex items-center gap-3">
-                    <div className="flex-1 border-t border-stone-200" />
-                    <span className="text-sm text-stone-400">{t('payment.or')}</span>
-                    <div className="flex-1 border-t border-stone-200" />
-                  </div>
+            {/* Notes */}
+            {selectedBooking.notes && (
+              <div className="rounded-lg bg-surface-sunken p-4">
+                <div className="mb-1 text-caption font-semibold text-ink">{t('booking.notes')}</div>
+                <div className="text-ink-muted">{selectedBooking.notes}</div>
+              </div>
+            )}
 
-                  {/* QR Code Display */}
-                  <div className="text-center">
-                    <h4 className="font-medium mb-3">{t('payment.scanQRCode')}</h4>
-                    <div className="p-4 bg-white border-2 border-stone-200 rounded-lg shadow-sm">
-                      <img
-                        src={promptPayQRUrl}
-                        alt="PromptPay QR Code"
-                        className="w-full object-contain"
-                        onError={(e) => {
-                          (e.target as HTMLImageElement).src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"%3E%3Crect fill="%23f3f4f6" width="160" height="160"/%3E%3Ctext x="80" y="80" text-anchor="middle" dy=".3em" fill="%239ca3af" font-size="12"%3EQR Code%3C/text%3E%3C/svg%3E';
-                        }}
-                      />
-                      <a
-                        href={promptPayQRUrl}
-                        download="promptpay-qr.png"
-                        className="inline-flex items-center justify-center gap-2 mt-3 w-full py-2 text-sm text-stone-500 hover:text-brand-600 transition-colors"
-                      >
-                        <FiDownload className="w-4 h-4" />
-                        {t('payment.downloadQR')}
-                      </a>
-                    </div>
-                  </div>
-                </>
-              )}
-
-              {/* Slip Upload Section */}
-              <div>
-                <h4 className="font-medium mb-3">{t('payment.uploadSlipDescription')}</h4>
-
-                {!slipPreview ? (
-                  <div
-                    className={`border-2 border-dashed rounded-lg p-8 text-center cursor-pointer transition-colors ${
-                      isDragging ? 'border-brand-500 bg-brand-50' : 'border-stone-300 hover:border-brand-400'
-                    }`}
-                    onDragOver={handleDragOver}
-                    onDragLeave={handleDragLeave}
-                    onDrop={handleDrop}
-                    onClick={() => fileInputRef.current?.click()}
-                    data-testid="slip-upload-dropzone"
-                  >
-                    <FiUpload className="w-10 h-10 text-stone-400 mx-auto mb-3" />
-                    <p className="text-stone-600 mb-2">{t('payment.dragDropSlip')}</p>
-                    <p className="text-xs text-stone-400">JPG, PNG (max 10MB)</p>
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      accept="image/jpeg,image/jpg,image/png"
-                      onChange={handleFileInputChange}
-                      className="hidden"
-                      data-testid="slip-upload-input"
-                    />
-                  </div>
-                ) : (
-                  <div className="relative border rounded-lg overflow-hidden">
-                    <img
-                      src={slipPreview}
-                      alt="Transfer slip preview"
-                      className="w-full max-h-48 object-contain bg-stone-100"
-                    />
-                    <button
-                      onClick={removeSlip}
-                      className="absolute top-2 right-2 p-2 bg-red-500 text-white rounded-full hover:bg-red-600"
-                      data-testid="slip-upload-remove"
-                    >
-                      <FiX className="w-4 h-4" />
-                    </button>
-                  </div>
+            {/* Cancellation Info */}
+            {selectedBooking.status === 'cancelled' && (
+              <div
+                className={clsx(
+                  'rounded-lg border p-4',
+                  selectedBooking.cancelledByAdmin ? 'border-warning-600 bg-warning-50' : 'border-error-600 bg-error-50'
                 )}
+              >
+                <div className="flex items-start">
+                  <FiAlertCircle
+                    className={clsx(
+                      'mr-2 mt-0.5 h-4 w-4 flex-shrink-0',
+                      selectedBooking.cancelledByAdmin ? 'text-warning-700' : 'text-error-600'
+                    )}
+                    aria-hidden="true"
+                  />
+                  <div>
+                    {selectedBooking.cancelledByAdmin && (
+                      <div className="mb-2 text-caption font-semibold text-warning-700">
+                        {t('booking.cancelledByAdmin')}
+                      </div>
+                    )}
+                    {selectedBooking.cancellationReason && (
+                      <>
+                        <div className={clsx('text-caption font-semibold', selectedBooking.cancelledByAdmin ? 'text-warning-700' : 'text-error-700')}>
+                          {t('booking.cancellationReason')}
+                        </div>
+                        <div className={selectedBooking.cancelledByAdmin ? 'text-warning-700' : 'text-error-600'}>
+                          {selectedBooking.cancellationReason}
+                        </div>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Booked On */}
+            <div className="text-center text-caption text-ink-muted">
+              {t('booking.bookedOn')}: {new Date(selectedBooking.createdAt).toLocaleDateString()}
+            </div>
+          </div>
+        )}
+      </Modal>
+
+      {/* Cancel Modal */}
+      <Modal
+        open={showCancelModal}
+        onClose={() => {
+          setShowCancelModal(false);
+          setSelectedBookingId(null);
+          setCancelReason('');
+        }}
+        size="sm"
+        footer={
+          <div className="flex justify-end gap-3">
+            <Button
+              variant="secondary"
+              onClick={() => {
+                setShowCancelModal(false);
+                setSelectedBookingId(null);
+                setCancelReason('');
+              }}
+              data-testid="cancel-modal-close"
+            >
+              {t('common.close')}
+            </Button>
+            <Button
+              variant="destructive"
+              loading={cancelBookingMutation.isPending}
+              onClick={handleConfirmCancel}
+              data-testid="confirm-cancel-button"
+            >
+              {t('booking.confirmCancel')}
+            </Button>
+          </div>
+        }
+      >
+        <div className="space-y-4">
+          <h3 className="text-title text-ink">{t('booking.cancelBookingTitle')}</h3>
+          <p className="text-caption text-ink-muted">{t('booking.cancelBookingConfirm')}</p>
+
+          <FormField label={`${t('booking.cancelReason')} (${t('common.optional')})`} htmlFor="cancel-reason-input">
+            <Textarea
+              value={cancelReason}
+              onChange={(e) => setCancelReason(e.target.value)}
+              rows={3}
+              placeholder={t('booking.cancelReasonPlaceholder')}
+              data-testid="cancel-reason-input"
+            />
+          </FormField>
+
+          <Badge tone="warning" className="w-full gap-2 py-3">
+            <FiAlertCircle className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+            <span>{t('booking.cancelWarning')}</span>
+          </Badge>
+        </div>
+      </Modal>
+
+      {/* Slip Upload Modal */}
+      <Modal
+        open={showSlipUploadModal && !!slipUploadBooking}
+        onClose={closeSlipUploadModal}
+        initialFocusRef={slipUploadModalHeadingRef}
+        footer={
+          slipUploadBooking && (
+            <div className="flex justify-end gap-3">
+              <Button variant="secondary" onClick={closeSlipUploadModal}>
+                {t('common.cancel')}
+              </Button>
+              <Button
+                loading={isUploading}
+                disabled={!slipFile}
+                onClick={handleSlipUpload}
+                data-testid="slip-upload-submit"
+              >
+                <FiUpload className="h-4 w-4" aria-hidden="true" />
+                {t('payment.submitSlip')}
+              </Button>
+            </div>
+          )
+        }
+      >
+        {slipUploadBooking && (
+          <div className="space-y-6">
+            <div className="mb-2 flex items-center justify-between border-b border-hairline pb-4">
+              <h3 ref={slipUploadModalHeadingRef} tabIndex={-1} className="text-title text-ink outline-none">
+                {t('payment.uploadSlip')}
+              </h3>
+              <button
+                type="button"
+                onClick={closeSlipUploadModal}
+                className="text-ink-faint hover:text-ink"
+                data-testid="slip-upload-modal-close"
+              >
+                <FiX className="h-6 w-6" aria-hidden="true" />
+              </button>
+            </div>
+
+            {/* Booking Summary */}
+            <div className="rounded-lg bg-surface-sunken p-4">
+              <h4 className="mb-2 font-semibold text-ink">{slipUploadBooking.roomTypeName}</h4>
+              <div className="grid grid-cols-2 gap-2 text-caption text-ink-muted">
+                <div>{t('booking.checkIn')}: {new Date(slipUploadBooking.checkInDate).toLocaleDateString()}</div>
+                <div>{t('booking.checkOut')}: {new Date(slipUploadBooking.checkOutDate).toLocaleDateString()}</div>
+              </div>
+              <div className="mt-2 text-title text-brand-600">
+                ฿{Number(slipUploadBooking.totalPrice).toLocaleString('th-TH')}
               </div>
             </div>
 
-            {/* Modal Footer */}
-            <div className="flex justify-end gap-3 p-6 border-t bg-stone-50">
-              <button
-                onClick={closeSlipUploadModal}
-                className="px-4 py-2 text-stone-600 border border-stone-300 rounded-md hover:bg-stone-100"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={handleSlipUpload}
-                disabled={!slipFile || isUploading}
-                className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:bg-stone-300 disabled:cursor-not-allowed flex items-center"
-                data-testid="slip-upload-submit"
-              >
-                {isUploading ? (
-                  <>
-                    <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2" />
-                    {t('common.processing')}
-                  </>
-                ) : (
-                  <>
-                    <FiUpload className="mr-2" />
-                    {t('payment.submitSlip')}
-                  </>
-                )}
-              </button>
+            {/* Existing Slips Section - Only show if booking has slips */}
+            {hasSlips(slipUploadBooking) && (
+              <div>
+                <h4 className="mb-3 font-semibold text-ink">{t('payment.yourSlips')}</h4>
+                <div className="grid grid-cols-2 gap-3">
+                  {slipUploadBooking.slips?.map((slip, index) => (
+                    <div key={slip.id} className="group relative">
+                      <img
+                        src={slip.slipUrl}
+                        alt={`${t('payment.slipPreview')} ${index + 1}`}
+                        className="h-32 w-full cursor-pointer rounded-lg border border-hairline object-cover transition-opacity hover:opacity-90"
+                        onClick={() => window.open(slip.slipUrl, '_blank')}
+                      />
+                      {/* Status badge overlay */}
+                      <div className="absolute bottom-1 right-1">
+                        {slip.slipokStatus && (
+                          <Badge tone={SLIP_OK_STATUS[slip.slipokStatus]?.tone ?? 'neutral'} size="sm">
+                            <StatusGlyph icon={SLIP_OK_STATUS[slip.slipokStatus]?.icon} />
+                          </Badge>
+                        )}
+                      </div>
+                      {/* Remove button - only show for non-verified slips */}
+                      {slip.adminStatus !== 'verified' && (
+                        <Button
+                          variant="destructive"
+                          size="icon"
+                          className="absolute right-1 top-1 h-7 w-7 opacity-0 transition-opacity group-hover:opacity-100"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            handleRemoveSlip(slip.id);
+                          }}
+                          aria-label={t('payment.removeSlip')}
+                        >
+                          <FiX className="h-3 w-3" aria-hidden="true" />
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Bank/QR Section - Show directly if no slips, or toggle if slips exist */}
+            {hasSlips(slipUploadBooking) && (
+              <Button variant="secondary" className="w-full" onClick={() => setShowBankDetails(!showBankDetails)}>
+                {showBankDetails ? t('payment.hideBankDetails') : t('payment.showBankDetails')}
+              </Button>
+            )}
+
+            {(!hasSlips(slipUploadBooking) || showBankDetails) && (
+              <>
+                {/* Bank Transfer Option */}
+                <div className="text-center">
+                  <h4 className="mb-3 font-semibold text-ink">{t('payment.bankTransfer')}</h4>
+                  <div
+                    className="cursor-pointer space-y-2 rounded-lg border border-hairline bg-white p-4 text-left shadow-soft transition-colors hover:border-brand-300"
+                    onClick={() => {
+                      navigator.clipboard.writeText('0461430473');
+                      toast.success(t('payment.copied'));
+                    }}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="text-ink-muted">{t('payment.bankName')}</span>
+                      <div className="flex items-center gap-2">
+                        <img src={kbankLogo} alt="KBank" className="h-6" />
+                        <span className="font-semibold text-ink">กสิกรไทย</span>
+                      </div>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-ink-muted">{t('payment.accountName')}</span>
+                      <span className="font-semibold text-ink">บจก. สายชล เฮอริเทจ</span>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <span className="text-ink-muted">{t('payment.accountNumber')}</span>
+                      <span className="font-mono font-semibold text-ink">046-1-43047-3</span>
+                    </div>
+                    <p className="text-center text-fine text-ink-faint">{t('payment.clickToCopy')}</p>
+                  </div>
+                </div>
+
+                {/* Divider with "or" */}
+                <div className="flex items-center gap-3">
+                  <div className="flex-1 border-t border-hairline" />
+                  <span className="text-caption text-ink-faint">{t('payment.or')}</span>
+                  <div className="flex-1 border-t border-hairline" />
+                </div>
+
+                {/* QR Code Display */}
+                <div className="text-center">
+                  <h4 className="mb-3 font-semibold text-ink">{t('payment.scanQRCode')}</h4>
+                  <div className="rounded-lg bg-white p-4 shadow-soft">
+                    <img
+                      src={promptPayQRUrl}
+                      alt="PromptPay QR Code"
+                      className="w-full object-contain"
+                      onError={(e) => {
+                        (e.target as HTMLImageElement).src = 'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 160 160"%3E%3Crect fill="%23f3f4f6" width="160" height="160"/%3E%3Ctext x="80" y="80" text-anchor="middle" dy=".3em" fill="%239ca3af" font-size="12"%3EQR Code%3C/text%3E%3C/svg%3E';
+                      }}
+                    />
+                    <a
+                      href={promptPayQRUrl}
+                      download="promptpay-qr.png"
+                      className="mt-3 inline-flex w-full items-center justify-center gap-2 py-2 text-caption text-ink-muted transition-colors hover:text-brand-600"
+                    >
+                      <FiDownload className="h-4 w-4" aria-hidden="true" />
+                      {t('payment.downloadQR')}
+                    </a>
+                  </div>
+                </div>
+              </>
+            )}
+
+            {/* Slip Upload Section */}
+            <div>
+              <h4 className="mb-3 font-semibold text-ink">{t('payment.uploadSlipDescription')}</h4>
+
+              {!slipPreview ? (
+                <div
+                  className={clsx(
+                    'cursor-pointer rounded-card border-2 border-dashed bg-surface-sunken p-8 text-center transition-colors',
+                    isDragging ? 'border-brand-600' : 'border-hairline-strong hover:border-brand-600'
+                  )}
+                  onDragOver={handleDragOver}
+                  onDragLeave={handleDragLeave}
+                  onDrop={handleDrop}
+                  onClick={() => fileInputRef.current?.click()}
+                  data-testid="slip-upload-dropzone"
+                >
+                  <FiUpload className="mx-auto mb-3 h-10 w-10 text-ink-faint" aria-hidden="true" />
+                  <p className="mb-2 text-body text-ink-muted">{t('payment.dragDropSlip')}</p>
+                  <p className="text-fine text-ink-faint">JPG, PNG (max 10MB)</p>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/jpeg,image/jpg,image/png"
+                    onChange={handleFileInputChange}
+                    className="hidden"
+                    data-testid="slip-upload-input"
+                  />
+                </div>
+              ) : (
+                <div className="relative overflow-hidden rounded-card border border-hairline">
+                  <img
+                    src={slipPreview}
+                    alt="Transfer slip preview"
+                    className="max-h-48 w-full bg-surface-sunken object-contain"
+                  />
+                  <Button
+                    variant="destructive"
+                    size="icon"
+                    onClick={removeSlip}
+                    className="absolute right-2 top-2 h-9 w-9"
+                    data-testid="slip-upload-remove"
+                  >
+                    <FiX className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </div>
+              )}
             </div>
           </div>
-        </div>
-      )}
-    </MainLayout>
+        )}
+      </Modal>
+    </AppShell>
   );
 }

--- a/frontend/src/pages/__tests__/BookingPage.test.tsx
+++ b/frontend/src/pages/__tests__/BookingPage.test.tsx
@@ -96,7 +96,7 @@ vi.mock('../../store/authStore', () => ({
     }),
 }));
 
-vi.mock('../../components/layout/MainLayout', () => ({
+vi.mock('../../components/layout/AppShell', () => ({
   default: ({ children, title }: { children: React.ReactNode; title: string }) => (
     <div>
       <h1>{title}</h1>

--- a/frontend/src/pages/__tests__/MyBookingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/MyBookingsPage.test.tsx
@@ -179,8 +179,8 @@ vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
 }));
 
-// Mock MainLayout
-vi.mock('../../components/layout/MainLayout', () => ({
+// Mock AppShell
+vi.mock('../../components/layout/AppShell', () => ({
   default: ({ children, title }: { children: React.ReactNode; title: string }) => (
     <div>
       <h1>{title}</h1>
@@ -195,7 +195,7 @@ import MyBookingsPage from '../MyBookingsPage';
 /** Wait for the query to resolve and bookings UI to render */
 async function waitForBookingsLoaded() {
   await waitFor(() => {
-    expect(screen.getByTestId('tab-current')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /Current Bookings/ })).toBeInTheDocument();
   });
 }
 
@@ -256,7 +256,7 @@ describe('MyBookingsPage', () => {
       expect(screen.getByText('Confirmed')).toBeInTheDocument();
 
       // Switch to history tab for completed and cancelled bookings
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // Check second booking (completed)
       expect(screen.getByTestId('booking-card-booking-2')).toBeInTheDocument();
@@ -276,7 +276,7 @@ describe('MyBookingsPage', () => {
       expect(screen.getByText('฿4,500')).toBeInTheDocument();
 
       // History tab shows booking-2 and booking-3
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
       expect(screen.getByText('฿2,000')).toBeInTheDocument();
       expect(screen.getByText('฿6,000')).toBeInTheDocument();
     });
@@ -290,7 +290,7 @@ describe('MyBookingsPage', () => {
       expect(screen.getAllByText('Click for details').length).toBe(1);
 
       // History tab has 4 bookings (booking-2, booking-3, booking-4, booking-5)
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
       expect(screen.getAllByText('Click for details').length).toBe(4);
     });
   });
@@ -304,7 +304,7 @@ describe('MyBookingsPage', () => {
       const card = screen.getByTestId('booking-card-booking-1');
       await user.click(card);
 
-      expect(screen.getByTestId('booking-details-modal')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     it('should open details modal on Enter key', async () => {
@@ -316,7 +316,7 @@ describe('MyBookingsPage', () => {
       card.focus();
       await user.keyboard('{Enter}');
 
-      expect(screen.getByTestId('booking-details-modal')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
   });
 
@@ -329,7 +329,7 @@ describe('MyBookingsPage', () => {
       // Open modal for first booking
       await user.click(screen.getByTestId('booking-card-booking-1'));
 
-      const modal = screen.getByTestId('booking-details-modal');
+      const modal = screen.getByRole('dialog');
       expect(modal).toBeInTheDocument();
 
       // Check room type name
@@ -357,10 +357,10 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       await user.click(screen.getByTestId('booking-card-booking-1'));
-      expect(screen.getByTestId('booking-details-modal')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
 
       await user.click(screen.getByTestId('booking-details-close'));
-      expect(screen.queryByTestId('booking-details-modal')).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
     it('should close modal when clicking backdrop', async () => {
@@ -369,10 +369,14 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       await user.click(screen.getByTestId('booking-card-booking-1'));
-      expect(screen.getByTestId('booking-details-modal')).toBeInTheDocument();
+      const dialog = screen.getByRole('dialog');
+      expect(dialog).toBeInTheDocument();
 
-      await user.click(screen.getByTestId('booking-details-modal-backdrop'));
-      expect(screen.queryByTestId('booking-details-modal')).not.toBeInTheDocument();
+      // Modal's backdrop is the dialog panel's portal parent — clicking it
+      // (not the panel itself) is what triggers the dismiss-on-backdrop
+      // behavior baked into the shared Modal primitive.
+      await user.click(dialog.parentElement as HTMLElement);
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
     it('should close modal when clicking Close button in footer', async () => {
@@ -381,10 +385,10 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       await user.click(screen.getByTestId('booking-card-booking-1'));
-      expect(screen.getByTestId('booking-details-modal')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
 
       await user.click(screen.getByRole('button', { name: 'Close' }));
-      expect(screen.queryByTestId('booking-details-modal')).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
     it('should show cancellation reason for cancelled bookings', async () => {
@@ -393,10 +397,10 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       // booking-3 is cancelled and in history tab
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
       await user.click(screen.getByTestId('booking-card-booking-3'));
 
-      const modal = screen.getByTestId('booking-details-modal');
+      const modal = screen.getByRole('dialog');
       expect(within(modal).getByText('Change of plans')).toBeInTheDocument();
       expect(within(modal).getByText('Cancellation reason')).toBeInTheDocument();
     });
@@ -414,7 +418,7 @@ describe('MyBookingsPage', () => {
       await user.click(screen.getByTestId('booking-details-close'));
 
       // Switch to history tab for completed and cancelled bookings
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // Open completed booking modal - should NOT have cancel button
       await user.click(screen.getByTestId('booking-card-booking-2'));
@@ -434,11 +438,14 @@ describe('MyBookingsPage', () => {
       await user.click(screen.getByTestId('booking-card-booking-1'));
       await user.click(screen.getByTestId('booking-details-cancel'));
 
-      // Details modal should close
-      expect(screen.queryByTestId('booking-details-modal')).not.toBeInTheDocument();
+      // Details modal should close — its content is gone, replaced by the
+      // cancel-confirmation dialog (both render as role="dialog", so content
+      // unique to the details modal body — not also shown on the booking
+      // card underneath — is the reliable way to tell them apart here).
+      expect(screen.queryByTestId('booking-nights-count')).not.toBeInTheDocument();
 
       // Cancel confirmation modal should open
-      expect(screen.getByTestId('cancel-modal')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
       expect(screen.getByText('Cancel Booking')).toBeInTheDocument();
       expect(screen.getByText('Are you sure?')).toBeInTheDocument();
     });
@@ -451,10 +458,10 @@ describe('MyBookingsPage', () => {
       await user.click(screen.getByTestId('booking-card-booking-1'));
       await user.click(screen.getByTestId('booking-details-cancel'));
 
-      expect(screen.getByTestId('cancel-modal')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
 
       await user.click(screen.getByTestId('cancel-modal-close'));
-      expect(screen.queryByTestId('cancel-modal')).not.toBeInTheDocument();
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     });
 
     it('should call mutate when confirming cancellation', async () => {
@@ -494,7 +501,7 @@ describe('MyBookingsPage', () => {
 
       const card = screen.getByTestId('booking-card-booking-1');
       const badge = within(card).getByText('Confirmed');
-      expect(badge).toHaveClass('bg-green-100', 'text-green-800');
+      expect(badge).toHaveAttribute('data-tone', 'success');
     });
 
     it('should display cancelled status with red badge', async () => {
@@ -503,11 +510,11 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       // booking-3 is cancelled and in history tab
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       const card = screen.getByTestId('booking-card-booking-3');
       const badge = within(card).getByText('Cancelled');
-      expect(badge).toHaveClass('bg-red-100', 'text-red-800');
+      expect(badge).toHaveAttribute('data-tone', 'error');
     });
 
     it('should display completed status with blue badge', async () => {
@@ -516,11 +523,11 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       // booking-2 is completed and in history tab
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       const card = screen.getByTestId('booking-card-booking-2');
       const badge = within(card).getByText('Completed');
-      expect(badge).toHaveClass('bg-brand-100', 'text-brand-800');
+      expect(badge).toHaveAttribute('data-tone', 'brand');
     });
   });
 
@@ -547,19 +554,19 @@ describe('MyBookingsPage', () => {
       render(<MyBookingsPage />, { wrapper });
       await waitForBookingsLoaded();
 
-      expect(screen.getByTestId('tab-current')).toBeInTheDocument();
-      expect(screen.getByTestId('tab-history')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Current Bookings/ })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /Booking History/ })).toBeInTheDocument();
     });
 
     it('should show Current Bookings tab as active by default', async () => {
       render(<MyBookingsPage />, { wrapper });
       await waitForBookingsLoaded();
 
-      const currentTab = screen.getByTestId('tab-current');
-      const historyTab = screen.getByTestId('tab-history');
+      const currentTab = screen.getByRole('tab', { name: /Current Bookings/ });
+      const historyTab = screen.getByRole('tab', { name: /Booking History/ });
 
-      expect(currentTab).toHaveClass('border-brand-500', 'text-brand-600');
-      expect(historyTab).toHaveClass('border-transparent', 'text-stone-500');
+      expect(currentTab).toHaveAttribute('aria-selected', 'true');
+      expect(historyTab).toHaveAttribute('aria-selected', 'false');
     });
 
     it('should display booking counts in tab labels', async () => {
@@ -572,8 +579,8 @@ describe('MyBookingsPage', () => {
       // booking-4 is confirmed + past = history
       // booking-5 is cancelled by admin = history
       // So: current = 1, history = 4
-      expect(screen.getByTestId('tab-current')).toHaveTextContent('Current Bookings (1)');
-      expect(screen.getByTestId('tab-history')).toHaveTextContent('Booking History (4)');
+      expect(screen.getByRole('tab', { name: /Current Bookings/ })).toHaveTextContent('Current Bookings (1)');
+      expect(screen.getByRole('tab', { name: /Booking History/ })).toHaveTextContent('Booking History (4)');
     });
   });
 
@@ -583,10 +590,10 @@ describe('MyBookingsPage', () => {
       render(<MyBookingsPage />, { wrapper });
       await waitForBookingsLoaded();
 
-      const historyTab = screen.getByTestId('tab-history');
+      const historyTab = screen.getByRole('tab', { name: /Booking History/ });
       await user.click(historyTab);
 
-      expect(historyTab).toHaveClass('border-brand-500', 'text-brand-600');
+      expect(historyTab).toHaveAttribute('aria-selected', 'true');
     });
 
     it('should update active tab styling on switch', async () => {
@@ -594,22 +601,22 @@ describe('MyBookingsPage', () => {
       render(<MyBookingsPage />, { wrapper });
       await waitForBookingsLoaded();
 
-      const currentTab = screen.getByTestId('tab-current');
-      const historyTab = screen.getByTestId('tab-history');
+      const currentTab = screen.getByRole('tab', { name: /Current Bookings/ });
+      const historyTab = screen.getByRole('tab', { name: /Booking History/ });
 
       // Initially current is active
-      expect(currentTab).toHaveClass('border-brand-500');
-      expect(historyTab).toHaveClass('border-transparent');
+      expect(currentTab).toHaveAttribute('aria-selected', 'true');
+      expect(historyTab).toHaveAttribute('aria-selected', 'false');
 
       // Switch to history
       await user.click(historyTab);
-      expect(historyTab).toHaveClass('border-brand-500');
-      expect(currentTab).toHaveClass('border-transparent');
+      expect(historyTab).toHaveAttribute('aria-selected', 'true');
+      expect(currentTab).toHaveAttribute('aria-selected', 'false');
 
       // Switch back to current
       await user.click(currentTab);
-      expect(currentTab).toHaveClass('border-brand-500');
-      expect(historyTab).toHaveClass('border-transparent');
+      expect(currentTab).toHaveAttribute('aria-selected', 'true');
+      expect(historyTab).toHaveAttribute('aria-selected', 'false');
     });
   });
 
@@ -658,7 +665,7 @@ describe('MyBookingsPage', () => {
       render(<MyBookingsPage />, { wrapper });
       await waitForBookingsLoaded();
 
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // booking-2 is completed
       expect(screen.getByTestId('booking-card-booking-2')).toBeInTheDocument();
@@ -669,7 +676,7 @@ describe('MyBookingsPage', () => {
       render(<MyBookingsPage />, { wrapper });
       await waitForBookingsLoaded();
 
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // booking-3 is cancelled
       expect(screen.getByTestId('booking-card-booking-3')).toBeInTheDocument();
@@ -680,7 +687,7 @@ describe('MyBookingsPage', () => {
       render(<MyBookingsPage />, { wrapper });
       await waitForBookingsLoaded();
 
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // booking-4 is confirmed but past (2025-12-01)
       expect(screen.getByTestId('booking-card-booking-4')).toBeInTheDocument();
@@ -691,7 +698,7 @@ describe('MyBookingsPage', () => {
       render(<MyBookingsPage />, { wrapper });
       await waitForBookingsLoaded();
 
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // booking-1 is confirmed + future
       expect(screen.queryByTestId('booking-card-booking-1')).not.toBeInTheDocument();
@@ -746,7 +753,7 @@ describe('MyBookingsPage', () => {
       render(<MyBookingsPage />, { wrapper });
       await waitForBookingsLoaded();
 
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       expect(screen.getByText('No past bookings')).toBeInTheDocument();
     });
@@ -760,7 +767,7 @@ describe('MyBookingsPage', () => {
 
       await user.click(screen.getByTestId('booking-card-booking-1'));
 
-      expect(screen.getByTestId('booking-details-modal')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     it('should open details modal when clicking card in history tab', async () => {
@@ -768,10 +775,10 @@ describe('MyBookingsPage', () => {
       render(<MyBookingsPage />, { wrapper });
       await waitForBookingsLoaded();
 
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
       await user.click(screen.getByTestId('booking-card-booking-2'));
 
-      expect(screen.getByTestId('booking-details-modal')).toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
 
     it('should show cancel button only for current bookings in modal', async () => {
@@ -785,7 +792,7 @@ describe('MyBookingsPage', () => {
       await user.click(screen.getByTestId('booking-details-close'));
 
       // Open history booking - should NOT have cancel button
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
       await user.click(screen.getByTestId('booking-card-booking-2'));
       expect(screen.queryByTestId('booking-details-cancel')).not.toBeInTheDocument();
     });
@@ -798,7 +805,7 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       // Switch to history tab to see the admin-cancelled booking
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // booking-5 is cancelled by admin
       const adminCancelledCard = screen.getByTestId('booking-card-booking-5');
@@ -815,7 +822,7 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       // Switch to history tab
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // booking-3 is cancelled by user (cancelledByAdmin=false)
       const userCancelledCard = screen.getByTestId('booking-card-booking-3');
@@ -832,12 +839,12 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       // Switch to history tab
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // Click on the admin-cancelled booking
       await user.click(screen.getByTestId('booking-card-booking-5'));
 
-      const modal = screen.getByTestId('booking-details-modal');
+      const modal = screen.getByRole('dialog');
 
       // Should show the cancellation reason
       expect(within(modal).getByText('Policy violation - no show')).toBeInTheDocument();
@@ -850,17 +857,17 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       // Switch to history tab
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // booking-3 (user cancelled) should have red badge
       const userCancelledCard = screen.getByTestId('booking-card-booking-3');
       const userBadge = within(userCancelledCard).getByText('Cancelled');
-      expect(userBadge).toHaveClass('bg-red-100', 'text-red-800');
+      expect(userBadge).toHaveAttribute('data-tone', 'error');
 
       // booking-5 (admin cancelled) should have amber/orange badge
       const adminCancelledCard = screen.getByTestId('booking-card-booking-5');
       const adminBadge = within(adminCancelledCard).getByText('Cancelled by Admin');
-      expect(adminBadge).toHaveClass('bg-amber-100', 'text-amber-800');
+      expect(adminBadge).toHaveAttribute('data-tone', 'warning');
     });
 
     it('should differentiate admin and user cancelled bookings in the modal', async () => {
@@ -869,17 +876,17 @@ describe('MyBookingsPage', () => {
       await waitForBookingsLoaded();
 
       // Switch to history tab
-      await user.click(screen.getByTestId('tab-history'));
+      await user.click(screen.getByRole('tab', { name: /Booking History/ }));
 
       // Open user-cancelled booking modal
       await user.click(screen.getByTestId('booking-card-booking-3'));
-      let modal = screen.getByTestId('booking-details-modal');
+      let modal = screen.getByRole('dialog');
       expect(within(modal).getByText('Cancelled')).toBeInTheDocument();
       await user.click(screen.getByTestId('booking-details-close'));
 
       // Open admin-cancelled booking modal
       await user.click(screen.getByTestId('booking-card-booking-5'));
-      modal = screen.getByTestId('booking-details-modal');
+      modal = screen.getByRole('dialog');
       expect(within(modal).getByText('Cancelled by Admin')).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary

Part of the UI-overhaul train, stacked on #298 (`feat/ui-integration`). Reskin-only pass over `BookingPage.tsx` (the LIFF-critical channel-booking flow LINE OA guests use inside the in-app webview) and `MyBookingsPage.tsx` (the booking browse/manage surface) onto the shared design system primitives — no logic, flow, or API changes.

- **BookingPage** (LIFF-critical): `AppShell variant="guest" hideTabBar` so a new fixed bottom CTA bar (running total + primary action) owns the thumb zone for the whole checkout flow; step indicator → compact numbered pills connected by hairlines; property and room-type selection → accessible radio-cards (sr-only input, label-wraps-card, selected = `border-brand-600 ring-1 ring-brand-600 bg-brand-50`); PromptPay QR on a pure white `shadow-soft` panel; hold-expiry countdown → warning `Badge`; slip dropzone restyled with an explicit ≥44px browse `Button`.
- **MyBookingsPage**: `AppShell variant="guest"` (tab bar visible); current/history tab strip → `TabNav` (button mode); booking rows → `Card`; the four status-color records (booking status, payment type, slip auto-verify status, admin verification status) now map to `Badge` tones (`success`/`warning`/`error`/`brand`) instead of bespoke bg/text class pairs, same semantics; the three hand-rolled `fixed inset-0` overlays (details, cancel-confirm, slip-upload) → the shared `Modal` primitive (sheet-on-mobile, destructive confirm button); empty tabs → `EmptyState`.
- Fixed a real footgun surfaced by adopting the `Modal` primitive: its default initial-focus lands on the first focusable descendant, which was each modal's icon-only close button. Combined with the existing Enter-key-opens-card behavior, that raced a still-in-flight Enter keypress into synthesizing a click on the now-focused close button — the modal closed itself immediately after opening. Fixed by pointing `initialFocusRef` at each modal's heading instead (better UX regardless: a freshly-opened modal shouldn't default focus onto a dismiss control).
- Design ratchet: this pass **reduced** the `font-medium` / `legacy-shadows` / `off-grammar-radii` / `oversized-titles` counts; baseline ratcheted down accordingly (`design-baseline.json` included).
- i18n: added one new key, `payment.browseFiles` (en/th/zh-CN), for the new browse button on BookingPage's slip dropzone. No existing keys touched.

## Behavior preservation

Zero logic/flow/API changes — traced the full diff against the pre-edit versions: state, `useEffect`/`useMutation`/`useQuery` hooks, and every handler body are byte-identical (only imports, styling-record shapes, and two new focus refs differ pre-JSX). Every existing `data-testid` is preserved where the shared primitives expose a prop surface for it; the handful of pure DOM-wrapper testids the `Modal`/`TabNav` primitives can't carry externally (modal panel/backdrop divs, per-tab button testids) are now targeted in tests via role + accessible-name queries instead, per this repo's UI-primitive test doctrine (`ui/README.md`) — no Playwright E2E spec depends on any of the changed testids (checked).

**Manual LIFF device pass is still pending** — this was verified via unit tests, typecheck, lint, design ratchet, and a production build only. Given BookingPage is the guest-facing checkout flow rendered inside the LINE LIFF in-app webview, please get an actual on-device LIFF smoke pass (property → dates → room → confirm → PromptPay QR → slip upload) before merging to `main`.

## Test plan

- [x] `npm run lint` (eslint + design ratchet) — 0 errors, ratchet improved and baseline updated
- [x] `npm run typecheck` — clean
- [x] `npm run test` — full suite green (2192 tests, 78 files), including both rewritten page test suites
- [x] `npm run check:translations` — all keys present in en/th
- [x] `npm run build` — production build succeeds
- [ ] Manual on-device LIFF pass of the booking flow (pending — see note above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)