### PR TITLE
feat(frontend): UI overhaul — Table primitive (responsive card reflow)

### DIFF
--- a/frontend/src/components/ui/Table.tsx
+++ b/frontend/src/components/ui/Table.tsx
@@ -1,0 +1,264 @@
+import type { JSX, KeyboardEvent, ReactNode } from 'react';
+import { Card } from './Card';
+import { Skeleton } from './Skeleton';
+import { cn } from './cn';
+
+export type TableColumnAlign = 'left' | 'right';
+
+export type TableColumn<T> = {
+  key: string;
+  header: ReactNode;
+  cell: (row: T) => ReactNode;
+  /** @default 'left' */
+  align?: TableColumnAlign;
+  /** Omit this column from the auto-generated mobile card. */
+  hideOnMobile?: boolean;
+};
+
+export type TableProps<T> = {
+  columns: TableColumn<T>[];
+  rows: T[];
+  rowKey: (row: T) => string;
+  /** Makes the desktop row and mobile card clickable (button semantics, keyboard operable). */
+  onRowClick?: (row: T) => void;
+  /** Custom mobile card renderer; falls back to an auto label/value layout. */
+  mobileCard?: (row: T) => ReactNode;
+  stickyHeader?: boolean;
+  /** Rendered when rows is empty (pages usually pass an <EmptyState/>). */
+  empty?: ReactNode;
+  /** Renders Skeleton rows/cards instead of content. */
+  loading?: boolean;
+  'aria-label'?: string;
+  className?: string;
+};
+
+const DESKTOP_SKELETON_ROW_COUNT = 5;
+const MOBILE_SKELETON_CARD_COUNT = 3;
+const DEFAULT_EMPTY_MESSAGE = 'No data available.';
+
+const HEADER_CELL_CLASSES = 'text-fine font-semibold uppercase tracking-wider text-ink-muted px-4 py-3';
+const BODY_CELL_CLASSES = 'px-4 py-3 text-caption text-ink';
+const INTERACTIVE_ROW_CLASSES =
+  'cursor-pointer hover:bg-surface-sunken focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-600 focus-visible:ring-inset';
+
+type RowInteractionProps = {
+  role?: 'button';
+  tabIndex?: number;
+  onClick?: () => void;
+  onKeyDown?: (event: KeyboardEvent<HTMLElement>) => void;
+};
+
+function isActivationKey(key: string): boolean {
+  return key === 'Enter' || key === ' ';
+}
+
+/** Row + mobile card share this: click/Enter/Space activation with button semantics. */
+function buildRowInteractionProps<T>(row: T, onRowClick?: (row: T) => void): RowInteractionProps {
+  if (!onRowClick) {
+    return {};
+  }
+  return {
+    role: 'button',
+    tabIndex: 0,
+    onClick: () => onRowClick(row),
+    onKeyDown: (event) => {
+      if (!isActivationKey(event.key)) {
+        return;
+      }
+      event.preventDefault();
+      onRowClick(row);
+    },
+  };
+}
+
+function resolveAlign(align?: TableColumnAlign): TableColumnAlign {
+  return align ?? 'left';
+}
+
+function renderEmptyContent(empty?: ReactNode): ReactNode {
+  return empty ?? <p className="py-8 text-center text-caption text-ink-muted">{DEFAULT_EMPTY_MESSAGE}</p>;
+}
+
+function TableHeaderCell<T>({
+  column,
+  stickyHeader,
+}: {
+  column: TableColumn<T>;
+  stickyHeader: boolean;
+}) {
+  const align = resolveAlign(column.align);
+  return (
+    <th
+      scope="col"
+      data-align={align}
+      className={cn(HEADER_CELL_CLASSES, align === 'right' && 'text-right', stickyHeader && 'sticky top-0 z-10')}
+    >
+      {column.header}
+    </th>
+  );
+}
+
+function TableBodyCell<T>({ column, row }: { column: TableColumn<T>; row: T }) {
+  const align = resolveAlign(column.align);
+  return (
+    <td data-align={align} className={cn(BODY_CELL_CLASSES, align === 'right' && 'text-right')}>
+      {column.cell(row)}
+    </td>
+  );
+}
+
+function DesktopBodyRow<T>({
+  row,
+  columns,
+  onRowClick,
+}: {
+  row: T;
+  columns: TableColumn<T>[];
+  onRowClick?: (row: T) => void;
+}) {
+  const interactionProps = buildRowInteractionProps(row, onRowClick);
+  return (
+    <tr className={cn(onRowClick && INTERACTIVE_ROW_CLASSES)} {...interactionProps}>
+      {columns.map((column) => (
+        <TableBodyCell key={column.key} column={column} row={row} />
+      ))}
+    </tr>
+  );
+}
+
+function DesktopSkeletonRows({ columnCount }: { columnCount: number }) {
+  return (
+    <>
+      {Array.from({ length: DESKTOP_SKELETON_ROW_COUNT }, (_, rowIndex) => (
+        <tr key={`table-skeleton-row-${rowIndex}`}>
+          {Array.from({ length: columnCount }, (_, cellIndex) => (
+            <td key={`table-skeleton-cell-${rowIndex}-${cellIndex}`} className={BODY_CELL_CLASSES}>
+              <Skeleton className="h-4 w-full" />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
+}
+
+function AutoMobileCardBody<T>({ row, columns }: { row: T; columns: TableColumn<T>[] }) {
+  const visibleColumns = columns.filter((column) => !column.hideOnMobile);
+  const [titleColumn, ...detailColumns] = visibleColumns;
+
+  if (!titleColumn) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-body font-semibold text-ink">{titleColumn.cell(row)}</p>
+      {detailColumns.map((column) => (
+        <div key={column.key} className="flex items-center justify-between gap-4">
+          <span className="text-fine text-ink-muted">{column.header}</span>
+          <span className="text-caption text-ink text-right">{column.cell(row)}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function MobileRowCard<T>({
+  row,
+  columns,
+  mobileCard,
+  onRowClick,
+}: {
+  row: T;
+  columns: TableColumn<T>[];
+  mobileCard?: (row: T) => ReactNode;
+  onRowClick?: (row: T) => void;
+}) {
+  const interactionProps = buildRowInteractionProps(row, onRowClick);
+  return (
+    <Card padding="md" className={cn(onRowClick && INTERACTIVE_ROW_CLASSES)} {...interactionProps}>
+      {mobileCard ? mobileCard(row) : <AutoMobileCardBody row={row} columns={columns} />}
+    </Card>
+  );
+}
+
+function MobileSkeletonCards() {
+  return (
+    <>
+      {Array.from({ length: MOBILE_SKELETON_CARD_COUNT }, (_, index) => (
+        <Card key={`table-mobile-skeleton-${index}`} padding="md" className="space-y-2">
+          <Skeleton className="h-4 w-1/2" />
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-full" />
+        </Card>
+      ))}
+    </>
+  );
+}
+
+export function Table<T>({
+  columns,
+  rows,
+  rowKey,
+  onRowClick,
+  mobileCard,
+  stickyHeader = false,
+  empty,
+  loading = false,
+  className,
+  'aria-label': ariaLabel,
+}: TableProps<T>): JSX.Element {
+  const isEmpty = !loading && rows.length === 0;
+
+  return (
+    <div className={cn(className)} data-loading={loading || undefined} data-empty={isEmpty || undefined}>
+      <div
+        data-view="desktop"
+        className="hidden md:block overflow-x-auto rounded-card border border-hairline bg-surface-card"
+      >
+        <table className="min-w-full" aria-label={ariaLabel}>
+          <thead>
+            <tr className="bg-surface-sunken">
+              {columns.map((column) => (
+                <TableHeaderCell key={column.key} column={column} stickyHeader={stickyHeader} />
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-hairline">
+            {loading ? (
+              <DesktopSkeletonRows columnCount={columns.length} />
+            ) : isEmpty ? (
+              <tr>
+                <td colSpan={columns.length} className={BODY_CELL_CLASSES}>
+                  {renderEmptyContent(empty)}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row) => (
+                <DesktopBodyRow key={rowKey(row)} row={row} columns={columns} onRowClick={onRowClick} />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div data-view="mobile" className="md:hidden space-y-3">
+        {loading ? (
+          <MobileSkeletonCards />
+        ) : isEmpty ? (
+          <div>{renderEmptyContent(empty)}</div>
+        ) : (
+          rows.map((row) => (
+            <MobileRowCard
+              key={rowKey(row)}
+              row={row}
+              columns={columns}
+              mobileCard={mobileCard}
+              onRowClick={onRowClick}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/__tests__/Table.test.tsx
+++ b/frontend/src/components/ui/__tests__/Table.test.tsx
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Table } from '../Table';
+import type { TableColumn } from '../Table';
+
+type Member = {
+  id: string;
+  name: string;
+  tier: string;
+  points: number;
+};
+
+const firstMember: Member = { id: 'm1', name: 'Alice Anders', tier: 'Gold', points: 1200 };
+
+const members: Member[] = [
+  firstMember,
+  { id: 'm2', name: 'Bob Baker', tier: 'Silver', points: 450 },
+  { id: 'm3', name: 'Cara Cole', tier: 'Bronze', points: 80 },
+];
+
+function buildColumns(): TableColumn<Member>[] {
+  return [
+    { key: 'name', header: 'Name', cell: (row) => row.name },
+    { key: 'tier', header: 'Tier', cell: (row) => row.tier },
+    { key: 'points', header: 'Points', cell: (row) => row.points, align: 'right' },
+    { key: 'internalId', header: 'Internal ID', cell: (row) => row.id, hideOnMobile: true },
+  ];
+}
+
+function getDesktopTable() {
+  return screen.getByRole('table');
+}
+
+function getMobileContainer(container: HTMLElement) {
+  return container.querySelector('[data-view="mobile"]') as HTMLElement;
+}
+
+describe('Table', () => {
+  it('should render a table with a column header per column', () => {
+    render(<Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} />);
+
+    const headers = within(getDesktopTable()).getAllByRole('columnheader');
+    expect(headers.map((header) => header.textContent)).toEqual(['Name', 'Tier', 'Points', 'Internal ID']);
+  });
+
+  it("should render each row's cells using the column cell renderer", () => {
+    render(<Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} />);
+
+    const table = getDesktopTable();
+    expect(within(table).getByText('Alice Anders')).toBeInTheDocument();
+    expect(within(table).getByText('Gold')).toBeInTheDocument();
+    expect(within(table).getByText('1200')).toBeInTheDocument();
+  });
+
+  it('should call rowKey for every row', () => {
+    const rowKey = vi.fn((row: Member) => row.id);
+    render(<Table columns={buildColumns()} rows={members} rowKey={rowKey} />);
+
+    members.forEach((member) => expect(rowKey).toHaveBeenCalledWith(member));
+  });
+
+  describe('onRowClick', () => {
+    it('should expose the desktop row with button semantics and fire onClick', async () => {
+      const user = userEvent.setup();
+      const handleRowClick = vi.fn();
+      render(
+        <Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} onRowClick={handleRowClick} />
+      );
+
+      const row = within(getDesktopTable()).getByRole('button', { name: /Alice Anders/ });
+      await user.click(row);
+
+      expect(handleRowClick).toHaveBeenCalledWith(members[0]);
+    });
+
+    it('should fire onRowClick when the desktop row is activated with Enter', async () => {
+      const user = userEvent.setup();
+      const handleRowClick = vi.fn();
+      render(
+        <Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} onRowClick={handleRowClick} />
+      );
+
+      within(getDesktopTable()).getByRole('button', { name: /Alice Anders/ }).focus();
+      await user.keyboard('{Enter}');
+
+      expect(handleRowClick).toHaveBeenCalledWith(members[0]);
+    });
+
+    it('should fire onRowClick when the desktop row is activated with Space', async () => {
+      const user = userEvent.setup();
+      const handleRowClick = vi.fn();
+      render(
+        <Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} onRowClick={handleRowClick} />
+      );
+
+      within(getDesktopTable()).getByRole('button', { name: /Alice Anders/ }).focus();
+      await user.keyboard(' ');
+
+      expect(handleRowClick).toHaveBeenCalledWith(members[0]);
+    });
+
+    it('should make the desktop row keyboard-focusable', () => {
+      render(<Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} onRowClick={vi.fn()} />);
+
+      const row = within(getDesktopTable()).getByRole('button', { name: /Alice Anders/ });
+      expect(row).toHaveAttribute('tabindex', '0');
+    });
+
+    it('should not expose row button semantics when onRowClick is omitted', () => {
+      render(<Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} />);
+
+      expect(within(getDesktopTable()).queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('should also expose the mobile card with button semantics and fire onClick', async () => {
+      const user = userEvent.setup();
+      const handleRowClick = vi.fn();
+      const { container } = render(
+        <Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} onRowClick={handleRowClick} />
+      );
+
+      const card = within(getMobileContainer(container)).getByRole('button', { name: /Alice Anders/ });
+      await user.click(card);
+
+      expect(handleRowClick).toHaveBeenCalledWith(members[0]);
+    });
+  });
+
+  describe('mobile card layout', () => {
+    it('should promote the first column to the card title and render remaining columns as label/value pairs', () => {
+      const { container } = render(<Table columns={buildColumns()} rows={[firstMember]} rowKey={(row) => row.id} />);
+
+      const mobile = getMobileContainer(container);
+      expect(within(mobile).getByText('Alice Anders')).toBeInTheDocument();
+      expect(within(mobile).getByText('Tier')).toBeInTheDocument();
+      expect(within(mobile).getByText('Gold')).toBeInTheDocument();
+      expect(within(mobile).getByText('Points')).toBeInTheDocument();
+      expect(within(mobile).getByText('1200')).toBeInTheDocument();
+    });
+
+    it('should skip hideOnMobile columns in the auto layout', () => {
+      const { container } = render(<Table columns={buildColumns()} rows={[firstMember]} rowKey={(row) => row.id} />);
+
+      const mobile = getMobileContainer(container);
+      expect(within(mobile).queryByText('Internal ID')).not.toBeInTheDocument();
+      expect(within(mobile).queryByText('m1')).not.toBeInTheDocument();
+    });
+
+    it('should render a custom mobileCard renderer instead of the auto layout when provided', () => {
+      const { container } = render(
+        <Table
+          columns={buildColumns()}
+          rows={[firstMember]}
+          rowKey={(row) => row.id}
+          mobileCard={(row) => <div>Custom card for {row.name}</div>}
+        />
+      );
+
+      const mobile = getMobileContainer(container);
+      expect(within(mobile).getByText('Custom card for Alice Anders')).toBeInTheDocument();
+      expect(within(mobile).queryByText('Tier')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('loading state', () => {
+    it('should stamp data-loading and hide row content on both layouts', () => {
+      const { container } = render(<Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} loading />);
+
+      expect(container.firstChild).toHaveAttribute('data-loading', 'true');
+      expect(screen.queryByText('Alice Anders')).not.toBeInTheDocument();
+    });
+
+    it('should render 5 desktop skeleton rows', () => {
+      render(<Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} loading />);
+
+      // 1 header row + 5 skeleton rows
+      expect(within(getDesktopTable()).getAllByRole('row')).toHaveLength(6);
+    });
+
+    it('should render 3 mobile skeleton cards', () => {
+      const { container } = render(<Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} loading />);
+
+      const mobile = getMobileContainer(container);
+      expect(mobile.querySelectorAll('[data-surface="card"]')).toHaveLength(3);
+    });
+  });
+
+  describe('empty state', () => {
+    it('should stamp data-empty and render the provided empty node in both layouts', () => {
+      const { container } = render(
+        <Table
+          columns={buildColumns()}
+          rows={[]}
+          rowKey={(row) => row.id}
+          empty={<p>No members match your filters</p>}
+        />
+      );
+
+      expect(container.firstChild).toHaveAttribute('data-empty', 'true');
+      expect(screen.getAllByText('No members match your filters')).toHaveLength(2);
+    });
+
+    it('should render a fallback message when empty is omitted', () => {
+      render(<Table columns={buildColumns()} rows={[]} rowKey={(row) => row.id} />);
+
+      expect(screen.getAllByText('No data available.').length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('column alignment', () => {
+    it('should stamp data-align="left" by default and data-align="right" when set', () => {
+      render(<Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} />);
+
+      const headers = within(getDesktopTable()).getAllByRole('columnheader');
+      expect(headers[0]).toHaveAttribute('data-align', 'left');
+      expect(headers[2]).toHaveAttribute('data-align', 'right');
+    });
+  });
+
+  describe('aria-label', () => {
+    it('should pass aria-label through to the desktop table', () => {
+      render(<Table columns={buildColumns()} rows={members} rowKey={(row) => row.id} aria-label="Members" />);
+
+      expect(screen.getByRole('table', { name: 'Members' })).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/ui/index.ts
+++ b/frontend/src/components/ui/index.ts
@@ -31,3 +31,4 @@ export { PageHeader, type PageHeaderProps, type PageHeaderDensity } from './Page
 export { Section, type SectionProps, type SectionSurface, type SectionWidth, type SectionSpacing, type SectionElement } from './Section';
 export { TabNav, type TabNavProps, type TabItem, type TabLinkItem } from './TabNav';
 export { EmptyState, type EmptyStateProps, type EmptyStateIcon } from './EmptyState';
+export { Table, type TableProps, type TableColumn, type TableColumnAlign } from './Table';


### PR DESCRIPTION
## Summary
- Adds the `Table` primitive to `frontend/src/components/ui/`: a generic, typed data table with a CSS-driven responsive dual render (desktop `<table>` / mobile card stack) — no JS `matchMedia`.
- Auto mobile card layout (first column promoted to title, remaining non-`hideOnMobile` columns as label/value rows) with an escape hatch via `mobileCard`.
- `onRowClick` makes the desktop row and mobile card keyboard-operable (Enter/Space) with button semantics.
- Handles `loading` (5 desktop skeleton rows / 3 mobile skeleton cards) and `empty` (caller-supplied node or a muted fallback) states, stamped via `data-loading` / `data-empty`.
- Column `align` reflected via `data-align` on header/body cells.
- Part of the UI-overhaul train — unblocks the admin table migration wave (11 admin data tables currently only overflow-x scroll on mobile).

## Test plan
- [x] `npm run lint` (eslint + design ratchet) — 0 errors
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 2211/2211 passing (79 files), including 19 new `Table.test.tsx` cases covering: table role + column headers, cell renderers receiving rows, `rowKey` usage, `onRowClick` click/Enter/Space + button semantics (desktop row and mobile card), mobile auto-layout label/value + `hideOnMobile` skip, custom `mobileCard` override, loading skeletons, empty state (custom + fallback), `data-align`, `aria-label` passthrough
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014po1W81GnccxF16Fuy5fom