### PR TITLE
feat(frontend): UI overhaul — admin rooms + booking ops (wave 3)

### DIFF
--- a/frontend/scripts/design-baseline.json
+++ b/frontend/scripts/design-baseline.json
@@ -2,9 +2,9 @@
   "primary-alias": 0,
   "cool-grays": 0,
   "font-extrabold": 0,
-  "font-medium": 390,
-  "legacy-shadows": 167,
-  "off-grammar-radii": 240,
+  "font-medium": 285,
+  "legacy-shadows": 148,
+  "off-grammar-radii": 167,
   "oversized-titles": 19,
   "hardcoded-hex": 105
 }

--- a/frontend/src/components/admin/SlipViewerSidebar.tsx
+++ b/frontend/src/components/admin/SlipViewerSidebar.tsx
@@ -3,7 +3,6 @@ import { useTranslation } from 'react-i18next';
 import {
   FiCheck,
   FiAlertTriangle,
-  FiRefreshCw,
   FiEdit,
   FiClock,
   FiImage,
@@ -17,6 +16,7 @@ import {
 import { formatDateTimeToEuropean } from '../../utils/dateFormatter';
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'react-hot-toast';
+import { Badge, Button, type BadgeTone } from '../ui';
 
 // Types matching BookingManagement
 interface BookingUser {
@@ -105,6 +105,9 @@ interface SlipViewerSidebarProps {
   onEdit: (booking: Booking) => void;
   onRefresh: () => void;
 }
+
+const ICON_BUTTON_CLASSES =
+  'flex h-11 w-11 items-center justify-center rounded-full bg-ink/50 text-white transition hover:bg-ink/70 disabled:opacity-30 disabled:cursor-not-allowed';
 
 const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
   booking,
@@ -259,22 +262,20 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
     status,
     verifiedAt
   }) => {
-    const badges: Record<string, { className: string; text: string }> = {
-      verified: { className: 'bg-green-100 text-green-800', text: t('admin.booking.bookingManagement.slipStatus.verified') },
-      failed: { className: 'bg-red-100 text-red-800', text: t('admin.booking.bookingManagement.slipStatus.failed') },
-      pending: { className: 'bg-yellow-100 text-yellow-800', text: t('admin.booking.bookingManagement.slipStatus.pending') },
-      quota_exceeded: { className: 'bg-orange-100 text-orange-800', text: t('admin.booking.bookingManagement.slipStatus.quotaExceeded') }
+    const badges: Record<string, { tone: BadgeTone; text: string }> = {
+      verified: { tone: 'success', text: t('admin.booking.bookingManagement.slipStatus.verified') },
+      failed: { tone: 'error', text: t('admin.booking.bookingManagement.slipStatus.failed') },
+      pending: { tone: 'warning', text: t('admin.booking.bookingManagement.slipStatus.pending') },
+      quota_exceeded: { tone: 'warning', text: t('admin.booking.bookingManagement.slipStatus.quotaExceeded') }
     };
 
     const badge = badges[status] ?? badges.pending;
 
     return (
-      <div className="flex flex-col">
-        <span className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${badge?.className ?? ''}`}>
-          {badge?.text ?? ''}
-        </span>
+      <div className="flex flex-col gap-1">
+        <Badge tone={badge?.tone ?? 'warning'}>{badge?.text ?? ''}</Badge>
         {verifiedAt && (
-          <span className="text-xs text-stone-500 mt-1">
+          <span className="text-fine text-ink-muted">
             {formatDateTimeToEuropean(verifiedAt)}
           </span>
         )}
@@ -287,26 +288,24 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
     verifiedAt: string | null;
     verifiedByName?: string | null;
   }> = ({ status, verifiedAt, verifiedByName }) => {
-    const badges: Record<string, { className: string; text: string }> = {
-      verified: { className: 'bg-green-100 text-green-800', text: t('admin.booking.bookingManagement.adminStatus.verified') },
-      needs_action: { className: 'bg-orange-100 text-orange-800', text: t('admin.booking.bookingManagement.adminStatus.needsAction') },
-      pending: { className: 'bg-yellow-100 text-yellow-800', text: t('admin.booking.bookingManagement.adminStatus.pending') }
+    const badges: Record<string, { tone: BadgeTone; text: string }> = {
+      verified: { tone: 'success', text: t('admin.booking.bookingManagement.adminStatus.verified') },
+      needs_action: { tone: 'error', text: t('admin.booking.bookingManagement.adminStatus.needsAction') },
+      pending: { tone: 'warning', text: t('admin.booking.bookingManagement.adminStatus.pending') }
     };
 
     const badge = badges[status] ?? badges.pending;
 
     return (
-      <div className="flex flex-col">
-        <span className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${badge?.className ?? ''}`}>
-          {badge?.text ?? ''}
-        </span>
+      <div className="flex flex-col gap-1">
+        <Badge tone={badge?.tone ?? 'warning'}>{badge?.text ?? ''}</Badge>
         {verifiedAt && (
-          <span className="text-xs text-stone-500 mt-1">
+          <span className="text-fine text-ink-muted">
             {formatDateTimeToEuropean(verifiedAt)}
           </span>
         )}
         {verifiedByName && (
-          <span className="text-xs text-stone-500">
+          <span className="text-fine text-ink-muted">
             {t('admin.booking.bookingManagement.by')}: {verifiedByName}
           </span>
         )}
@@ -332,15 +331,15 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
   // No booking selected state
   if (!booking) {
     return (
-      <div className="bg-white rounded-lg shadow h-full">
-        <div className="p-4 border-b border-stone-200">
-          <h3 className="text-lg font-semibold text-stone-900">
+      <div className="h-full rounded-card border border-hairline bg-surface-card">
+        <div className="border-b border-hairline p-4">
+          <h3 className="text-body font-semibold text-ink">
             {t('admin.booking.bookingManagement.slipViewer.title')}
           </h3>
         </div>
-        <div className="p-6 flex flex-col items-center justify-center text-stone-500 h-64">
-          <FiImage className="w-12 h-12 mb-4 opacity-50" />
-          <p className="text-center">{t('admin.booking.bookingManagement.slipViewer.selectBooking')}</p>
+        <div className="flex h-64 flex-col items-center justify-center p-6 text-ink-muted">
+          <FiImage className="mb-4 h-12 w-12 opacity-50" aria-hidden="true" />
+          <p className="text-center text-caption">{t('admin.booking.bookingManagement.slipViewer.selectBooking')}</p>
         </div>
       </div>
     );
@@ -349,14 +348,14 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
   const recentAudit = booking.auditHistory?.slice(0, 3) ?? [];
 
   return (
-    <div className="bg-white rounded-lg shadow h-full flex flex-col">
+    <div className="flex h-full flex-col rounded-card border border-hairline bg-surface-card">
       {/* Header */}
-      <div className="p-4 border-b border-stone-200">
-        <h3 className="text-lg font-semibold text-stone-900">
+      <div className="border-b border-hairline p-4">
+        <h3 className="text-body font-semibold text-ink">
           {t('admin.booking.bookingManagement.slipViewer.title')}
         </h3>
         {slips.length > 0 && slips[0] && (
-          <p className="text-sm text-stone-500 mt-1">
+          <p className="mt-1 text-caption text-ink-muted">
             {slips.length > 1
               ? t('admin.booking.bookingManagement.slipViewer.slipCount', { count: slips.length })
               : t('admin.booking.bookingManagement.slipViewer.uploaded') + ': ' + formatDateTimeToEuropean(slips[0].uploadedAt)
@@ -367,15 +366,15 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
 
       {/* Status Section - Show current slip status */}
       {currentSlip && (
-        <div className="p-4 border-b border-stone-200 grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-4 border-b border-hairline p-4">
           <div>
-            <p className="text-xs text-stone-500 mb-1">
+            <p className="mb-1 text-fine text-ink-muted">
               {t('admin.booking.bookingManagement.slipViewer.slipokStatus')}
             </p>
             <SlipStatusBadge status={currentSlip.slipokStatus} verifiedAt={currentSlip.slipokVerifiedAt} />
           </div>
           <div>
-            <p className="text-xs text-stone-500 mb-1">
+            <p className="mb-1 text-fine text-ink-muted">
               {t('admin.booking.bookingManagement.slipViewer.adminStatus')}
             </p>
             <AdminStatusBadge
@@ -388,32 +387,32 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
       )}
 
       {/* Image Section - Gallery View for Multiple Slips */}
-      <div className="p-4 border-b border-stone-200 flex-1 flex flex-col min-h-0">
+      <div className="flex min-h-0 flex-1 flex-col border-b border-hairline p-4">
         {slips.length > 0 ? (
           <>
-          <div className="relative flex-1 min-h-[300px]">
+          <div className="relative min-h-[300px] flex-1 rounded-lg border border-hairline bg-surface-card p-2">
             {/* Main Image */}
             <img
               src={currentSlip?.slipUrl}
               alt={t('admin.booking.bookingManagement.slipViewer.slipImage')}
-              className="w-full h-full object-contain rounded-lg cursor-pointer"
+              className="h-full w-full cursor-pointer object-contain rounded-lg"
               onClick={() => currentSlip && openFullscreen(currentSlip.slipUrl)}
             />
 
             {/* Fullscreen Button */}
             <button
               onClick={() => currentSlip && openFullscreen(currentSlip.slipUrl)}
-              className="absolute top-2 right-2 p-2 bg-black/50 rounded-full text-white hover:bg-black/70"
+              className={`absolute right-2 top-2 ${ICON_BUTTON_CLASSES}`}
               title={t('admin.booking.bookingManagement.slipViewer.fullscreen')}
             >
-              <FiMaximize2 className="w-4 h-4" />
+              <FiMaximize2 className="h-4 w-4" aria-hidden="true" />
             </button>
 
             {/* Multi-slip Navigation */}
             {hasMultipleSlips && (
               <>
                 {/* Slip Counter */}
-                <div className="absolute top-2 left-2 px-2 py-1 bg-black/50 rounded text-white text-sm">
+                <div className="absolute left-2 top-2 rounded bg-ink/50 px-2 py-1 text-caption text-white">
                   {currentSlipIndex + 1} / {slips.length}
                 </div>
 
@@ -421,32 +420,32 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
                 <button
                   onClick={() => setCurrentSlipIndex(prev => Math.max(0, prev - 1))}
                   disabled={currentSlipIndex === 0}
-                  className="absolute left-2 top-1/2 -translate-y-1/2 p-2 bg-black/50 rounded-full text-white hover:bg-black/70 disabled:opacity-30 disabled:cursor-not-allowed"
+                  className={`absolute left-2 top-1/2 -translate-y-1/2 ${ICON_BUTTON_CLASSES}`}
                 >
-                  <FiChevronLeft className="w-5 h-5" />
+                  <FiChevronLeft className="h-5 w-5" aria-hidden="true" />
                 </button>
                 <button
                   onClick={() => setCurrentSlipIndex(prev => Math.min(slips.length - 1, prev + 1))}
                   disabled={currentSlipIndex === slips.length - 1}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 p-2 bg-black/50 rounded-full text-white hover:bg-black/70 disabled:opacity-30 disabled:cursor-not-allowed"
+                  className={`absolute right-2 top-1/2 -translate-y-1/2 ${ICON_BUTTON_CLASSES}`}
                 >
-                  <FiChevronRight className="w-5 h-5" />
+                  <FiChevronRight className="h-5 w-5" aria-hidden="true" />
                 </button>
 
                 {/* Thumbnail Strip */}
-                <div className="absolute bottom-2 left-1/2 -translate-x-1/2 flex gap-1 bg-black/30 p-1 rounded">
+                <div className="absolute bottom-2 left-1/2 flex -translate-x-1/2 gap-1 rounded bg-ink/40 p-1 backdrop-blur-sm">
                   {slips.map((slip, index) => (
                     <button
                       key={slip.id}
                       onClick={() => setCurrentSlipIndex(index)}
-                      className={`w-12 h-12 rounded overflow-hidden border-2 transition-all ${
+                      className={`h-11 w-11 overflow-hidden rounded border-2 transition-all ${
                         index === currentSlipIndex ? 'border-white' : 'border-transparent opacity-70 hover:opacity-100'
                       }`}
                     >
                       <img
                         src={slip.slipUrl}
                         alt={`Slip ${index + 1}`}
-                        className="w-full h-full object-cover"
+                        className="h-full w-full object-cover"
                       />
                     </button>
                   ))}
@@ -457,13 +456,13 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
 
           {/* Pagination Dots - Always visible below image */}
           {hasMultipleSlips && (
-            <div className="flex justify-center items-center gap-2 mt-3">
+            <div className="mt-3 flex items-center justify-center gap-2">
               <button
                 onClick={() => setCurrentSlipIndex(prev => Math.max(0, prev - 1))}
                 disabled={currentSlipIndex === 0}
-                className="p-1 text-stone-400 hover:text-stone-600 disabled:opacity-30 disabled:cursor-not-allowed"
+                className="flex h-11 w-11 items-center justify-center text-ink-faint transition hover:text-ink-muted disabled:cursor-not-allowed disabled:opacity-30"
               >
-                <FiChevronLeft className="w-5 h-5" />
+                <FiChevronLeft className="h-5 w-5" aria-hidden="true" />
               </button>
 
               <div className="flex items-center gap-1.5">
@@ -471,10 +470,10 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
                   <button
                     key={index}
                     onClick={() => setCurrentSlipIndex(index)}
-                    className={`transition-all duration-200 rounded-full ${
+                    className={`rounded-full transition-all duration-200 ${
                       currentSlipIndex === index
-                        ? 'w-6 h-2 bg-brand-600'
-                        : 'w-2 h-2 bg-stone-300 hover:bg-stone-400'
+                        ? 'h-2 w-6 bg-brand-600'
+                        : 'h-2 w-2 bg-hairline-strong hover:bg-ink-faint'
                     }`}
                     aria-label={`Go to slip ${index + 1}`}
                   />
@@ -484,87 +483,89 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
               <button
                 onClick={() => setCurrentSlipIndex(prev => Math.min(slips.length - 1, prev + 1))}
                 disabled={currentSlipIndex === slips.length - 1}
-                className="p-1 text-stone-400 hover:text-stone-600 disabled:opacity-30 disabled:cursor-not-allowed"
+                className="flex h-11 w-11 items-center justify-center text-ink-faint transition hover:text-ink-muted disabled:cursor-not-allowed disabled:opacity-30"
               >
-                <FiChevronRight className="w-5 h-5" />
+                <FiChevronRight className="h-5 w-5" aria-hidden="true" />
               </button>
 
-              <span className="text-sm text-stone-500 ml-2">
+              <span className="ml-2 text-caption text-ink-muted">
                 {currentSlipIndex + 1} / {slips.length}
               </span>
             </div>
           )}
           </>
         ) : (
-          <div className="h-48 bg-stone-100 rounded-lg flex flex-col items-center justify-center text-stone-400">
-            <FiImage className="w-12 h-12 mb-2" />
-            <p className="text-sm">{t('admin.booking.bookingManagement.slipViewer.noSlip')}</p>
+          <div className="flex h-48 flex-col items-center justify-center rounded-lg bg-surface-sunken text-ink-faint">
+            <FiImage className="mb-2 h-12 w-12" aria-hidden="true" />
+            <p className="text-caption">{t('admin.booking.bookingManagement.slipViewer.noSlip')}</p>
           </div>
         )}
       </div>
 
       {/* Action Buttons */}
-      <div className="p-4 border-b border-stone-200 space-y-2">
+      <div className="space-y-2 border-b border-hairline p-4">
         {currentSlip ? (
           <>
             {/* Multi-slip actions - operate on current slip */}
-            <button
+            <Button
+              type="button"
+              variant="primary"
+              className="w-full bg-success-600 hover:bg-success-700"
               onClick={() => handleVerifySlip(currentSlip.id)}
-              disabled={verifySlipByIdMutation.isPending}
-              className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+              loading={verifySlipByIdMutation.isPending}
             >
-              {verifySlipByIdMutation.isPending ? (
-                <FiRefreshCw className="w-4 h-4 animate-spin" />
-              ) : (
-                <FiCheck className="w-4 h-4" />
-              )}
+              {!verifySlipByIdMutation.isPending && <FiCheck className="h-4 w-4" aria-hidden="true" />}
               {hasMultipleSlips
                 ? t('admin.booking.bookingManagement.actions.verifySlip', { number: currentSlipIndex + 1 })
                 : t('admin.booking.bookingManagement.actions.verify')
               }
-            </button>
-            <button
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              className="w-full bg-warning-600 hover:bg-warning-700"
               onClick={() => handleNeedsActionClick(currentSlip.id)}
-              disabled={markSlipNeedsActionMutation.isPending}
-              className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-orange-500 text-white rounded-md hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed"
+              loading={markSlipNeedsActionMutation.isPending}
             >
-              <FiAlertTriangle className="w-4 h-4" />
+              {!markSlipNeedsActionMutation.isPending && <FiAlertTriangle className="h-4 w-4" aria-hidden="true" />}
               {t('admin.booking.bookingManagement.actions.needsAction')}
-            </button>
+            </Button>
           </>
         ) : (
           <>
             {/* Legacy single slip actions */}
-            <button
+            <Button
+              type="button"
+              variant="primary"
+              className="w-full bg-success-600 hover:bg-success-700"
               onClick={handleLegacyVerifyClick}
               disabled={true}
-              className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <FiCheck className="w-4 h-4" />
+              <FiCheck className="h-4 w-4" aria-hidden="true" />
               {t('admin.booking.bookingManagement.actions.verify')}
-            </button>
-            <button
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              className="w-full bg-warning-600 hover:bg-warning-700"
               onClick={() => handleNeedsActionClick()}
               disabled={true}
-              className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-orange-500 text-white rounded-md hover:bg-orange-600 disabled:opacity-50 disabled:cursor-not-allowed"
             >
-              <FiAlertTriangle className="w-4 h-4" />
+              <FiAlertTriangle className="h-4 w-4" aria-hidden="true" />
               {t('admin.booking.bookingManagement.actions.needsAction')}
-            </button>
+            </Button>
           </>
         )}
-        <button
+        <Button
+          type="button"
+          variant="secondary"
+          className="w-full"
           onClick={() => fileInputRef.current?.click()}
-          disabled={isUploading}
-          className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-stone-100 text-stone-700 rounded-md hover:bg-stone-200 disabled:opacity-50 disabled:cursor-not-allowed"
+          loading={isUploading}
         >
-          {isUploading ? (
-            <FiRefreshCw className="w-4 h-4 animate-spin" />
-          ) : (
-            <FiUpload className="w-4 h-4" />
-          )}
+          {!isUploading && <FiUpload className="h-4 w-4" aria-hidden="true" />}
           {t('admin.booking.bookingManagement.actions.replaceSlip')}
-        </button>
+        </Button>
         <input
           ref={fileInputRef}
           type="file"
@@ -572,25 +573,22 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
           onChange={handleReplaceSlip}
           className="hidden"
         />
-        <button
-          onClick={() => onEdit(booking)}
-          className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-brand-100 text-brand-700 rounded-md hover:bg-brand-200"
-        >
-          <FiEdit className="w-4 h-4" />
+        <Button type="button" variant="ghost" className="w-full" onClick={() => onEdit(booking)}>
+          <FiEdit className="h-4 w-4" aria-hidden="true" />
           {t('admin.booking.bookingManagement.actions.edit')}
-        </button>
+        </Button>
       </div>
 
       {/* Audit Summary */}
       <div className="p-4">
-        <div className="flex items-center justify-between mb-2">
-          <h4 className="text-sm font-medium text-stone-900">
+        <div className="mb-2 flex items-center justify-between">
+          <h4 className="text-caption font-semibold text-ink">
             {t('admin.booking.bookingManagement.slipViewer.auditSummary')}
           </h4>
           {booking.auditHistory && booking.auditHistory.length > 0 && (
             <button
               onClick={() => setShowAuditModal(true)}
-              className="text-xs text-brand-600 hover:text-brand-800"
+              className="text-fine text-brand-600 hover:text-brand-800"
             >
               {t('admin.booking.bookingManagement.slipViewer.viewFullHistory')}
             </button>
@@ -599,16 +597,16 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
         {recentAudit.length > 0 ? (
           <div className="space-y-2">
             {recentAudit.map((entry) => (
-              <div key={entry.id} className="text-xs border-l-2 border-stone-200 pl-2">
-                <p className="font-medium text-stone-900">{formatAuditAction(entry.action)}</p>
-                <p className="text-stone-500">
+              <div key={entry.id} className="border-l-2 border-hairline pl-2 text-fine">
+                <p className="font-semibold text-ink">{formatAuditAction(entry.action)}</p>
+                <p className="text-ink-muted">
                   {entry.adminName} - {formatDateTimeToEuropean(entry.createdAt)}
                 </p>
               </div>
             ))}
           </div>
         ) : (
-          <p className="text-xs text-stone-500">
+          <p className="text-fine text-ink-muted">
             {t('admin.booking.bookingManagement.slipViewer.noAuditHistory')}
           </p>
         )}
@@ -617,7 +615,7 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
       {/* Fullscreen Modal */}
       {isFullscreen && fullscreenSlipUrl && (
         <div
-          className="fixed inset-0 bg-black z-50 flex items-center justify-center"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-ink"
           onClick={() => {
             setIsFullscreen(false);
             setFullscreenSlipUrl(null);
@@ -628,14 +626,14 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
               setIsFullscreen(false);
               setFullscreenSlipUrl(null);
             }}
-            className="absolute top-4 right-4 p-2 bg-white/20 rounded-full text-white hover:bg-white/30"
+            className="absolute right-4 top-4 flex h-11 w-11 items-center justify-center rounded-full bg-white/20 text-white hover:bg-white/30"
           >
-            <FiX className="w-6 h-6" />
+            <FiX className="h-6 w-6" aria-hidden="true" />
           </button>
           <img
             src={fullscreenSlipUrl}
             alt={t('admin.booking.bookingManagement.slipViewer.slipImage')}
-            className="max-w-full max-h-full object-contain p-4"
+            className="max-h-full max-w-full object-contain p-4"
             onClick={(e) => e.stopPropagation()}
           />
         </div>
@@ -643,39 +641,38 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
 
       {/* Notes Modal */}
       {showNotesModal && (
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-lg max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold text-stone-900 mb-4">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-ink/40 p-4 backdrop-blur-sm">
+          <div className="w-full max-w-md rounded-card border border-hairline bg-surface-card p-6">
+            <h3 className="mb-4 text-body font-semibold text-ink">
               {t('admin.booking.bookingManagement.modals.needsAction.title')}
             </h3>
             <textarea
               value={notesInput}
               onChange={(e) => setNotesInput(e.target.value)}
               placeholder={t('admin.booking.bookingManagement.modals.needsAction.placeholder')}
-              className="w-full border border-stone-300 rounded-md p-3 h-32 resize-none focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+              className="h-32 w-full resize-none rounded-lg border border-hairline-strong bg-surface-card p-3 text-body text-ink focus:border-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-600"
             />
-            <div className="flex justify-end gap-3 mt-4">
-              <button
+            <div className="mt-4 flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="secondary"
                 onClick={() => {
                   setShowNotesModal(false);
                   setNotesInput('');
                   setActiveSlipId(null);
                 }}
-                className="px-4 py-2 text-stone-700 bg-stone-100 rounded-md hover:bg-stone-200"
               >
                 {t('common.cancel')}
-              </button>
-              <button
+              </Button>
+              <Button
+                type="button"
+                className="bg-warning-600 hover:bg-warning-700"
                 onClick={handleNotesSubmit}
-                disabled={!notesInput.trim() || markSlipNeedsActionMutation.isPending}
-                className="px-4 py-2 bg-orange-500 text-white rounded-md hover:bg-orange-600 disabled:opacity-50"
+                disabled={!notesInput.trim()}
+                loading={markSlipNeedsActionMutation.isPending}
               >
-                {markSlipNeedsActionMutation.isPending ? (
-                  <FiRefreshCw className="w-4 h-4 animate-spin" />
-                ) : (
-                  t('admin.booking.bookingManagement.modals.needsAction.submit')
-                )}
-              </button>
+                {t('admin.booking.bookingManagement.modals.needsAction.submit')}
+              </Button>
             </div>
           </div>
         </div>
@@ -683,55 +680,55 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
 
       {/* Audit History Modal */}
       {showAuditModal && (
-        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-lg max-w-lg w-full max-h-[80vh] overflow-hidden">
-            <div className="p-4 border-b border-stone-200 flex items-center justify-between">
-              <h3 className="text-lg font-semibold text-stone-900 flex items-center gap-2">
-                <FiList className="w-5 h-5" />
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-ink/40 p-4 backdrop-blur-sm">
+          <div className="max-h-[80vh] w-full max-w-lg overflow-hidden rounded-card border border-hairline bg-surface-card">
+            <div className="flex items-center justify-between border-b border-hairline p-4">
+              <h3 className="flex items-center gap-2 text-body font-semibold text-ink">
+                <FiList className="h-5 w-5" aria-hidden="true" />
                 {t('admin.booking.bookingManagement.modals.auditHistory.title')}
               </h3>
               <button
                 onClick={() => setShowAuditModal(false)}
-                className="text-stone-400 hover:text-stone-600"
+                className="flex h-11 w-11 items-center justify-center text-ink-faint hover:text-ink-muted"
               >
-                <FiX className="w-5 h-5" />
+                <FiX className="h-5 w-5" aria-hidden="true" />
               </button>
             </div>
-            <div className="p-4 overflow-y-auto max-h-[60vh]">
+            <div className="max-h-[60vh] overflow-y-auto p-4">
               {booking.auditHistory && booking.auditHistory.length > 0 ? (
                 <div className="space-y-4">
                   {booking.auditHistory.map((entry) => (
                     <div
                       key={entry.id}
-                      className="border-l-4 border-brand-500 pl-4 py-2"
+                      className="border-l-4 border-brand-500 py-2 pl-4"
                     >
                       <div className="flex items-start justify-between">
                         <div>
-                          <p className="font-medium text-stone-900">
+                          <p className="font-semibold text-ink">
                             {formatAuditAction(entry.action)}
                           </p>
-                          <p className="text-sm text-stone-600">
+                          <p className="text-caption text-ink-muted">
                             {entry.adminName}
                           </p>
                         </div>
-                        <span className="text-xs text-stone-500 flex items-center gap-1">
-                          <FiClock className="w-3 h-3" />
+                        <span className="flex items-center gap-1 text-fine text-ink-muted">
+                          <FiClock className="h-3 w-3" aria-hidden="true" />
                           {formatDateTimeToEuropean(entry.createdAt)}
                         </span>
                       </div>
                       {(entry.oldValue ?? entry.newValue) && (
-                        <div className="mt-2 text-sm">
+                        <div className="mt-2 text-caption">
                           {entry.oldValue && (
-                            <p className="text-red-600">
-                              <span className="font-medium">
+                            <p className="text-error-600">
+                              <span className="font-semibold">
                                 {t('admin.booking.bookingManagement.modals.auditHistory.oldValue')}:
                               </span>{' '}
                               {entry.oldValue}
                             </p>
                           )}
                           {entry.newValue && (
-                            <p className="text-green-600">
-                              <span className="font-medium">
+                            <p className="text-success-600">
+                              <span className="font-semibold">
                                 {t('admin.booking.bookingManagement.modals.auditHistory.newValue')}:
                               </span>{' '}
                               {entry.newValue}
@@ -740,7 +737,7 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
                         </div>
                       )}
                       {entry.notes && (
-                        <p className="mt-1 text-sm text-stone-500 italic">
+                        <p className="mt-1 text-caption italic text-ink-muted">
                           &quot;{entry.notes}&quot;
                         </p>
                       )}
@@ -748,7 +745,7 @@ const SlipViewerSidebar: React.FC<SlipViewerSidebarProps> = ({
                   ))}
                 </div>
               ) : (
-                <p className="text-stone-500 text-center py-8">
+                <p className="py-8 text-center text-ink-muted">
                   {t('admin.booking.bookingManagement.slipViewer.noAuditHistory')}
                 </p>
               )}

--- a/frontend/src/pages/admin/BookingEditModal.tsx
+++ b/frontend/src/pages/admin/BookingEditModal.tsx
@@ -1,8 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-hot-toast';
 import {
-  FiX,
   FiCalendar,
   FiDollarSign,
   FiClock,
@@ -12,6 +11,8 @@ import {
 } from 'react-icons/fi';
 import { formatDateTimeToEuropean } from '../../utils/dateFormatter';
 import { useQuery, useMutation } from '@tanstack/react-query';
+import { Button, Card, FormField, Input, Modal, Select, Textarea, TabNav } from '../../components/ui';
+import type { TabItem } from '../../components/ui';
 
 // Types matching BookingManagement
 interface BookingUser {
@@ -92,6 +93,7 @@ const BookingEditModal: React.FC<BookingEditModalProps> = ({
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<TabType>('details');
   const [isSaving, setIsSaving] = useState(false);
+  const headingRef = useRef<HTMLParagraphElement>(null);
 
   // Form state - Details tab
   const [checkInDate, setCheckInDate] = useState(booking.checkInDate.split('T')[0]);
@@ -261,538 +263,502 @@ const BookingEditModal: React.FC<BookingEditModalProps> = ({
     return actionMap[action] ?? action;
   };
 
+  // Table's onRowClick primitive gives us a single activation per tab strip;
+  // the Cancel tab stays unreachable once a booking is already cancelled,
+  // matching the old disabled <button> — TabNav has no per-item disabled
+  // state, so the guard lives in the change handler instead.
+  const handleTabChange = (value: string) => {
+    if (value === 'cancel' && isBookingCancelled) {
+      return;
+    }
+    setActiveTab(value as TabType);
+  };
+
+  const tabItems: TabItem[] = [
+    {
+      value: 'details',
+      label: (
+        <span className="flex items-center gap-2">
+          <FiCalendar className="h-4 w-4" aria-hidden="true" />
+          {t('admin.booking.bookingManagement.editModal.tabs.details')}
+        </span>
+      ),
+    },
+    {
+      value: 'payment',
+      label: (
+        <span className="flex items-center gap-2">
+          <FiDollarSign className="h-4 w-4" aria-hidden="true" />
+          {t('admin.booking.bookingManagement.editModal.tabs.payment')}
+        </span>
+      ),
+    },
+    {
+      value: 'audit',
+      label: (
+        <span className="flex items-center gap-2">
+          <FiClock className="h-4 w-4" aria-hidden="true" />
+          {t('admin.booking.bookingManagement.editModal.tabs.audit')}
+        </span>
+      ),
+    },
+    {
+      value: 'cancel',
+      label: (
+        <span className={`flex items-center gap-2 ${isBookingCancelled ? 'opacity-40' : ''}`}>
+          <FiAlertTriangle className="h-4 w-4" aria-hidden="true" />
+          {t('admin.booking.bookingManagement.editModal.tabs.cancel')}
+        </span>
+      ),
+    },
+  ];
+
   if (!isOpen) {return null;}
 
   return (
-    <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-lg max-w-2xl w-full max-h-[90vh] overflow-hidden flex flex-col">
-        {/* Header */}
-        <div className="px-6 py-4 border-b border-stone-200 flex items-center justify-between">
+    <Modal
+      open={isOpen}
+      onClose={onClose}
+      title={t('admin.booking.bookingManagement.editModal.title')}
+      size="lg"
+      initialFocusRef={headingRef}
+      footer={
+        <div className="flex justify-end gap-3">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            {t('common.cancel')}
+          </Button>
+          {activeTab !== 'audit' && activeTab !== 'cancel' && (
+            <Button type="button" onClick={handleSave} loading={isSaving}>
+              {isSaving ? t('common.saving') : t('common.save')}
+            </Button>
+          )}
+        </div>
+      }
+    >
+      <p ref={headingRef} tabIndex={-1} className="mb-4 text-caption text-ink-muted outline-none">
+        {t('admin.booking.bookingManagement.editModal.bookingId')}: {booking.id.substring(0, 8)}...
+      </p>
+
+      <TabNav
+        aria-label={t('admin.booking.bookingManagement.editModal.title')}
+        items={tabItems}
+        value={activeTab}
+        onChange={handleTabChange}
+        className="mb-6"
+      />
+
+      {/* Details Tab */}
+      {activeTab === 'details' && (
+        <div className="space-y-6">
+          {/* User Info (Read-only) */}
+          <Card surface="sunken">
+            <h3 className="mb-3 flex items-center gap-2 text-caption font-semibold text-ink">
+              <FiUser className="h-4 w-4" aria-hidden="true" />
+              {t('admin.booking.bookingManagement.editModal.userInfo')}
+            </h3>
+            <div className="grid grid-cols-2 gap-4 text-caption">
+              <div>
+                <span className="text-ink-muted">{t('admin.booking.bookingManagement.editModal.name')}:</span>
+                <span className="ml-2 text-ink">
+                  {booking.user.firstName && booking.user.lastName
+                    ? `${booking.user.firstName} ${booking.user.lastName}`
+                    : booking.user.email}
+                </span>
+              </div>
+              <div>
+                <span className="text-ink-muted">{t('admin.booking.bookingManagement.editModal.email')}:</span>
+                <span className="ml-2 text-ink">{booking.user.email}</span>
+              </div>
+              <div>
+                <span className="text-ink-muted">{t('admin.booking.bookingManagement.editModal.membershipId')}:</span>
+                <span className="ml-2 font-mono text-ink">
+                  {booking.user.membershipId ?? '-'}
+                </span>
+              </div>
+              <div>
+                <span className="text-ink-muted">{t('admin.booking.bookingManagement.editModal.phone')}:</span>
+                <span className="ml-2 text-ink">{booking.user.phone ?? '-'}</span>
+              </div>
+            </div>
+          </Card>
+
+          {/* Editable Fields */}
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <FormField label={t('admin.booking.bookingManagement.editModal.checkInDate')} htmlFor="edit-check-in">
+              <Input
+                id="edit-check-in"
+                type="date"
+                value={checkInDate}
+                onChange={(e) => setCheckInDate(e.target.value)}
+              />
+            </FormField>
+            <FormField label={t('admin.booking.bookingManagement.editModal.checkOutDate')} htmlFor="edit-check-out">
+              <Input
+                id="edit-check-out"
+                type="date"
+                value={checkOutDate}
+                onChange={(e) => setCheckOutDate(e.target.value)}
+                min={checkInDate}
+              />
+            </FormField>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <FormField label={t('admin.booking.bookingManagement.editModal.numberOfGuests')} htmlFor="edit-guests">
+              <Input
+                id="edit-guests"
+                type="number"
+                value={numberOfGuests}
+                onChange={(e) => setNumberOfGuests(parseInt(e.target.value) || 1)}
+                min={1}
+                max={10}
+              />
+            </FormField>
+            <FormField label={t('admin.booking.bookingManagement.editModal.roomType')} htmlFor="edit-room-type">
+              <Select
+                id="edit-room-type"
+                value={roomTypeId}
+                onChange={(e) => setRoomTypeId(e.target.value)}
+              >
+                {roomTypes.map((rt) => (
+                  <option key={rt.id} value={rt.id}>
+                    {rt.name}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+          </div>
+
+          {/* Original Booking Notes (Read-only) */}
+          {booking.notes && (
+            <div className="space-y-1.5">
+              <p className="text-caption font-semibold text-ink">
+                {t('admin.booking.bookingManagement.editModal.originalNotes')}
+              </p>
+              <div className="rounded-lg bg-surface-sunken p-3 text-caption text-ink-muted">
+                {booking.notes}
+              </div>
+            </div>
+          )}
+
+          {/* Admin Notes (Editable) */}
+          <FormField label={t('admin.booking.bookingManagement.editModal.adminNotes')} htmlFor="edit-admin-notes">
+            <Textarea
+              id="edit-admin-notes"
+              value={adminNotes}
+              onChange={(e) => setAdminNotes(e.target.value)}
+              placeholder={t('admin.booking.bookingManagement.editModal.adminNotesPlaceholder')}
+              rows={3}
+            />
+          </FormField>
+        </div>
+      )}
+
+      {/* Payment Tab */}
+      {activeTab === 'payment' && (
+        <div className="space-y-6">
+          {/* Current Payment Info */}
+          <Card surface="sunken">
+            <h3 className="mb-3 text-caption font-semibold text-ink">
+              {t('admin.booking.bookingManagement.editModal.currentPayment')}
+            </h3>
+            <div className="grid grid-cols-2 gap-4 text-caption">
+              <div>
+                <span className="text-ink-muted">
+                  {t('admin.booking.bookingManagement.editModal.paymentType')}:
+                </span>
+                <span className="ml-2 font-semibold text-ink">
+                  {booking.paymentType === 'full'
+                    ? t('admin.booking.bookingManagement.paymentType.full')
+                    : t('admin.booking.bookingManagement.paymentType.deposit')}
+                </span>
+              </div>
+              <div>
+                <span className="text-ink-muted">
+                  {t('admin.booking.bookingManagement.editModal.paymentAmount')}:
+                </span>
+                <span className="ml-2 font-semibold text-ink">
+                  {booking.paymentAmount !== null
+                    ? `${booking.paymentAmount.toLocaleString()} THB`
+                    : '-'}
+                </span>
+              </div>
+            </div>
+          </Card>
+
+          {/* Total Price (Editable) */}
           <div>
-            <h2 className="text-xl font-semibold text-stone-900">
-              {t('admin.booking.bookingManagement.editModal.title')}
-            </h2>
-            <p className="text-sm text-stone-600 mt-1">
-              {t('admin.booking.bookingManagement.editModal.bookingId')}: {booking.id.substring(0, 8)}...
+            <FormField label={t('admin.booking.bookingManagement.editModal.totalPrice')} htmlFor="edit-total-price">
+              <Input
+                id="edit-total-price"
+                type="number"
+                value={totalPrice}
+                onChange={(e) => setTotalPrice(parseFloat(e.target.value) || 0)}
+                min={0}
+                step={0.01}
+                trailingSlot={<span className="pr-3 text-caption text-ink-muted">THB</span>}
+              />
+            </FormField>
+            <p className="mt-1 text-fine text-ink-muted">
+              {t('admin.booking.bookingManagement.editModal.calculatedPayment')}:{' '}
+              {calculatePaymentAmount(totalPrice).toLocaleString()} THB
             </p>
           </div>
-          <button
-            onClick={onClose}
-            className="text-stone-400 hover:text-stone-600"
-          >
-            <FiX className="w-6 h-6" />
-          </button>
-        </div>
 
-        {/* Tabs */}
-        <div className="border-b border-stone-200">
-          <nav className="flex -mb-px">
-            <button
-              onClick={() => setActiveTab('details')}
-              className={`px-6 py-3 text-sm font-medium border-b-2 ${
-                activeTab === 'details'
-                  ? 'border-brand-500 text-brand-600'
-                  : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
-              }`}
-            >
-              <FiCalendar className="w-4 h-4 inline-block mr-2" />
-              {t('admin.booking.bookingManagement.editModal.tabs.details')}
-            </button>
-            <button
-              onClick={() => setActiveTab('payment')}
-              className={`px-6 py-3 text-sm font-medium border-b-2 ${
-                activeTab === 'payment'
-                  ? 'border-brand-500 text-brand-600'
-                  : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
-              }`}
-            >
-              <FiDollarSign className="w-4 h-4 inline-block mr-2" />
-              {t('admin.booking.bookingManagement.editModal.tabs.payment')}
-            </button>
-            <button
-              onClick={() => setActiveTab('audit')}
-              className={`px-6 py-3 text-sm font-medium border-b-2 ${
-                activeTab === 'audit'
-                  ? 'border-brand-500 text-brand-600'
-                  : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
-              }`}
-            >
-              <FiClock className="w-4 h-4 inline-block mr-2" />
-              {t('admin.booking.bookingManagement.editModal.tabs.audit')}
-            </button>
-            <button
-              onClick={() => setActiveTab('cancel')}
-              disabled={isBookingCancelled}
-              className={`px-6 py-3 text-sm font-medium border-b-2 ${
-                activeTab === 'cancel'
-                  ? 'border-red-500 text-red-600'
-                  : isBookingCancelled
-                    ? 'border-transparent text-stone-300 cursor-not-allowed'
-                    : 'border-transparent text-stone-500 hover:text-red-600 hover:border-red-300'
-              }`}
-            >
-              <FiAlertTriangle className="w-4 h-4 inline-block mr-2" />
-              {t('admin.booking.bookingManagement.editModal.tabs.cancel')}
-            </button>
-          </nav>
-        </div>
+          {/* Current Discount */}
+          {booking.discountAmount && booking.discountAmount > 0 && (
+            <Card className="border-success-200 bg-success-50">
+              <h4 className="mb-2 flex items-center gap-2 text-caption font-semibold text-success-700">
+                <FiPercent className="h-4 w-4" aria-hidden="true" />
+                {t('admin.booking.bookingManagement.editModal.currentDiscount')}
+              </h4>
+              <p className="text-title text-success-700">
+                -{booking.discountAmount.toLocaleString()} THB
+              </p>
+              {booking.discountReason && (
+                <p className="mt-1 text-caption text-success-600">
+                  {t('admin.booking.bookingManagement.editModal.reason')}: {booking.discountReason}
+                </p>
+              )}
+            </Card>
+          )}
 
-        {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
-          {/* Details Tab */}
-          {activeTab === 'details' && (
-            <div className="space-y-6">
-              {/* User Info (Read-only) */}
-              <div className="bg-stone-50 rounded-lg p-4">
-                <h3 className="text-sm font-medium text-stone-700 mb-3 flex items-center gap-2">
-                  <FiUser className="w-4 h-4" />
+          {/* Apply Discount Section */}
+          {!showDiscountForm ? (
+            <Button
+              type="button"
+              variant="secondary"
+              className="w-full border-dashed"
+              onClick={() => setShowDiscountForm(true)}
+            >
+              <FiPercent className="h-4 w-4" aria-hidden="true" />
+              {t('admin.booking.bookingManagement.editModal.applyDiscount')}
+            </Button>
+          ) : (
+            <Card className="space-y-4">
+              <h4 className="text-caption font-semibold text-ink">
+                {t('admin.booking.bookingManagement.editModal.applyDiscount')}
+              </h4>
+              <FormField label={t('admin.booking.bookingManagement.editModal.discountAmount')} htmlFor="edit-discount-amount">
+                <Input
+                  id="edit-discount-amount"
+                  type="number"
+                  value={discountAmount}
+                  onChange={(e) => setDiscountAmount(parseFloat(e.target.value) || 0)}
+                  min={0}
+                  max={totalPrice}
+                  step={0.01}
+                  trailingSlot={<span className="pr-3 text-caption text-ink-muted">THB</span>}
+                />
+              </FormField>
+              <FormField
+                label={t('admin.booking.bookingManagement.editModal.discountReason')}
+                htmlFor="edit-discount-reason"
+                required
+              >
+                <Input
+                  id="edit-discount-reason"
+                  type="text"
+                  value={discountReason}
+                  onChange={(e) => setDiscountReason(e.target.value)}
+                  placeholder={t('admin.booking.bookingManagement.editModal.discountReasonPlaceholder')}
+                />
+              </FormField>
+              <div className="flex gap-3">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="flex-1"
+                  onClick={() => {
+                    setShowDiscountForm(false);
+                    setDiscountAmount(booking.discountAmount ?? 0);
+                    setDiscountReason(booking.discountReason ?? '');
+                  }}
+                >
+                  {t('common.cancel')}
+                </Button>
+                <Button
+                  type="button"
+                  className="flex-1 bg-success-600 hover:bg-success-700"
+                  onClick={handleApplyDiscount}
+                  disabled={!discountReason.trim()}
+                  loading={applyDiscountMutation.isPending}
+                >
+                  {t('admin.booking.bookingManagement.editModal.applyDiscountBtn')}
+                </Button>
+              </div>
+            </Card>
+          )}
+        </div>
+      )}
+
+      {/* Audit History Tab */}
+      {activeTab === 'audit' && (
+        <div className="space-y-4">
+          {booking.auditHistory && booking.auditHistory.length > 0 ? (
+            <div className="space-y-4">
+              {booking.auditHistory.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="rounded-r-lg border-l-4 border-brand-500 bg-surface-sunken py-3 pl-4"
+                >
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <p className="font-semibold text-ink">
+                        {formatAuditAction(entry.action)}
+                      </p>
+                      <p className="text-caption text-ink-muted">
+                        {entry.adminName}
+                      </p>
+                    </div>
+                    <span className="flex items-center gap-1 text-fine text-ink-muted">
+                      <FiClock className="h-3 w-3" aria-hidden="true" />
+                      {formatDateTimeToEuropean(entry.createdAt)}
+                    </span>
+                  </div>
+                  {(entry.oldValue ?? entry.newValue) && (
+                    <div className="mt-2 space-y-1 text-caption">
+                      {entry.oldValue && (
+                        <div className="flex items-center gap-2">
+                          <span className="rounded bg-error-50 px-2 py-0.5 text-fine text-error-700">
+                            {t('admin.booking.bookingManagement.editModal.auditOld')}
+                          </span>
+                          <span className="text-ink-muted">{entry.oldValue}</span>
+                        </div>
+                      )}
+                      {entry.newValue && (
+                        <div className="flex items-center gap-2">
+                          <span className="rounded bg-success-50 px-2 py-0.5 text-fine text-success-700">
+                            {t('admin.booking.bookingManagement.editModal.auditNew')}
+                          </span>
+                          <span className="text-ink-muted">{entry.newValue}</span>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                  {entry.notes && (
+                    <p className="mt-2 border-l-2 border-hairline-strong pl-2 text-caption italic text-ink-muted">
+                      &quot;{entry.notes}&quot;
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="py-12 text-center text-ink-muted">
+              <FiClock className="mx-auto mb-4 h-12 w-12 opacity-50" aria-hidden="true" />
+              <p>{t('admin.booking.bookingManagement.editModal.noAuditHistory')}</p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Cancel Tab */}
+      {activeTab === 'cancel' && (
+        <div className="space-y-6">
+          {isBookingCancelled ? (
+            /* Already Cancelled State */
+            <Card surface="sunken" className="p-6 text-center">
+              <FiAlertTriangle className="mx-auto mb-4 h-12 w-12 text-ink-faint" aria-hidden="true" />
+              <p className="text-caption text-ink-muted">{t('admin.booking.cancel.alreadyCancelled')}</p>
+            </Card>
+          ) : (
+            <>
+              {/* Warning Alert */}
+              <Card className="border-error-200 bg-error-50">
+                <div className="flex items-start gap-3">
+                  <FiAlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-error-600" aria-hidden="true" />
+                  <div>
+                    <h4 className="text-caption font-semibold text-error-700">
+                      {t('admin.booking.cancel.title')}
+                    </h4>
+                    <p className="mt-1 text-caption text-error-600">
+                      {t('admin.booking.cancel.warning')}
+                    </p>
+                  </div>
+                </div>
+              </Card>
+
+              {/* Booking Summary */}
+              <Card surface="sunken">
+                <h3 className="mb-3 flex items-center gap-2 text-caption font-semibold text-ink">
+                  <FiUser className="h-4 w-4" aria-hidden="true" />
                   {t('admin.booking.bookingManagement.editModal.userInfo')}
                 </h3>
-                <div className="grid grid-cols-2 gap-4 text-sm">
+                <div className="grid grid-cols-2 gap-4 text-caption">
                   <div>
-                    <span className="text-stone-500">{t('admin.booking.bookingManagement.editModal.name')}:</span>
-                    <span className="ml-2 text-stone-900">
+                    <span className="text-ink-muted">{t('admin.booking.bookingManagement.editModal.name')}:</span>
+                    <span className="ml-2 text-ink">
                       {booking.user.firstName && booking.user.lastName
                         ? `${booking.user.firstName} ${booking.user.lastName}`
                         : booking.user.email}
                     </span>
                   </div>
                   <div>
-                    <span className="text-stone-500">{t('admin.booking.bookingManagement.editModal.email')}:</span>
-                    <span className="ml-2 text-stone-900">{booking.user.email}</span>
-                  </div>
-                  <div>
-                    <span className="text-stone-500">{t('admin.booking.bookingManagement.editModal.membershipId')}:</span>
-                    <span className="ml-2 text-stone-900 font-mono">
-                      {booking.user.membershipId ?? '-'}
+                    <span className="text-ink-muted">{t('admin.booking.bookingManagement.editModal.checkInDate')}:</span>
+                    <span className="ml-2 text-ink">
+                      {new Date(booking.checkInDate).toLocaleDateString()}
                     </span>
                   </div>
                   <div>
-                    <span className="text-stone-500">{t('admin.booking.bookingManagement.editModal.phone')}:</span>
-                    <span className="ml-2 text-stone-900">{booking.user.phone ?? '-'}</span>
+                    <span className="text-ink-muted">{t('admin.booking.bookingManagement.editModal.checkOutDate')}:</span>
+                    <span className="ml-2 text-ink">
+                      {new Date(booking.checkOutDate).toLocaleDateString()}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-ink-muted">{t('admin.booking.bookingManagement.editModal.totalPrice')}:</span>
+                    <span className="ml-2 font-semibold text-ink">
+                      {booking.totalPrice.toLocaleString()} THB
+                    </span>
                   </div>
                 </div>
-              </div>
+              </Card>
 
-              {/* Editable Fields */}
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.bookingManagement.editModal.checkInDate')}
-                  </label>
-                  <input
-                    type="date"
-                    value={checkInDate}
-                    onChange={(e) => setCheckInDate(e.target.value)}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.bookingManagement.editModal.checkOutDate')}
-                  </label>
-                  <input
-                    type="date"
-                    value={checkOutDate}
-                    onChange={(e) => setCheckOutDate(e.target.value)}
-                    min={checkInDate}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-                  />
-                </div>
-              </div>
-
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.bookingManagement.editModal.numberOfGuests')}
-                  </label>
-                  <input
-                    type="number"
-                    value={numberOfGuests}
-                    onChange={(e) => setNumberOfGuests(parseInt(e.target.value) || 1)}
-                    min={1}
-                    max={10}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.bookingManagement.editModal.roomType')}
-                  </label>
-                  <select
-                    value={roomTypeId}
-                    onChange={(e) => setRoomTypeId(e.target.value)}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-                  >
-                    {roomTypes.map((rt) => (
-                      <option key={rt.id} value={rt.id}>
-                        {rt.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-
-              {/* Original Booking Notes (Read-only) */}
-              {booking.notes && (
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.bookingManagement.editModal.originalNotes')}
-                  </label>
-                  <div className="bg-stone-50 rounded-md p-3 text-sm text-stone-600">
-                    {booking.notes}
-                  </div>
-                </div>
-              )}
-
-              {/* Admin Notes (Editable) */}
-              <div>
-                <label className="block text-sm font-medium text-stone-700 mb-1">
-                  {t('admin.booking.bookingManagement.editModal.adminNotes')}
-                </label>
-                <textarea
-                  value={adminNotes}
-                  onChange={(e) => setAdminNotes(e.target.value)}
-                  placeholder={t('admin.booking.bookingManagement.editModal.adminNotesPlaceholder')}
+              {/* Cancellation Reason */}
+              <FormField label={t('admin.booking.cancel.reasonLabel')} htmlFor="cancel-reason">
+                <Textarea
+                  id="cancel-reason"
+                  value={cancelReason}
+                  onChange={(e) => setCancelReason(e.target.value)}
+                  placeholder={t('admin.booking.cancel.reasonPlaceholder')}
                   rows={3}
-                  className="w-full border border-stone-300 rounded-md px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                  className="focus:border-error-600 focus:ring-error-600"
                 />
-              </div>
-            </div>
-          )}
+              </FormField>
 
-          {/* Payment Tab */}
-          {activeTab === 'payment' && (
-            <div className="space-y-6">
-              {/* Current Payment Info */}
-              <div className="bg-stone-50 rounded-lg p-4">
-                <h3 className="text-sm font-medium text-stone-700 mb-3">
-                  {t('admin.booking.bookingManagement.editModal.currentPayment')}
-                </h3>
-                <div className="grid grid-cols-2 gap-4 text-sm">
-                  <div>
-                    <span className="text-stone-500">
-                      {t('admin.booking.bookingManagement.editModal.paymentType')}:
-                    </span>
-                    <span className="ml-2 text-stone-900 font-medium">
-                      {booking.paymentType === 'full'
-                        ? t('admin.booking.bookingManagement.paymentType.full')
-                        : t('admin.booking.bookingManagement.paymentType.deposit')}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-stone-500">
-                      {t('admin.booking.bookingManagement.editModal.paymentAmount')}:
-                    </span>
-                    <span className="ml-2 text-stone-900 font-medium">
-                      {booking.paymentAmount !== null
-                        ? `${booking.paymentAmount.toLocaleString()} THB`
-                        : '-'}
-                    </span>
-                  </div>
-                </div>
-              </div>
+              {/* Confirmation Checkbox */}
+              <label htmlFor="confirmCancel" className="flex items-center gap-3">
+                <input
+                  type="checkbox"
+                  id="confirmCancel"
+                  checked={confirmCancel}
+                  onChange={(e) => setConfirmCancel(e.target.checked)}
+                  className="h-4 w-4 rounded border-hairline-strong text-error-600 focus:ring-error-600"
+                />
+                <span className="text-caption text-ink">
+                  {t('admin.booking.cancel.confirmCheckbox')}
+                </span>
+              </label>
 
-              {/* Total Price (Editable) */}
-              <div>
-                <label className="block text-sm font-medium text-stone-700 mb-1">
-                  {t('admin.booking.bookingManagement.editModal.totalPrice')}
-                </label>
-                <div className="relative">
-                  <input
-                    type="number"
-                    value={totalPrice}
-                    onChange={(e) => setTotalPrice(parseFloat(e.target.value) || 0)}
-                    min={0}
-                    step={0.01}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 pr-12 focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-                  />
-                  <span className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-500">
-                    THB
-                  </span>
-                </div>
-                <p className="text-xs text-stone-500 mt-1">
-                  {t('admin.booking.bookingManagement.editModal.calculatedPayment')}:{' '}
-                  {calculatePaymentAmount(totalPrice).toLocaleString()} THB
-                </p>
-              </div>
-
-              {/* Current Discount */}
-              {booking.discountAmount && booking.discountAmount > 0 && (
-                <div className="bg-green-50 border border-green-200 rounded-lg p-4">
-                  <h4 className="text-sm font-medium text-green-800 mb-2 flex items-center gap-2">
-                    <FiPercent className="w-4 h-4" />
-                    {t('admin.booking.bookingManagement.editModal.currentDiscount')}
-                  </h4>
-                  <p className="text-lg font-semibold text-green-700">
-                    -{booking.discountAmount.toLocaleString()} THB
-                  </p>
-                  {booking.discountReason && (
-                    <p className="text-sm text-green-600 mt-1">
-                      {t('admin.booking.bookingManagement.editModal.reason')}: {booking.discountReason}
-                    </p>
-                  )}
-                </div>
-              )}
-
-              {/* Apply Discount Section */}
-              {!showDiscountForm ? (
-                <button
-                  onClick={() => setShowDiscountForm(true)}
-                  className="w-full flex items-center justify-center gap-2 px-4 py-2 border border-dashed border-stone-300 rounded-md text-stone-600 hover:border-brand-500 hover:text-brand-600"
-                >
-                  <FiPercent className="w-4 h-4" />
-                  {t('admin.booking.bookingManagement.editModal.applyDiscount')}
-                </button>
-              ) : (
-                <div className="border border-stone-200 rounded-lg p-4 space-y-4">
-                  <h4 className="text-sm font-medium text-stone-700">
-                    {t('admin.booking.bookingManagement.editModal.applyDiscount')}
-                  </h4>
-                  <div>
-                    <label className="block text-sm text-stone-600 mb-1">
-                      {t('admin.booking.bookingManagement.editModal.discountAmount')}
-                    </label>
-                    <div className="relative">
-                      <input
-                        type="number"
-                        value={discountAmount}
-                        onChange={(e) => setDiscountAmount(parseFloat(e.target.value) || 0)}
-                        min={0}
-                        max={totalPrice}
-                        step={0.01}
-                        className="w-full border border-stone-300 rounded-md px-3 py-2 pr-12 focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-                      />
-                      <span className="absolute right-3 top-1/2 -translate-y-1/2 text-stone-500">
-                        THB
-                      </span>
-                    </div>
-                  </div>
-                  <div>
-                    <label className="block text-sm text-stone-600 mb-1">
-                      {t('admin.booking.bookingManagement.editModal.discountReason')} *
-                    </label>
-                    <input
-                      type="text"
-                      value={discountReason}
-                      onChange={(e) => setDiscountReason(e.target.value)}
-                      placeholder={t('admin.booking.bookingManagement.editModal.discountReasonPlaceholder')}
-                      className="w-full border border-stone-300 rounded-md px-3 py-2 focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-                    />
-                  </div>
-                  <div className="flex gap-3">
-                    <button
-                      onClick={() => {
-                        setShowDiscountForm(false);
-                        setDiscountAmount(booking.discountAmount ?? 0);
-                        setDiscountReason(booking.discountReason ?? '');
-                      }}
-                      className="flex-1 px-4 py-2 bg-stone-100 text-stone-700 rounded-md hover:bg-stone-200"
-                    >
-                      {t('common.cancel')}
-                    </button>
-                    <button
-                      onClick={handleApplyDiscount}
-                      disabled={applyDiscountMutation.isPending || !discountReason.trim()}
-                      className="flex-1 px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50"
-                    >
-                      {applyDiscountMutation.isPending
-                        ? t('common.processing')
-                        : t('admin.booking.bookingManagement.editModal.applyDiscountBtn')}
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Audit History Tab */}
-          {activeTab === 'audit' && (
-            <div className="space-y-4">
-              {booking.auditHistory && booking.auditHistory.length > 0 ? (
-                <div className="space-y-4">
-                  {booking.auditHistory.map((entry) => (
-                    <div
-                      key={entry.id}
-                      className="border-l-4 border-brand-500 pl-4 py-3 bg-stone-50 rounded-r-lg"
-                    >
-                      <div className="flex items-start justify-between">
-                        <div>
-                          <p className="font-medium text-stone-900">
-                            {formatAuditAction(entry.action)}
-                          </p>
-                          <p className="text-sm text-stone-600">
-                            {entry.adminName}
-                          </p>
-                        </div>
-                        <span className="text-xs text-stone-500 flex items-center gap-1">
-                          <FiClock className="w-3 h-3" />
-                          {formatDateTimeToEuropean(entry.createdAt)}
-                        </span>
-                      </div>
-                      {(entry.oldValue ?? entry.newValue) && (
-                        <div className="mt-2 text-sm space-y-1">
-                          {entry.oldValue && (
-                            <div className="flex items-center gap-2">
-                              <span className="px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs">
-                                {t('admin.booking.bookingManagement.editModal.auditOld')}
-                              </span>
-                              <span className="text-stone-600">{entry.oldValue}</span>
-                            </div>
-                          )}
-                          {entry.newValue && (
-                            <div className="flex items-center gap-2">
-                              <span className="px-2 py-0.5 bg-green-100 text-green-700 rounded text-xs">
-                                {t('admin.booking.bookingManagement.editModal.auditNew')}
-                              </span>
-                              <span className="text-stone-600">{entry.newValue}</span>
-                            </div>
-                          )}
-                        </div>
-                      )}
-                      {entry.notes && (
-                        <p className="mt-2 text-sm text-stone-500 italic border-l-2 border-stone-300 pl-2">
-                          &quot;{entry.notes}&quot;
-                        </p>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-12 text-stone-500">
-                  <FiClock className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                  <p>{t('admin.booking.bookingManagement.editModal.noAuditHistory')}</p>
-                </div>
-              )}
-            </div>
-          )}
-
-          {/* Cancel Tab */}
-          {activeTab === 'cancel' && (
-            <div className="space-y-6">
-              {isBookingCancelled ? (
-                /* Already Cancelled State */
-                <div className="bg-stone-50 rounded-lg p-6 text-center">
-                  <FiAlertTriangle className="w-12 h-12 mx-auto mb-4 text-stone-400" />
-                  <p className="text-stone-600">{t('admin.booking.cancel.alreadyCancelled')}</p>
-                </div>
-              ) : (
-                <>
-                  {/* Warning Alert */}
-                  <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-                    <div className="flex items-start gap-3">
-                      <FiAlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
-                      <div>
-                        <h4 className="text-sm font-medium text-red-800">
-                          {t('admin.booking.cancel.title')}
-                        </h4>
-                        <p className="text-sm text-red-700 mt-1">
-                          {t('admin.booking.cancel.warning')}
-                        </p>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Booking Summary */}
-                  <div className="bg-stone-50 rounded-lg p-4">
-                    <h3 className="text-sm font-medium text-stone-700 mb-3 flex items-center gap-2">
-                      <FiUser className="w-4 h-4" />
-                      {t('admin.booking.bookingManagement.editModal.userInfo')}
-                    </h3>
-                    <div className="grid grid-cols-2 gap-4 text-sm">
-                      <div>
-                        <span className="text-stone-500">{t('admin.booking.bookingManagement.editModal.name')}:</span>
-                        <span className="ml-2 text-stone-900">
-                          {booking.user.firstName && booking.user.lastName
-                            ? `${booking.user.firstName} ${booking.user.lastName}`
-                            : booking.user.email}
-                        </span>
-                      </div>
-                      <div>
-                        <span className="text-stone-500">{t('admin.booking.bookingManagement.editModal.checkInDate')}:</span>
-                        <span className="ml-2 text-stone-900">
-                          {new Date(booking.checkInDate).toLocaleDateString()}
-                        </span>
-                      </div>
-                      <div>
-                        <span className="text-stone-500">{t('admin.booking.bookingManagement.editModal.checkOutDate')}:</span>
-                        <span className="ml-2 text-stone-900">
-                          {new Date(booking.checkOutDate).toLocaleDateString()}
-                        </span>
-                      </div>
-                      <div>
-                        <span className="text-stone-500">{t('admin.booking.bookingManagement.editModal.totalPrice')}:</span>
-                        <span className="ml-2 text-stone-900 font-medium">
-                          {booking.totalPrice.toLocaleString()} THB
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-
-                  {/* Cancellation Reason */}
-                  <div>
-                    <label className="block text-sm font-medium text-stone-700 mb-1">
-                      {t('admin.booking.cancel.reasonLabel')}
-                    </label>
-                    <textarea
-                      value={cancelReason}
-                      onChange={(e) => setCancelReason(e.target.value)}
-                      placeholder={t('admin.booking.cancel.reasonPlaceholder')}
-                      rows={3}
-                      className="w-full border border-stone-300 rounded-md px-3 py-2 focus:ring-2 focus:ring-red-500 focus:border-red-500"
-                    />
-                  </div>
-
-                  {/* Confirmation Checkbox */}
-                  <div className="flex items-center gap-3">
-                    <input
-                      type="checkbox"
-                      id="confirmCancel"
-                      checked={confirmCancel}
-                      onChange={(e) => setConfirmCancel(e.target.checked)}
-                      className="w-4 h-4 text-red-600 border-stone-300 rounded focus:ring-red-500"
-                    />
-                    <label htmlFor="confirmCancel" className="text-sm text-stone-700">
-                      {t('admin.booking.cancel.confirmCheckbox')}
-                    </label>
-                  </div>
-
-                  {/* Cancel Button */}
-                  <button
-                    onClick={handleCancelBooking}
-                    disabled={!cancelReason.trim() || !confirmCancel || isCancelling}
-                    className="w-full px-4 py-3 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed font-medium"
-                  >
-                    {isCancelling
-                      ? t('admin.booking.cancel.cancelling')
-                      : t('admin.booking.cancel.button')}
-                  </button>
-                </>
-              )}
-            </div>
+              {/* Cancel Button */}
+              <Button
+                type="button"
+                variant="destructive"
+                className="w-full"
+                onClick={handleCancelBooking}
+                disabled={!cancelReason.trim() || !confirmCancel}
+                loading={isCancelling}
+              >
+                {isCancelling
+                  ? t('admin.booking.cancel.cancelling')
+                  : t('admin.booking.cancel.button')}
+              </Button>
+            </>
           )}
         </div>
-
-        {/* Footer */}
-        <div className="px-6 py-4 border-t border-stone-200 flex justify-end gap-3">
-          <button
-            onClick={onClose}
-            className="px-4 py-2 text-stone-700 bg-stone-100 rounded-md hover:bg-stone-200"
-          >
-            {t('common.cancel')}
-          </button>
-          {activeTab !== 'audit' && activeTab !== 'cancel' && (
-            <button
-              onClick={handleSave}
-              disabled={isSaving}
-              className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:opacity-50"
-            >
-              {isSaving ? t('common.saving') : t('common.save')}
-            </button>
-          )}
-        </div>
-      </div>
-    </div>
+      )}
+    </Modal>
   );
 };
 

--- a/frontend/src/pages/admin/BookingManagement.tsx
+++ b/frontend/src/pages/admin/BookingManagement.tsx
@@ -1,19 +1,20 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-hot-toast';
 import {
-  FiCalendar,
   FiSearch,
   FiCheck,
   FiX,
   FiAlertTriangle,
+  FiCalendar,
   FiClock,
   FiRefreshCw,
   FiChevronUp,
   FiChevronDown
 } from 'react-icons/fi';
-import DashboardButton from '../../components/navigation/DashboardButton';
+import AppShell from '../../components/layout/AppShell';
+import { Badge, Button, EmptyState, Input, Table, TabNav } from '../../components/ui';
+import type { BadgeTone, TableColumn, TabItem } from '../../components/ui';
 import SlipViewerSidebar from '../../components/admin/SlipViewerSidebar';
 import BookingEditModal from './BookingEditModal';
 import { formatDateToDDMMYYYY, formatDateTimeToEuropean } from '../../utils/dateFormatter';
@@ -91,6 +92,31 @@ interface StatusCounts {
   cancelled: number;
   completed: number;
 }
+
+// Semantic tone lookups — kept in sync with the guest-facing booking page
+// (src/pages/MyBookingsPage.tsx) so the same status reads the same color
+// on both sides of a booking's lifecycle.
+const BOOKING_STATUS_TONE: Record<string, BadgeTone> = {
+  confirmed: 'success',
+  cancelled: 'error',
+  completed: 'brand',
+};
+
+const SLIP_OK_STATUS_TONE: Record<string, BadgeTone> = {
+  verified: 'success',
+  failed: 'error',
+  pending: 'warning',
+  quota_exceeded: 'warning',
+};
+
+const ADMIN_STATUS_TONE: Record<string, BadgeTone> = {
+  verified: 'success',
+  needs_action: 'error',
+  pending: 'warning',
+};
+
+const ROW_ACTION_BUTTON_CLASSES =
+  'flex h-11 w-11 items-center justify-center rounded-full transition disabled:cursor-not-allowed disabled:opacity-40';
 
 const BookingManagement: React.FC = () => {
   const { t } = useTranslation();
@@ -235,10 +261,6 @@ const BookingManagement: React.FC = () => {
     }
   };
 
-  const handleRowClick = (booking: Booking) => {
-    setSelectedBooking(booking);
-  };
-
   const handleVerifySlip = async (bookingId: string) => {
     await verifySlipMutation.mutateAsync({ bookingId });
   };
@@ -262,472 +284,371 @@ const BookingManagement: React.FC = () => {
   };
 
   // Status badge components
-  const SlipOkStatusBadge: React.FC<{ status: string }> = ({ status }) => {
-    const badges: Record<string, { icon: React.ReactNode; text: string; className: string }> = {
-      verified: {
-        icon: <FiCheck className="w-3 h-3" />,
-        text: t('admin.booking.bookingManagement.slipStatus.verified'),
-        className: 'bg-green-100 text-green-800'
-      },
-      failed: {
-        icon: <FiAlertTriangle className="w-3 h-3" />,
-        text: t('admin.booking.bookingManagement.slipStatus.failed'),
-        className: 'bg-red-100 text-red-800'
-      },
-      pending: {
-        icon: <FiClock className="w-3 h-3" />,
-        text: t('admin.booking.bookingManagement.slipStatus.pending'),
-        className: 'bg-yellow-100 text-yellow-800'
-      },
-      quota_exceeded: {
-        icon: <FiAlertTriangle className="w-3 h-3" />,
-        text: t('admin.booking.bookingManagement.slipStatus.quotaExceeded'),
-        className: 'bg-orange-100 text-orange-800'
-      }
+  const BookingStatusBadge: React.FC<{ status: string }> = ({ status }) => {
+    const icons: Record<string, React.ReactNode> = {
+      confirmed: <FiCheck className="h-3 w-3" aria-hidden="true" />,
+      cancelled: <FiX className="h-3 w-3" aria-hidden="true" />,
+      completed: <FiCheck className="h-3 w-3" aria-hidden="true" />,
+    };
+    const labels: Record<string, string> = {
+      confirmed: t('booking.status.confirmed'),
+      cancelled: t('booking.status.cancelled'),
+      completed: t('booking.status.completed'),
     };
 
-    const badge = badges[status] ?? badges.pending;
+    return (
+      <Badge tone={BOOKING_STATUS_TONE[status] ?? 'success'}>
+        {icons[status] ?? icons.confirmed}
+        {labels[status] ?? labels.confirmed}
+      </Badge>
+    );
+  };
+
+  const SlipOkStatusBadge: React.FC<{ status: string }> = ({ status }) => {
+    const icons: Record<string, React.ReactNode> = {
+      verified: <FiCheck className="h-3 w-3" aria-hidden="true" />,
+      failed: <FiAlertTriangle className="h-3 w-3" aria-hidden="true" />,
+      pending: <FiClock className="h-3 w-3" aria-hidden="true" />,
+      quota_exceeded: <FiAlertTriangle className="h-3 w-3" aria-hidden="true" />,
+    };
+    const labels: Record<string, string> = {
+      verified: t('admin.booking.bookingManagement.slipStatus.verified'),
+      failed: t('admin.booking.bookingManagement.slipStatus.failed'),
+      pending: t('admin.booking.bookingManagement.slipStatus.pending'),
+      quota_exceeded: t('admin.booking.bookingManagement.slipStatus.quotaExceeded'),
+    };
 
     return (
-      <span className={clsx('inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full', badge?.className)}>
-        {badge?.icon}
-        {badge?.text}
-      </span>
+      <Badge tone={SLIP_OK_STATUS_TONE[status] ?? 'warning'}>
+        {icons[status] ?? icons.pending}
+        {labels[status] ?? labels.pending}
+      </Badge>
     );
   };
 
   const AdminStatusBadge: React.FC<{ status: string }> = ({ status }) => {
-    const badges: Record<string, { icon: React.ReactNode; text: string; className: string }> = {
-      verified: {
-        icon: <FiCheck className="w-3 h-3" />,
-        text: t('admin.booking.bookingManagement.adminStatus.verified'),
-        className: 'bg-green-100 text-green-800'
-      },
-      needs_action: {
-        icon: <FiAlertTriangle className="w-3 h-3" />,
-        text: t('admin.booking.bookingManagement.adminStatus.needsAction'),
-        className: 'bg-orange-100 text-orange-800'
-      },
-      pending: {
-        icon: <FiClock className="w-3 h-3" />,
-        text: t('admin.booking.bookingManagement.adminStatus.pending'),
-        className: 'bg-yellow-100 text-yellow-800'
-      }
+    const icons: Record<string, React.ReactNode> = {
+      verified: <FiCheck className="h-3 w-3" aria-hidden="true" />,
+      needs_action: <FiAlertTriangle className="h-3 w-3" aria-hidden="true" />,
+      pending: <FiClock className="h-3 w-3" aria-hidden="true" />,
+    };
+    const labels: Record<string, string> = {
+      verified: t('admin.booking.bookingManagement.adminStatus.verified'),
+      needs_action: t('admin.booking.bookingManagement.adminStatus.needsAction'),
+      pending: t('admin.booking.bookingManagement.adminStatus.pending'),
     };
 
-    const badge = badges[status] ?? badges.pending;
-
     return (
-      <span className={clsx('inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full', badge?.className)}>
-        {badge?.icon}
-        {badge?.text}
-      </span>
-    );
-  };
-
-  const BookingStatusBadge: React.FC<{ status: string }> = ({ status }) => {
-    const badges: Record<string, { icon: React.ReactNode; text: string; className: string }> = {
-      confirmed: {
-        icon: <FiCheck className="w-3 h-3" />,
-        text: t('booking.status.confirmed'),
-        className: 'bg-green-100 text-green-800'
-      },
-      cancelled: {
-        icon: <FiX className="w-3 h-3" />,
-        text: t('booking.status.cancelled'),
-        className: 'bg-red-100 text-red-800'
-      },
-      completed: {
-        icon: <FiCheck className="w-3 h-3" />,
-        text: t('booking.status.completed'),
-        className: 'bg-brand-100 text-brand-800'
-      }
-    };
-
-    const badge = badges[status] ?? badges.confirmed;
-
-    return (
-      <span className={clsx('inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full', badge?.className)}>
-        {badge?.icon}
-        {badge?.text}
-      </span>
+      <Badge tone={ADMIN_STATUS_TONE[status] ?? 'warning'}>
+        {icons[status] ?? icons.pending}
+        {labels[status] ?? labels.pending}
+      </Badge>
     );
   };
 
   const SortIcon: React.FC<{ field: SortField }> = ({ field }) => {
     if (sortField !== field) {return null;}
     return sortDirection === 'asc' ? (
-      <FiChevronUp className="w-4 h-4" />
+      <FiChevronUp className="h-4 w-4" aria-hidden="true" />
     ) : (
-      <FiChevronDown className="w-4 h-4" />
+      <FiChevronDown className="h-4 w-4" aria-hidden="true" />
     );
   };
+
+  const SortableHeader: React.FC<{ field: SortField; label: string }> = ({ field, label }) => (
+    <button
+      type="button"
+      onClick={() => handleSort(field)}
+      className="flex items-center gap-1 hover:text-ink"
+    >
+      {label}
+      <SortIcon field={field} />
+    </button>
+  );
+
+  const guestDisplayName = (booking: Booking) =>
+    booking.user.firstName && booking.user.lastName
+      ? `${booking.user.firstName} ${booking.user.lastName}`
+      : booking.user.email;
+
+  const rowActionButtons = (booking: Booking) => (
+    <div className="flex gap-1">
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          if (booking.slip) {handleVerifySlip(booking.id);}
+        }}
+        disabled={!booking.slip || verifySlipMutation.isPending}
+        className={`${ROW_ACTION_BUTTON_CLASSES} text-success-600 hover:bg-success-50`}
+        title={t('admin.booking.bookingManagement.actions.verify')}
+      >
+        <FiCheck className="h-4 w-4" aria-hidden="true" />
+      </button>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          if (booking.slip) {
+            const notes = prompt(t('admin.booking.bookingManagement.actions.enterNotes'));
+            if (notes) {handleNeedsAction(booking.id, notes);}
+          }
+        }}
+        disabled={!booking.slip || markNeedsActionMutation.isPending}
+        className={`${ROW_ACTION_BUTTON_CLASSES} text-warning-600 hover:bg-warning-50`}
+        title={t('admin.booking.bookingManagement.actions.needsAction')}
+      >
+        <FiAlertTriangle className="h-4 w-4" aria-hidden="true" />
+      </button>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          handleEditBooking(booking);
+        }}
+        className={`${ROW_ACTION_BUTTON_CLASSES} text-brand-600 hover:bg-brand-50`}
+        title={t('admin.booking.bookingManagement.actions.edit')}
+      >
+        <FiCalendar className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+
+  const columns: TableColumn<Booking>[] = [
+    {
+      key: 'created',
+      header: <SortableHeader field="created_at" label={t('admin.booking.bookingManagement.table.created')} />,
+      cell: (booking) => formatDateTimeToEuropean(booking.createdAt),
+    },
+    {
+      key: 'user',
+      header: <SortableHeader field="user_name" label={t('admin.booking.bookingManagement.table.user')} />,
+      cell: (booking) => (
+        <div>
+          <p className="text-body font-semibold text-ink">{guestDisplayName(booking)}</p>
+          <p className="font-mono text-fine text-ink-muted">{booking.user.membershipId ?? '-'}</p>
+        </div>
+      ),
+    },
+    {
+      key: 'roomType',
+      header: <SortableHeader field="room_type" label={t('admin.booking.bookingManagement.table.roomType')} />,
+      cell: (booking) => booking.roomType.name,
+    },
+    {
+      key: 'dates',
+      header: <SortableHeader field="check_in_date" label={t('admin.booking.bookingManagement.table.dates')} />,
+      cell: (booking) => (
+        <div>
+          <div>{formatDateToDDMMYYYY(booking.checkInDate)}</div>
+          <div className="text-ink-muted">- {formatDateToDDMMYYYY(booking.checkOutDate)}</div>
+        </div>
+      ),
+    },
+    {
+      key: 'status',
+      header: <SortableHeader field="status" label={t('admin.booking.bookingManagement.table.status')} />,
+      cell: (booking) => <BookingStatusBadge status={booking.status} />,
+    },
+    {
+      key: 'payment',
+      header: <SortableHeader field="total_price" label={t('admin.booking.bookingManagement.table.payment')} />,
+      cell: (booking) => (
+        <div>
+          <p>
+            {booking.paymentType === 'full'
+              ? t('admin.booking.bookingManagement.paymentType.full')
+              : t('admin.booking.bookingManagement.paymentType.deposit')}
+          </p>
+          <p className="font-semibold text-ink">
+            {booking.paymentAmount !== null ? `${booking.paymentAmount.toLocaleString()} THB` : '-'}
+          </p>
+        </div>
+      ),
+    },
+    {
+      key: 'slipStatus',
+      header: t('admin.booking.bookingManagement.table.slipStatus'),
+      cell: (booking) =>
+        booking.slip ? (
+          <SlipOkStatusBadge status={booking.slip.slipokStatus} />
+        ) : (
+          <span className="text-fine text-ink-faint">{t('admin.booking.bookingManagement.noSlip')}</span>
+        ),
+      hideOnMobile: true,
+    },
+    {
+      key: 'adminStatus',
+      header: t('admin.booking.bookingManagement.table.adminStatus'),
+      cell: (booking) => (booking.slip ? <AdminStatusBadge status={booking.slip.adminStatus} /> : '-'),
+      hideOnMobile: true,
+    },
+    {
+      key: 'actions',
+      header: t('admin.booking.bookingManagement.table.actions'),
+      cell: rowActionButtons,
+    },
+  ];
+
+  const statusTabItems: TabItem[] = [
+    { value: '', label: t('admin.booking.bookingManagement.allStatuses'), count: statusCounts.all },
+    { value: 'confirmed', label: t('booking.status.confirmed'), count: statusCounts.confirmed },
+    { value: 'cancelled', label: t('booking.status.cancelled'), count: statusCounts.cancelled },
+    { value: 'completed', label: t('booking.status.completed'), count: statusCounts.completed },
+  ];
 
   // Loading state
   if (initialLoading) {
     return (
-      <div className="min-h-screen bg-stone-50 p-4">
-        <div className="max-w-full mx-auto">
-          <div className="animate-pulse">
-            <div className="h-8 bg-stone-300 rounded w-64 mb-6" />
-            <div className="h-12 bg-stone-300 rounded mb-6" />
-            <div className="bg-white rounded-lg shadow p-6">
-              {[1, 2, 3, 4, 5].map(i => (
-                <div key={i} className="h-16 bg-stone-200 rounded mb-4" />
-              ))}
-            </div>
+      <AppShell variant="admin" title={t('admin.booking.bookingManagement.title')}>
+        <div className="animate-pulse space-y-6">
+          <div className="h-8 w-64 rounded-lg bg-surface-sunken" />
+          <div className="h-12 rounded-lg bg-surface-sunken" />
+          <div className="space-y-4 rounded-card border border-hairline bg-surface-card p-6">
+            {[1, 2, 3, 4, 5].map(i => (
+              <div key={i} className="h-16 rounded-lg bg-surface-sunken" />
+            ))}
           </div>
         </div>
-      </div>
+      </AppShell>
     );
   }
 
   return (
-    <div className="min-h-screen bg-stone-50">
-      {/* Header */}
-      <header className="bg-white shadow">
-        <div className="max-w-full mx-auto px-4 py-6">
-          <div className="flex justify-between items-center">
-            <div className="flex items-center">
-              <FiCalendar className="h-8 w-8 text-brand-600 mr-3" />
-              <div>
-                <h1 className="text-2xl font-bold text-stone-900">
-                  {t('admin.booking.bookingManagement.title')}
-                </h1>
-                <p className="text-sm text-stone-600">
-                  {t('admin.booking.bookingManagement.subtitle')}
-                </p>
-              </div>
-            </div>
-            <div className="flex items-center space-x-4">
-              <button
-                onClick={() => bookingsQuery.refetch()}
-                disabled={bookingsQuery.isRefetching}
-                className="inline-flex items-center px-4 py-2 border border-stone-300 rounded-md text-sm font-medium text-stone-700 bg-white hover:bg-stone-50 disabled:opacity-50"
-              >
-                <FiRefreshCw className={clsx('w-4 h-4 mr-2', bookingsQuery.isRefetching && 'animate-spin')} />
-                {t('common.refresh')}
-              </button>
-              <DashboardButton variant="outline" size="md" />
-            </div>
-          </div>
-        </div>
-      </header>
+    <AppShell variant="admin" title={t('admin.booking.bookingManagement.title')}>
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <p className="text-caption text-ink-muted">{t('admin.booking.bookingManagement.subtitle')}</p>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => bookingsQuery.refetch()}
+          disabled={bookingsQuery.isRefetching}
+        >
+          <FiRefreshCw className={`h-4 w-4 ${bookingsQuery.isRefetching ? 'animate-spin' : ''}`} aria-hidden="true" />
+          {t('common.refresh')}
+        </Button>
+      </div>
 
-      {/* Main Content */}
-      <div className="max-w-full mx-auto p-4">
-        <div className="flex gap-6">
-          {/* Left: Table Section (70%) */}
-          <div className="w-[70%]">
-            {/* Status Tabs */}
-            <div className="bg-white rounded-lg shadow mb-6">
-              <div className="border-b border-stone-200">
-                <nav className="-mb-px flex">
-                  <button
-                    onClick={() => setStatusFilter('')}
-                    className={clsx(
-                      'py-4 px-6 border-b-2 font-medium text-sm',
-                      statusFilter === ''
-                        ? 'border-brand-500 text-brand-600'
-                        : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
-                    )}
-                  >
-                    {t('admin.booking.bookingManagement.allStatuses')} ({statusCounts.all})
-                  </button>
-                  <button
-                    onClick={() => setStatusFilter('confirmed')}
-                    className={clsx(
-                      'py-4 px-6 border-b-2 font-medium text-sm',
-                      statusFilter === 'confirmed'
-                        ? 'border-brand-500 text-brand-600'
-                        : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
-                    )}
-                  >
-                    {t('booking.status.confirmed')} ({statusCounts.confirmed})
-                  </button>
-                  <button
-                    onClick={() => setStatusFilter('cancelled')}
-                    className={clsx(
-                      'py-4 px-6 border-b-2 font-medium text-sm',
-                      statusFilter === 'cancelled'
-                        ? 'border-brand-500 text-brand-600'
-                        : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
-                    )}
-                  >
-                    {t('booking.status.cancelled')} ({statusCounts.cancelled})
-                  </button>
-                  <button
-                    onClick={() => setStatusFilter('completed')}
-                    className={clsx(
-                      'py-4 px-6 border-b-2 font-medium text-sm',
-                      statusFilter === 'completed'
-                        ? 'border-brand-500 text-brand-600'
-                        : 'border-transparent text-stone-500 hover:text-stone-700 hover:border-stone-300'
-                    )}
-                  >
-                    {t('booking.status.completed')} ({statusCounts.completed})
-                  </button>
-                </nav>
-              </div>
-            </div>
+      <div className="flex flex-col gap-6 lg:flex-row">
+        {/* Left: Table Section */}
+        <div className="min-w-0 lg:w-[70%]">
+          {/* Status Tabs */}
+          <TabNav
+            aria-label={t('admin.booking.bookingManagement.title')}
+            items={statusTabItems}
+            value={statusFilter}
+            onChange={(value) => setStatusFilter(value as typeof statusFilter)}
+            className="mb-6"
+          />
 
-            {/* Search Bar */}
-            <div className="bg-white p-6 rounded-lg shadow mb-6">
-              <form onSubmit={handleSearch}>
-                <div className="relative">
-                  <FiSearch className="absolute left-3 top-1/2 transform -translate-y-1/2 text-stone-400" />
-                  <input
-                    type="text"
-                    placeholder={t('admin.booking.bookingManagement.searchPlaceholder')}
-                    value={searchTerm}
-                    onChange={(e) => setSearchTerm(e.target.value)}
-                    className="w-full pl-10 pr-10 py-2 border border-stone-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-                  />
-                  {isSearching && (
-                    <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
-                      <div className="animate-spin h-4 w-4 border-2 border-brand-500 border-t-transparent rounded-full" />
-                    </div>
-                  )}
-                </div>
-              </form>
-              <p className="text-xs text-stone-500 mt-2">
-                {t('admin.booking.bookingManagement.searchHint')}
-              </p>
-            </div>
+          {/* Search Bar */}
+          <form onSubmit={handleSearch} className="mb-6">
+            <Input
+              type="text"
+              placeholder={t('admin.booking.bookingManagement.searchPlaceholder')}
+              value={searchTerm}
+              onChange={(e) => setSearchTerm(e.target.value)}
+              leadingIcon={<FiSearch aria-hidden="true" />}
+              trailingSlot={
+                isSearching ? (
+                  <span className="pr-3">
+                    <span className="block h-4 w-4 animate-spin rounded-full border-2 border-brand-600 border-t-transparent" />
+                  </span>
+                ) : undefined
+              }
+            />
+            <p className="mt-2 text-fine text-ink-muted">
+              {t('admin.booking.bookingManagement.searchHint')}
+            </p>
+          </form>
 
-            {/* Bookings Table */}
-            <div className="bg-white rounded-lg shadow overflow-hidden relative">
-              {isSearching && (
-                <div className="absolute inset-0 bg-white/50 z-10 flex items-center justify-center">
-                  <div className="animate-spin h-8 w-8 border-4 border-brand-500 border-t-transparent rounded-full" />
-                </div>
-              )}
-              <div className="overflow-x-auto">
-                <table className="min-w-full divide-y divide-stone-200">
-                  <thead className="bg-stone-50">
-                    <tr>
-                      <th
-                        onClick={() => handleSort('created_at')}
-                        className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider cursor-pointer hover:bg-stone-100"
-                      >
-                        <div className="flex items-center gap-1">
-                          {t('admin.booking.bookingManagement.table.created')}
-                          <SortIcon field="created_at" />
-                        </div>
-                      </th>
-                      <th
-                        onClick={() => handleSort('user_name')}
-                        className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider cursor-pointer hover:bg-stone-100"
-                      >
-                        <div className="flex items-center gap-1">
-                          {t('admin.booking.bookingManagement.table.user')}
-                          <SortIcon field="user_name" />
-                        </div>
-                      </th>
-                      <th
-                        onClick={() => handleSort('room_type')}
-                        className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider cursor-pointer hover:bg-stone-100"
-                      >
-                        <div className="flex items-center gap-1">
-                          {t('admin.booking.bookingManagement.table.roomType')}
-                          <SortIcon field="room_type" />
-                        </div>
-                      </th>
-                      <th
-                        onClick={() => handleSort('check_in_date')}
-                        className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider cursor-pointer hover:bg-stone-100"
-                      >
-                        <div className="flex items-center gap-1">
-                          {t('admin.booking.bookingManagement.table.dates')}
-                          <SortIcon field="check_in_date" />
-                        </div>
-                      </th>
-                      <th
-                        onClick={() => handleSort('status')}
-                        className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider cursor-pointer hover:bg-stone-100"
-                      >
-                        <div className="flex items-center gap-1">
-                          {t('admin.booking.bookingManagement.table.status')}
-                          <SortIcon field="status" />
-                        </div>
-                      </th>
-                      <th
-                        onClick={() => handleSort('total_price')}
-                        className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider cursor-pointer hover:bg-stone-100"
-                      >
-                        <div className="flex items-center gap-1">
-                          {t('admin.booking.bookingManagement.table.payment')}
-                          <SortIcon field="total_price" />
-                        </div>
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                        {t('admin.booking.bookingManagement.table.slipStatus')}
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                        {t('admin.booking.bookingManagement.table.adminStatus')}
-                      </th>
-                      <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                        {t('admin.booking.bookingManagement.table.actions')}
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody className="bg-white divide-y divide-stone-200">
-                    {bookings.length === 0 ? (
-                      <tr>
-                        <td colSpan={9} className="px-4 py-8 text-center text-stone-500">
-                          {t('admin.booking.bookingManagement.noBookings')}
-                        </td>
-                      </tr>
-                    ) : (
-                      bookings.map((booking) => (
-                        <tr
-                          key={booking.id}
-                          onClick={() => handleRowClick(booking)}
-                          onDoubleClick={() => handleEditBooking(booking)}
-                          className={clsx(
-                            'hover:bg-stone-50 cursor-pointer',
-                            selectedBooking?.id === booking.id && 'bg-brand-50'
-                          )}
-                        >
-                          <td className="px-4 py-4 whitespace-nowrap text-sm text-stone-900">
-                            {formatDateTimeToEuropean(booking.createdAt)}
-                          </td>
-                          <td className="px-4 py-4 whitespace-nowrap">
-                            <div className="text-sm font-medium text-stone-900">
-                              {booking.user.firstName && booking.user.lastName
-                                ? `${booking.user.firstName} ${booking.user.lastName}`
-                                : booking.user.email}
-                            </div>
-                            <div className="text-xs text-stone-500 font-mono">
-                              {booking.user.membershipId ?? '-'}
-                            </div>
-                          </td>
-                          <td className="px-4 py-4 whitespace-nowrap text-sm text-stone-900">
-                            {booking.roomType.name}
-                          </td>
-                          <td className="px-4 py-4 whitespace-nowrap text-sm text-stone-900">
-                            <div>{formatDateToDDMMYYYY(booking.checkInDate)}</div>
-                            <div className="text-stone-500">
-                              - {formatDateToDDMMYYYY(booking.checkOutDate)}
-                            </div>
-                          </td>
-                          <td className="px-4 py-4 whitespace-nowrap">
-                            <BookingStatusBadge status={booking.status} />
-                          </td>
-                          <td className="px-4 py-4 whitespace-nowrap">
-                            <div className="text-sm text-stone-900">
-                              {booking.paymentType === 'full'
-                                ? t('admin.booking.bookingManagement.paymentType.full')
-                                : t('admin.booking.bookingManagement.paymentType.deposit')}
-                            </div>
-                            <div className="text-sm font-medium text-stone-900">
-                              {booking.paymentAmount !== null
-                                ? `${booking.paymentAmount.toLocaleString()} THB`
-                                : '-'}
-                            </div>
-                          </td>
-                          <td className="px-4 py-4 whitespace-nowrap">
-                            {booking.slip ? (
-                              <SlipOkStatusBadge status={booking.slip.slipokStatus} />
-                            ) : (
-                              <span className="text-xs text-stone-400">
-                                {t('admin.booking.bookingManagement.noSlip')}
-                              </span>
-                            )}
-                          </td>
-                          <td className="px-4 py-4 whitespace-nowrap">
-                            {booking.slip ? (
-                              <AdminStatusBadge status={booking.slip.adminStatus} />
-                            ) : (
-                              <span className="text-xs text-stone-400">-</span>
-                            )}
-                          </td>
-                          <td className="px-4 py-4 whitespace-nowrap text-sm">
-                            <div className="flex space-x-2">
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  if (booking.slip) {handleVerifySlip(booking.id);}
-                                }}
-                                disabled={!booking.slip || verifySlipMutation.isPending}
-                                className="p-1 text-green-600 hover:text-green-900 disabled:opacity-50 disabled:cursor-not-allowed"
-                                title={t('admin.booking.bookingManagement.actions.verify')}
-                              >
-                                <FiCheck className="w-4 h-4" />
-                              </button>
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  if (booking.slip) {
-                                    const notes = prompt(t('admin.booking.bookingManagement.actions.enterNotes'));
-                                    if (notes) {handleNeedsAction(booking.id, notes);}
-                                  }
-                                }}
-                                disabled={!booking.slip || markNeedsActionMutation.isPending}
-                                className="p-1 text-orange-600 hover:text-orange-900 disabled:opacity-50 disabled:cursor-not-allowed"
-                                title={t('admin.booking.bookingManagement.actions.needsAction')}
-                              >
-                                <FiAlertTriangle className="w-4 h-4" />
-                              </button>
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  handleEditBooking(booking);
-                                }}
-                                className="p-1 text-brand-600 hover:text-brand-900"
-                                title={t('admin.booking.bookingManagement.actions.edit')}
-                              >
-                                <FiCalendar className="w-4 h-4" />
-                              </button>
-                            </div>
-                          </td>
-                        </tr>
-                      ))
-                    )}
-                  </tbody>
-                </table>
-              </div>
-            </div>
-
-            {/* Pagination */}
-            {totalPages > 1 && (
-              <div className="flex justify-between items-center mt-6">
-                <div className="text-sm text-stone-700">
-                  {t('admin.booking.bookingManagement.pagination', {
-                    current: currentPage,
-                    total: totalPages
-                  })}
-                </div>
-                <div className="flex space-x-2">
-                  <button
-                    onClick={() => setCurrentPage(currentPage - 1)}
-                    disabled={currentPage === 1}
-                    className="px-3 py-2 border border-stone-300 rounded-md text-sm font-medium text-stone-700 bg-white hover:bg-stone-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {t('common.previous')}
-                  </button>
-                  <button
-                    onClick={() => setCurrentPage(currentPage + 1)}
-                    disabled={currentPage === totalPages}
-                    className="px-3 py-2 border border-stone-300 rounded-md text-sm font-medium text-stone-700 bg-white hover:bg-stone-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                  >
-                    {t('common.next')}
-                  </button>
-                </div>
+          {/* Bookings Table */}
+          <div className="relative">
+            {isSearching && (
+              <div className="absolute inset-0 z-10 flex items-center justify-center rounded-card bg-surface-card/60 backdrop-blur-sm">
+                <span className="block h-8 w-8 animate-spin rounded-full border-4 border-brand-600 border-t-transparent" />
               </div>
             )}
-          </div>
-
-          {/* Right: Slip Viewer Sidebar (30%) */}
-          <div className="w-[30%]">
-            <SlipViewerSidebar
-              booking={selectedBooking}
-              onVerify={handleVerifySlip}
-              onNeedsAction={handleNeedsAction}
-              onEdit={handleEditBooking}
-              onRefresh={() => bookingsQuery.refetch()}
+            <Table<Booking>
+              aria-label={t('admin.booking.bookingManagement.title')}
+              columns={columns}
+              rows={bookings}
+              rowKey={(booking) => booking.id}
+              onRowClick={handleEditBooking}
+              empty={<EmptyState title={t('admin.booking.bookingManagement.noBookings')} />}
+              mobileCard={(booking) => (
+                <div className="space-y-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-body font-semibold text-ink">{guestDisplayName(booking)}</p>
+                      <p className="text-caption text-ink-muted">
+                        {formatDateToDDMMYYYY(booking.checkInDate)} - {formatDateToDDMMYYYY(booking.checkOutDate)}
+                      </p>
+                    </div>
+                    <BookingStatusBadge status={booking.status} />
+                  </div>
+                  <div className="flex items-center justify-between text-caption text-ink-muted">
+                    <span>{booking.roomType.name}</span>
+                    <span>{formatDateTimeToEuropean(booking.createdAt)}</span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {booking.slip ? (
+                      <>
+                        <SlipOkStatusBadge status={booking.slip.slipokStatus} />
+                        <AdminStatusBadge status={booking.slip.adminStatus} />
+                      </>
+                    ) : (
+                      <span className="text-fine text-ink-faint">{t('admin.booking.bookingManagement.noSlip')}</span>
+                    )}
+                    <span className="ml-auto text-caption font-semibold text-ink">
+                      {booking.paymentAmount !== null ? `${booking.paymentAmount.toLocaleString()} THB` : '-'}
+                    </span>
+                  </div>
+                  <div className="flex justify-end gap-1 pt-1">{rowActionButtons(booking)}</div>
+                </div>
+              )}
             />
           </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="mt-6 flex items-center justify-between">
+              <div className="text-caption text-ink-muted">
+                {t('admin.booking.bookingManagement.pagination', {
+                  current: currentPage,
+                  total: totalPages
+                })}
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setCurrentPage(currentPage - 1)}
+                  disabled={currentPage === 1}
+                >
+                  {t('common.previous')}
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => setCurrentPage(currentPage + 1)}
+                  disabled={currentPage === totalPages}
+                >
+                  {t('common.next')}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Right: Slip Viewer Sidebar */}
+        <div className="min-w-0 lg:w-[30%]">
+          <SlipViewerSidebar
+            booking={selectedBooking}
+            onVerify={handleVerifySlip}
+            onNeedsAction={handleNeedsAction}
+            onEdit={handleEditBooking}
+            onRefresh={() => bookingsQuery.refetch()}
+          />
         </div>
       </div>
 
@@ -740,7 +661,7 @@ const BookingManagement: React.FC = () => {
           onSave={handleEditSave}
         />
       )}
-    </div>
+    </AppShell>
   );
 };
 

--- a/frontend/src/pages/admin/RoomAvailability.tsx
+++ b/frontend/src/pages/admin/RoomAvailability.tsx
@@ -2,7 +2,8 @@ import React, { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import DashboardButton from '../../components/navigation/DashboardButton';
+import AppShell from '../../components/layout/AppShell';
+import { Button, Card, FormField, Input, Modal, Select } from '../../components/ui';
 
 // Types
 interface RoomType {
@@ -345,10 +346,10 @@ const RoomAvailability: React.FC = () => {
     today.setHours(0, 0, 0, 0);
     const isPast = date < today;
 
-    let baseClasses = 'w-8 h-8 text-xs flex items-center justify-center cursor-pointer transition-all border';
+    let baseClasses = 'h-11 w-11 min-h-11 min-w-11 text-fine flex items-center justify-center cursor-pointer transition-all border';
 
     if (isSelected) {
-      baseClasses += ' ring-2 ring-brand-500 ring-offset-1';
+      baseClasses += ' ring-2 ring-brand-600 ring-offset-1';
     }
 
     if (isPast) {
@@ -359,51 +360,36 @@ const RoomAvailability: React.FC = () => {
       case 'booked':
         return `${baseClasses} bg-brand-500 text-white border-brand-600 cursor-not-allowed`;
       case 'blocked':
-        return `${baseClasses} bg-red-500 text-white border-red-600`;
+        return `${baseClasses} bg-error-600 text-white border-error-700`;
       default:
-        return `${baseClasses} bg-green-100 text-green-800 border-green-300 hover:bg-green-200`;
+        return `${baseClasses} bg-success-50 text-success-700 border-hairline hover:border-success-600`;
     }
   }, [getCellStatus, getCellKey, selectedCells]);
 
   const isLoading = blockedLoading || bookingsLoading;
 
   return (
-    <div className="min-h-screen bg-stone-50" onMouseUp={handleMouseUp}>
-      {/* Header */}
-      <div className="bg-white shadow-sm">
-        <div className="max-w-7xl mx-auto p-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-bold text-stone-900">
-                {t('admin.booking.availability.title')}
-              </h1>
-              <p className="text-stone-600 mt-1">
-                {t('admin.booking.availability.subtitle')}
-              </p>
-            </div>
-            <DashboardButton variant="outline" size="md" />
-          </div>
-        </div>
-      </div>
+    <div onMouseUp={handleMouseUp}>
+      <AppShell variant="admin" title={t('admin.booking.availability.title')}>
+        <p className="mb-6 text-caption text-ink-muted">{t('admin.booking.availability.subtitle')}</p>
 
-      {/* Content */}
-      <div className="max-w-7xl mx-auto p-4">
         {/* Controls */}
-        <div className="bg-white rounded-lg shadow p-4 mb-6">
+        <Card className="mb-6">
           <div className="flex flex-wrap items-center gap-4">
             {/* Room Type Selector */}
-            <div className="flex items-center space-x-2">
-              <label className="text-sm font-medium text-stone-700">
-                {t('admin.booking.availability.selectRoomType')}:
+            <div className="flex items-center gap-2">
+              <label htmlFor="availability-room-type" className="text-caption font-semibold text-ink">
+                {t('admin.booking.availability.selectRoomType')}
               </label>
-              <select
+              <Select
+                id="availability-room-type"
                 value={selectedRoomTypeId}
                 onChange={(e) => {
                   setSelectedRoomTypeId(e.target.value);
                   setSelectedCells(new Set());
                   setSelectedRoomId(null);
                 }}
-                className="border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
+                className="w-auto min-w-[180px]"
               >
                 <option value="all">{t('admin.booking.availability.allRoomTypes')}</option>
                 {roomTypes?.map((rt: RoomType) => (
@@ -411,132 +397,120 @@ const RoomAvailability: React.FC = () => {
                     {rt.name}
                   </option>
                 ))}
-              </select>
+              </Select>
             </div>
 
             {/* Month Navigation */}
             {selectedRoomTypeId && (
-              <div className="flex items-center space-x-2">
-                <button
-                  onClick={handlePrevMonth}
-                  className="px-3 py-2 bg-stone-100 text-stone-700 rounded-md hover:bg-stone-200"
-                >
+              <div className="flex items-center gap-2">
+                <Button type="button" variant="secondary" size="sm" onClick={handlePrevMonth}>
                   {t('common.previous')}
-                </button>
-                <span className="text-lg font-medium min-w-[160px] text-center">
+                </Button>
+                <span className="min-w-[160px] text-center text-body font-semibold text-ink">
                   {formatMonthYear(currentMonth)}
                 </span>
-                <button
-                  onClick={handleNextMonth}
-                  className="px-3 py-2 bg-stone-100 text-stone-700 rounded-md hover:bg-stone-200"
-                >
+                <Button type="button" variant="secondary" size="sm" onClick={handleNextMonth}>
                   {t('common.next')}
-                </button>
+                </Button>
               </div>
             )}
 
             {/* Selection Actions */}
             {selectedCells.size > 0 && selectedRoomId && (
-              <div className="flex items-center space-x-2 ml-auto">
-                <span className="text-sm text-stone-600">
+              <div className="ml-auto flex items-center gap-2">
+                <span className="text-caption text-ink-muted">
                   {t('admin.booking.availability.selectedDates', { count: selectedCells.size })}
                 </span>
-                <button
-                  onClick={handleBlockSelected}
-                  className="px-3 py-2 bg-red-600 text-white text-sm rounded-md hover:bg-red-700"
-                >
+                <Button type="button" variant="destructive" size="sm" onClick={handleBlockSelected}>
                   {t('admin.booking.availability.blockSelected')}
-                </button>
-                <button
-                  onClick={handleClearSelection}
-                  className="px-3 py-2 bg-stone-100 text-stone-700 text-sm rounded-md hover:bg-stone-200"
-                >
+                </Button>
+                <Button type="button" variant="secondary" size="sm" onClick={handleClearSelection}>
                   {t('admin.booking.availability.clearSelection')}
-                </button>
+                </Button>
               </div>
             )}
           </div>
-        </div>
+        </Card>
 
         {/* Legend */}
         {selectedRoomTypeId && (
-          <div className="bg-white rounded-lg shadow p-4 mb-6">
+          <Card className="mb-6">
             <div className="flex flex-wrap items-center gap-6">
-              <div className="flex items-center space-x-2">
-                <div className="w-6 h-6 bg-green-100 border border-green-300 rounded" />
-                <span className="text-sm text-stone-700">{t('admin.booking.availability.available')}</span>
+              <div className="flex items-center gap-2">
+                <div className="h-6 w-6 rounded border border-hairline bg-success-50" />
+                <span className="text-caption text-ink">{t('admin.booking.availability.available')}</span>
               </div>
-              <div className="flex items-center space-x-2">
-                <div className="w-6 h-6 bg-red-500 border border-red-600 rounded" />
-                <span className="text-sm text-stone-700">{t('admin.booking.availability.blocked')}</span>
+              <div className="flex items-center gap-2">
+                <div className="h-6 w-6 rounded border border-error-700 bg-error-600" />
+                <span className="text-caption text-ink">{t('admin.booking.availability.blocked')}</span>
               </div>
-              <div className="flex items-center space-x-2">
-                <div className="w-6 h-6 bg-brand-500 border border-brand-600 rounded" />
-                <span className="text-sm text-stone-700">{t('admin.booking.availability.booked')}</span>
+              <div className="flex items-center gap-2">
+                <div className="h-6 w-6 rounded border border-brand-600 bg-brand-500" />
+                <span className="text-caption text-ink">{t('admin.booking.availability.booked')}</span>
               </div>
-              <div className="text-sm text-stone-500 ml-auto">
+              <div className="ml-auto text-caption text-ink-muted">
                 {t('admin.booking.availability.dragHint')}
               </div>
             </div>
-          </div>
+          </Card>
         )}
 
         {/* Loading */}
         {isLoading && (
-          <div className="bg-white rounded-lg shadow p-6">
+          <Card>
             <div className="animate-pulse space-y-4">
-              <div className="h-6 bg-stone-200 rounded w-1/4" />
+              <div className="h-6 w-1/4 rounded-lg bg-surface-sunken" />
               <div className="space-y-3">
                 {[...Array(5)].map((_, i) => (
-                  <div key={i} className="h-12 bg-stone-200 rounded" />
+                  <div key={i} className="h-12 rounded-lg bg-surface-sunken" />
                 ))}
               </div>
             </div>
-          </div>
+          </Card>
         )}
 
         {/* Calendar Grid */}
         {!isLoading && rooms && (
-          <div className="bg-white rounded-lg shadow overflow-hidden">
+          <Card padding="none" className="overflow-hidden">
             <div className="overflow-x-auto">
               <table className="min-w-full">
-                <thead className="bg-stone-50">
+                <thead className="bg-surface-sunken">
                   <tr>
-                    <th className="px-4 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider sticky left-0 bg-stone-50 z-10 min-w-[120px]">
+                    <th className="sticky left-0 z-10 min-w-[120px] bg-surface-sunken px-4 py-3 text-left text-fine font-semibold uppercase tracking-wider text-ink-muted">
                       {t('admin.booking.availability.room')}
                     </th>
                     {daysInMonth.map((date) => (
                       <th
                         key={date.toISOString()}
-                        className="px-1 py-3 text-center text-xs font-medium text-stone-500"
+                        className="px-1 py-3 text-center text-fine font-semibold text-ink-muted"
                       >
                         <div>{date.getDate()}</div>
-                        <div className="text-[10px] text-stone-400">
+                        <div className="text-fine text-ink-faint">
                           {date.toLocaleDateString('en-US', { weekday: 'short' })}
                         </div>
                       </th>
                     ))}
                   </tr>
                 </thead>
-                <tbody className="bg-white divide-y divide-stone-200">
+                <tbody className="divide-y divide-hairline bg-surface-card">
                   {rooms.length === 0 ? (
                     <tr>
                       <td colSpan={daysInMonth.length + 1} className="px-6 py-12 text-center">
-                        <div className="text-stone-500">
-                          <p className="text-lg font-medium">{t('admin.booking.availability.noRooms')}</p>
-                          <p className="text-sm mt-1">{t('admin.booking.availability.noRoomsDescription')}</p>
+                        <div className="text-ink-muted">
+                          <p className="text-body font-semibold">{t('admin.booking.availability.noRooms')}</p>
+                          <p className="mt-1 text-caption">{t('admin.booking.availability.noRoomsDescription')}</p>
                         </div>
                       </td>
                     </tr>
                   ) : (
                     rooms.map((room: Room) => (
-                      <tr key={room.id} className="hover:bg-stone-50">
-                        <td className="px-4 py-2 whitespace-nowrap sticky left-0 bg-white z-10">
-                          <div className="text-sm font-medium text-stone-900">
+                      <tr key={room.id} className="hover:bg-surface-sunken">
+                        <td className="sticky left-0 z-10 whitespace-nowrap bg-surface-card px-4 py-2">
+                          <div className="text-caption font-semibold text-ink">
                             {room.roomNumber}
                           </div>
                           {room.floor && (
-                            <div className="text-xs text-stone-500">
+                            <div className="text-fine text-ink-muted">
                               {t('admin.booking.availability.floor')} {room.floor}
                             </div>
                           )}
@@ -563,122 +537,103 @@ const RoomAvailability: React.FC = () => {
                 </tbody>
               </table>
             </div>
-          </div>
+          </Card>
         )}
-      </div>
 
-      {/* Block Modal */}
-      {showBlockModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-md w-full">
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-semibold">{t('admin.booking.availability.blockDates')}</h2>
-                <button
-                  onClick={() => {
-                    setShowBlockModal(false);
-                    setBlockReason('');
-                  }}
-                  className="text-stone-400 hover:text-stone-600"
-                >
-                  X
-                </button>
-              </div>
-
-              <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-md">
-                <p className="text-sm text-yellow-800">
-                  {t('admin.booking.availability.blockingInfo', { count: selectedCells.size })}
-                </p>
-              </div>
-
-              <div className="mb-4">
-                <label className="block text-sm font-medium text-stone-700 mb-1">
-                  {t('admin.booking.availability.blockReason')} *
-                </label>
-                <input
-                  type="text"
-                  required
-                  value={blockReason}
-                  onChange={(e) => setBlockReason(e.target.value)}
-                  placeholder={t('admin.booking.availability.blockReasonPlaceholder')}
-                  className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
-                />
-              </div>
-
-              <div className="flex justify-end space-x-3">
-                <button
-                  onClick={() => {
-                    setShowBlockModal(false);
-                    setBlockReason('');
-                  }}
-                  className="px-4 py-2 text-stone-700 bg-stone-100 rounded-md hover:bg-stone-200"
-                >
-                  {t('common.cancel')}
-                </button>
-                <button
-                  onClick={confirmBlock}
-                  disabled={blockMutation.isPending || !blockReason.trim()}
-                  className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50"
-                >
-                  {blockMutation.isPending ? t('common.processing') : t('admin.booking.availability.confirmBlock')}
-                </button>
-              </div>
+        {/* Block Modal */}
+        <Modal
+          open={showBlockModal}
+          onClose={() => {
+            setShowBlockModal(false);
+            setBlockReason('');
+          }}
+          title={t('admin.booking.availability.blockDates')}
+          size="sm"
+          footer={
+            <div className="flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => {
+                  setShowBlockModal(false);
+                  setBlockReason('');
+                }}
+              >
+                {t('common.cancel')}
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={confirmBlock}
+                disabled={!blockReason.trim()}
+                loading={blockMutation.isPending}
+              >
+                {blockMutation.isPending ? t('common.processing') : t('admin.booking.availability.confirmBlock')}
+              </Button>
             </div>
-          </div>
-        </div>
-      )}
+          }
+        >
+          <Card className="mb-4 border-warning-200 bg-warning-50">
+            <p className="text-caption text-warning-700">
+              {t('admin.booking.availability.blockingInfo', { count: selectedCells.size })}
+            </p>
+          </Card>
 
-      {/* View Blocked Reason Modal */}
-      {showReasonModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-md w-full">
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-semibold">{t('admin.booking.availability.blockedDate')}</h2>
-                <button
-                  onClick={() => {
-                    setShowReasonModal(false);
-                    setViewedBlockReason('');
-                    setSelectedCells(new Set());
-                    setSelectedRoomId(null);
-                  }}
-                  className="text-stone-400 hover:text-stone-600"
-                >
-                  X
-                </button>
-              </div>
+          <FormField label={t('admin.booking.availability.blockReason')} htmlFor="block-reason" required>
+            <Input
+              id="block-reason"
+              type="text"
+              required
+              value={blockReason}
+              onChange={(e) => setBlockReason(e.target.value)}
+              placeholder={t('admin.booking.availability.blockReasonPlaceholder')}
+            />
+          </FormField>
+        </Modal>
 
-              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
-                <p className="text-sm font-medium text-red-800 mb-1">
-                  {t('admin.booking.availability.blockReason')}:
-                </p>
-                <p className="text-sm text-red-700">{viewedBlockReason || '-'}</p>
-              </div>
-
-              <div className="flex justify-end space-x-3">
-                <button
-                  onClick={() => {
-                    setShowReasonModal(false);
-                    setViewedBlockReason('');
-                    setSelectedCells(new Set());
-                    setSelectedRoomId(null);
-                  }}
-                  className="px-4 py-2 text-stone-700 bg-stone-100 rounded-md hover:bg-stone-200"
-                >
-                  {t('common.close')}
-                </button>
-                <button
-                  onClick={handleUnblockSelected}
-                  disabled={unblockMutation.isPending}
-                  className="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50"
-                >
-                  {unblockMutation.isPending ? t('common.processing') : t('admin.booking.availability.unblock')}
-                </button>
-              </div>
+        {/* View Blocked Reason Modal */}
+        <Modal
+          open={showReasonModal}
+          onClose={() => {
+            setShowReasonModal(false);
+            setViewedBlockReason('');
+            setSelectedCells(new Set());
+            setSelectedRoomId(null);
+          }}
+          title={t('admin.booking.availability.blockedDate')}
+          size="sm"
+          footer={
+            <div className="flex justify-end gap-3">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => {
+                  setShowReasonModal(false);
+                  setViewedBlockReason('');
+                  setSelectedCells(new Set());
+                  setSelectedRoomId(null);
+                }}
+              >
+                {t('common.close')}
+              </Button>
+              <Button
+                type="button"
+                onClick={handleUnblockSelected}
+                loading={unblockMutation.isPending}
+              >
+                {unblockMutation.isPending ? t('common.processing') : t('admin.booking.availability.unblock')}
+              </Button>
             </div>
-          </div>
-        </div>
-      )}
+          }
+        >
+          <Card className="border-error-200 bg-error-50">
+            <p className="mb-1 text-caption font-semibold text-error-700">
+              {t('admin.booking.availability.blockReason')}:
+            </p>
+            <p className="text-caption text-error-600">{viewedBlockReason || '-'}</p>
+          </Card>
+        </Modal>
+      </AppShell>
     </div>
   );
 };

--- a/frontend/src/pages/admin/RoomManagement.tsx
+++ b/frontend/src/pages/admin/RoomManagement.tsx
@@ -2,7 +2,9 @@ import React, { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import DashboardButton from '../../components/navigation/DashboardButton';
+import AppShell from '../../components/layout/AppShell';
+import { Badge, Button, Card, EmptyState, FormField, Input, Modal, Select, Table, Textarea } from '../../components/ui';
+import type { TableColumn } from '../../components/ui';
 
 // Types based on backend schema
 interface Room {
@@ -40,6 +42,90 @@ const initialFormData: RoomFormData = {
   floor: '',
   notes: '',
   isActive: true,
+};
+
+const CHECKBOX_CLASSES = 'h-4 w-4 rounded border-hairline-strong text-brand-600 focus:ring-brand-600';
+
+interface RoomFormFieldsProps {
+  formId: string;
+  formData: RoomFormData;
+  setFormData: React.Dispatch<React.SetStateAction<RoomFormData>>;
+  onSubmit: (e: React.FormEvent) => void;
+  roomTypes: RoomType[] | undefined;
+  activeToggleId: string;
+}
+
+const RoomFormFields: React.FC<RoomFormFieldsProps> = ({
+  formId,
+  formData,
+  setFormData,
+  onSubmit,
+  roomTypes,
+  activeToggleId,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <form id={formId} onSubmit={onSubmit} className="space-y-4">
+      <FormField label={t('admin.booking.rooms.roomType')} htmlFor={`${formId}-roomType`} required>
+        <Select
+          id={`${formId}-roomType`}
+          required
+          value={formData.roomTypeId}
+          onChange={(e) => setFormData({ ...formData, roomTypeId: e.target.value })}
+        >
+          <option value="">{t('admin.booking.rooms.selectRoomType')}</option>
+          {roomTypes?.map((rt) => (
+            <option key={rt.id} value={rt.id}>
+              {rt.name}
+            </option>
+          ))}
+        </Select>
+      </FormField>
+
+      <FormField label={t('admin.booking.rooms.roomNumber')} htmlFor={`${formId}-roomNumber`} required>
+        <Input
+          id={`${formId}-roomNumber`}
+          type="text"
+          required
+          value={formData.roomNumber}
+          onChange={(e) => setFormData({ ...formData, roomNumber: e.target.value })}
+          placeholder={t('admin.booking.rooms.roomNumberPlaceholder')}
+        />
+      </FormField>
+
+      <FormField label={t('admin.booking.rooms.floor')} htmlFor={`${formId}-floor`}>
+        <Input
+          id={`${formId}-floor`}
+          type="number"
+          value={formData.floor}
+          onChange={(e) => setFormData({ ...formData, floor: e.target.value })}
+          placeholder={t('admin.booking.rooms.floorPlaceholder')}
+        />
+      </FormField>
+
+      <FormField label={t('admin.booking.rooms.notes')} htmlFor={`${formId}-notes`}>
+        <Textarea
+          id={`${formId}-notes`}
+          value={formData.notes}
+          onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+          rows={3}
+          placeholder={t('admin.booking.rooms.notesPlaceholder')}
+        />
+      </FormField>
+
+      <label htmlFor={activeToggleId} className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id={activeToggleId}
+          checked={formData.isActive}
+          onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
+          className={CHECKBOX_CLASSES}
+        />
+        <span className="text-caption text-ink">{t('admin.booking.rooms.isActive')}</span>
+      </label>
+    </form>
+  );
 };
 
 const RoomManagement: React.FC = () => {
@@ -145,6 +231,11 @@ const RoomManagement: React.FC = () => {
     setShowCreateModal(true);
   }, [resetForm, roomTypes]);
 
+  const handleCancelCreate = useCallback(() => {
+    setShowCreateModal(false);
+    resetForm();
+  }, [resetForm]);
+
   const handleOpenEdit = useCallback((room: Room) => {
     setSelectedRoom(room);
     setFormData({
@@ -157,10 +248,22 @@ const RoomManagement: React.FC = () => {
     setShowEditModal(true);
   }, []);
 
+  const handleCancelEdit = useCallback(() => {
+    setShowEditModal(false);
+    setSelectedRoom(null);
+    resetForm();
+  }, [resetForm]);
+
   const handleOpenDelete = useCallback((room: Room) => {
     setSelectedRoom(room);
     setDeleteConfirmText('');
     setShowDeleteModal(true);
+  }, []);
+
+  const handleCancelDelete = useCallback(() => {
+    setShowDeleteModal(false);
+    setSelectedRoom(null);
+    setDeleteConfirmText('');
   }, []);
 
   const handleCreate = useCallback((e: React.FormEvent) => {
@@ -200,507 +303,237 @@ const RoomManagement: React.FC = () => {
     return roomType?.name ?? '-';
   }, [roomTypes]);
 
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-stone-50 p-4">
-        <div className="max-w-6xl mx-auto">
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="animate-pulse space-y-4">
-              <div className="h-6 bg-stone-200 rounded w-1/4" />
-              <div className="space-y-3">
-                {[...Array(5)].map((_, i) => (
-                  <div key={i} className="h-16 bg-stone-200 rounded" />
-                ))}
-              </div>
-            </div>
-          </div>
+  const columns: TableColumn<Room>[] = [
+    {
+      key: 'roomNumber',
+      header: t('admin.booking.rooms.roomNumber'),
+      cell: (room) => <span className="text-body font-semibold text-ink">{room.roomNumber}</span>,
+    },
+    {
+      key: 'floor',
+      header: t('admin.booking.rooms.floor'),
+      cell: (room) => room.floor ?? '-',
+    },
+    {
+      key: 'roomType',
+      header: t('admin.booking.rooms.roomType'),
+      cell: (room) => getRoomTypeName(room.roomTypeId),
+    },
+    {
+      key: 'notes',
+      header: t('admin.booking.rooms.notes'),
+      cell: (room) => <span className="block max-w-xs truncate">{room.notes ?? '-'}</span>,
+    },
+    {
+      key: 'status',
+      header: t('admin.booking.rooms.status'),
+      cell: (room) => (
+        <Badge tone={room.isActive ? 'success' : 'neutral'}>
+          {room.isActive ? t('common.active') : t('common.inactive')}
+        </Badge>
+      ),
+    },
+    {
+      key: 'actions',
+      header: t('admin.booking.rooms.actions'),
+      cell: (room) => (
+        <div className="flex gap-3">
+          <Button variant="ghost" size="sm" onClick={() => handleOpenEdit(room)}>
+            {t('common.edit')}
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => handleOpenDelete(room)}>
+            {t('common.delete')}
+          </Button>
         </div>
-      </div>
-    );
-  }
+      ),
+    },
+  ];
 
   return (
-    <div className="min-h-screen bg-stone-50">
-      {/* Header */}
-      <div className="bg-white shadow-sm">
-        <div className="max-w-6xl mx-auto p-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-bold text-stone-900">
-                {t('admin.booking.rooms.title')}
-              </h1>
-              <p className="text-stone-600 mt-1">
-                {t('admin.booking.rooms.subtitle')}
-              </p>
-            </div>
-            <div className="flex items-center space-x-3">
-              <button
-                onClick={handleOpenCreate}
-                disabled={!roomTypes || roomTypes.length === 0}
-                className="inline-flex items-center font-medium bg-brand-600 text-white px-4 py-2 text-sm rounded-md hover:bg-brand-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {t('admin.booking.rooms.createRoom')}
-              </button>
-              <DashboardButton variant="outline" size="md" />
-            </div>
-          </div>
-        </div>
+    <AppShell variant="admin" title={t('admin.booking.rooms.title')}>
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <p className="text-caption text-ink-muted">{t('admin.booking.rooms.subtitle')}</p>
+        <Button onClick={handleOpenCreate} disabled={!roomTypes || roomTypes.length === 0}>
+          {t('admin.booking.rooms.createRoom')}
+        </Button>
       </div>
 
-      {/* Content */}
-      <div className="max-w-6xl mx-auto p-4">
-        {/* Filter */}
-        <div className="bg-white rounded-lg shadow p-4 mb-6">
-          <div className="flex items-center space-x-4">
-            <label className="text-sm font-medium text-stone-700">
-              {t('admin.booking.rooms.filterByType')}:
-            </label>
-            <select
-              value={filterRoomTypeId}
-              onChange={(e) => setFilterRoomTypeId(e.target.value)}
-              className="border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
-            >
-              <option value="">{t('admin.booking.rooms.allRoomTypes')}</option>
-              {roomTypes?.map((rt: RoomType) => (
-                <option key={rt.id} value={rt.id}>
-                  {rt.name}
-                </option>
-              ))}
-            </select>
-          </div>
+      {/* Filter */}
+      <Card className="mb-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <label htmlFor="room-type-filter" className="text-caption font-semibold text-ink">
+            {t('admin.booking.rooms.filterByType')}
+          </label>
+          <Select
+            id="room-type-filter"
+            value={filterRoomTypeId}
+            onChange={(e) => setFilterRoomTypeId(e.target.value)}
+            className="w-auto min-w-[200px]"
+          >
+            <option value="">{t('admin.booking.rooms.allRoomTypes')}</option>
+            {roomTypes?.map((rt: RoomType) => (
+              <option key={rt.id} value={rt.id}>
+                {rt.name}
+              </option>
+            ))}
+          </Select>
         </div>
+      </Card>
 
-        {error && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
-            <div className="flex">
-              <div className="text-red-400 mr-3">!</div>
-              <div>
-                <h3 className="text-red-800 font-medium">{t('common.error')}</h3>
-                <p className="text-red-700 mt-1">{error.message}</p>
-              </div>
+      {error && (
+        <Card className="mb-6 border-error-200 bg-error-50">
+          <p className="text-caption font-semibold text-error-700">{t('common.error')}</p>
+          <p className="text-caption text-error-600">{error.message}</p>
+        </Card>
+      )}
+
+      {(!roomTypes || roomTypes.length === 0) && (
+        <Card className="mb-6 border-warning-200 bg-warning-50">
+          <p className="text-caption font-semibold text-warning-700">{t('admin.booking.rooms.noRoomTypesWarning')}</p>
+          <p className="text-caption text-warning-600">{t('admin.booking.rooms.createRoomTypesFirst')}</p>
+        </Card>
+      )}
+
+      <Table<Room>
+        aria-label={t('admin.booking.rooms.title')}
+        columns={columns}
+        rows={rooms ?? []}
+        rowKey={(room) => room.id}
+        loading={isLoading}
+        empty={
+          <EmptyState
+            title={t('admin.booking.rooms.noRooms')}
+            description={t('admin.booking.rooms.noRoomsDescription')}
+          />
+        }
+        mobileCard={(room) => (
+          <div className="space-y-3">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-body font-semibold text-ink">{room.roomNumber}</p>
+              <Badge tone={room.isActive ? 'success' : 'neutral'}>
+                {room.isActive ? t('common.active') : t('common.inactive')}
+              </Badge>
+            </div>
+            <p className="text-caption text-ink-muted">{getRoomTypeName(room.roomTypeId)}</p>
+            <div className="flex gap-2 pt-1">
+              <Button variant="secondary" size="sm" onClick={() => handleOpenEdit(room)}>
+                {t('common.edit')}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => handleOpenDelete(room)}>
+                {t('common.delete')}
+              </Button>
             </div>
           </div>
         )}
-
-        {(!roomTypes || roomTypes.length === 0) && (
-          <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4 mb-6">
-            <div className="flex">
-              <div className="text-yellow-400 mr-3">!</div>
-              <div>
-                <h3 className="text-yellow-800 font-medium">{t('admin.booking.rooms.noRoomTypesWarning')}</h3>
-                <p className="text-yellow-700 mt-1">{t('admin.booking.rooms.createRoomTypesFirst')}</p>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Rooms Table */}
-        <div className="bg-white rounded-lg shadow overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-stone-200">
-              <thead className="bg-stone-50">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.rooms.roomNumber')}
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.rooms.floor')}
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.rooms.roomType')}
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.rooms.notes')}
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.rooms.status')}
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.rooms.actions')}
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-stone-200">
-                {!rooms || rooms.length === 0 ? (
-                  <tr>
-                    <td colSpan={6} className="px-6 py-12 text-center">
-                      <div className="text-stone-500">
-                        <p className="text-lg font-medium">{t('admin.booking.rooms.noRooms')}</p>
-                        <p className="text-sm mt-1">{t('admin.booking.rooms.noRoomsDescription')}</p>
-                      </div>
-                    </td>
-                  </tr>
-                ) : (
-                  rooms.map((room) => (
-                    <tr key={room.id} className="hover:bg-stone-50">
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm font-medium text-stone-900">
-                          {room.roomNumber}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-stone-900">
-                          {room.floor ?? '-'}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-stone-900">
-                          {getRoomTypeName(room.roomTypeId)}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4">
-                        <div className="text-sm text-stone-500 truncate max-w-xs">
-                          {room.notes ?? '-'}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                          room.isActive
-                            ? 'bg-green-100 text-green-800'
-                            : 'bg-stone-100 text-stone-800'
-                        }`}
-                        >
-                          {room.isActive ? t('common.active') : t('common.inactive')}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                        <div className="flex space-x-2">
-                          <button
-                            onClick={() => handleOpenEdit(room as Room)}
-                            className="text-brand-600 hover:text-brand-900"
-                          >
-                            {t('common.edit')}
-                          </button>
-                          <button
-                            onClick={() => handleOpenDelete(room as Room)}
-                            className="text-red-600 hover:text-red-900"
-                          >
-                            {t('common.delete')}
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
+      />
 
       {/* Create Modal */}
-      {showCreateModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-lg w-full max-h-[90vh] overflow-y-auto">
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-semibold">{t('admin.booking.rooms.createRoom')}</h2>
-                <button
-                  onClick={() => {
-                    setShowCreateModal(false);
-                    resetForm();
-                  }}
-                  className="text-stone-400 hover:text-stone-600"
-                >
-                  X
-                </button>
-              </div>
-
-              <form onSubmit={handleCreate} className="space-y-4">
-                {/* Room Type */}
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.rooms.roomType')} *
-                  </label>
-                  <select
-                    required
-                    value={formData.roomTypeId}
-                    onChange={(e) => setFormData({ ...formData, roomTypeId: e.target.value })}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
-                  >
-                    <option value="">{t('admin.booking.rooms.selectRoomType')}</option>
-                    {roomTypes?.map((rt: RoomType) => (
-                      <option key={rt.id} value={rt.id}>
-                        {rt.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Room Number */}
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.rooms.roomNumber')} *
-                  </label>
-                  <input
-                    type="text"
-                    required
-                    value={formData.roomNumber}
-                    onChange={(e) => setFormData({ ...formData, roomNumber: e.target.value })}
-                    placeholder={t('admin.booking.rooms.roomNumberPlaceholder')}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
-                  />
-                </div>
-
-                {/* Floor */}
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.rooms.floor')}
-                  </label>
-                  <input
-                    type="number"
-                    value={formData.floor}
-                    onChange={(e) => setFormData({ ...formData, floor: e.target.value })}
-                    placeholder={t('admin.booking.rooms.floorPlaceholder')}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
-                  />
-                </div>
-
-                {/* Notes */}
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.rooms.notes')}
-                  </label>
-                  <textarea
-                    value={formData.notes}
-                    onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-                    rows={3}
-                    placeholder={t('admin.booking.rooms.notesPlaceholder')}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
-                  />
-                </div>
-
-                {/* Active Toggle */}
-                <div className="flex items-center space-x-2">
-                  <input
-                    type="checkbox"
-                    id="isActive"
-                    checked={formData.isActive}
-                    onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
-                    className="h-4 w-4 text-brand-600 focus:ring-brand-500 border-stone-300 rounded"
-                  />
-                  <label htmlFor="isActive" className="text-sm text-stone-700">
-                    {t('admin.booking.rooms.isActive')}
-                  </label>
-                </div>
-
-                {/* Actions */}
-                <div className="flex justify-end space-x-3 pt-4">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setShowCreateModal(false);
-                      resetForm();
-                    }}
-                    className="px-4 py-2 text-stone-700 bg-stone-100 rounded-md hover:bg-stone-200"
-                  >
-                    {t('common.cancel')}
-                  </button>
-                  <button
-                    type="submit"
-                    disabled={createMutation.isPending}
-                    className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:opacity-50"
-                  >
-                    {createMutation.isPending ? t('common.processing') : t('common.create')}
-                  </button>
-                </div>
-              </form>
-            </div>
+      <Modal
+        open={showCreateModal}
+        onClose={handleCancelCreate}
+        title={t('admin.booking.rooms.createRoom')}
+        size="md"
+        footer={
+          <div className="flex justify-end gap-3">
+            <Button type="button" variant="secondary" onClick={handleCancelCreate}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" form="room-create-form" loading={createMutation.isPending}>
+              {createMutation.isPending ? t('common.processing') : t('common.create')}
+            </Button>
           </div>
-        </div>
-      )}
+        }
+      >
+        <RoomFormFields
+          formId="room-create-form"
+          formData={formData}
+          setFormData={setFormData}
+          onSubmit={handleCreate}
+          roomTypes={roomTypes}
+          activeToggleId="isActive"
+        />
+      </Modal>
 
       {/* Edit Modal */}
-      {showEditModal && selectedRoom && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-lg w-full max-h-[90vh] overflow-y-auto">
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-semibold">{t('admin.booking.rooms.editRoom')}</h2>
-                <button
-                  onClick={() => {
-                    setShowEditModal(false);
-                    setSelectedRoom(null);
-                    resetForm();
-                  }}
-                  className="text-stone-400 hover:text-stone-600"
-                >
-                  X
-                </button>
-              </div>
-
-              <form onSubmit={handleUpdate} className="space-y-4">
-                {/* Room Type */}
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.rooms.roomType')} *
-                  </label>
-                  <select
-                    required
-                    value={formData.roomTypeId}
-                    onChange={(e) => setFormData({ ...formData, roomTypeId: e.target.value })}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
-                  >
-                    <option value="">{t('admin.booking.rooms.selectRoomType')}</option>
-                    {roomTypes?.map((rt: RoomType) => (
-                      <option key={rt.id} value={rt.id}>
-                        {rt.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-
-                {/* Room Number */}
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.rooms.roomNumber')} *
-                  </label>
-                  <input
-                    type="text"
-                    required
-                    value={formData.roomNumber}
-                    onChange={(e) => setFormData({ ...formData, roomNumber: e.target.value })}
-                    placeholder={t('admin.booking.rooms.roomNumberPlaceholder')}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
-                  />
-                </div>
-
-                {/* Floor */}
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.rooms.floor')}
-                  </label>
-                  <input
-                    type="number"
-                    value={formData.floor}
-                    onChange={(e) => setFormData({ ...formData, floor: e.target.value })}
-                    placeholder={t('admin.booking.rooms.floorPlaceholder')}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
-                  />
-                </div>
-
-                {/* Notes */}
-                <div>
-                  <label className="block text-sm font-medium text-stone-700 mb-1">
-                    {t('admin.booking.rooms.notes')}
-                  </label>
-                  <textarea
-                    value={formData.notes}
-                    onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
-                    rows={3}
-                    placeholder={t('admin.booking.rooms.notesPlaceholder')}
-                    className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
-                  />
-                </div>
-
-                {/* Active Toggle */}
-                <div className="flex items-center space-x-2">
-                  <input
-                    type="checkbox"
-                    id="isActiveEdit"
-                    checked={formData.isActive}
-                    onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
-                    className="h-4 w-4 text-brand-600 focus:ring-brand-500 border-stone-300 rounded"
-                  />
-                  <label htmlFor="isActiveEdit" className="text-sm text-stone-700">
-                    {t('admin.booking.rooms.isActive')}
-                  </label>
-                </div>
-
-                {/* Actions */}
-                <div className="flex justify-end space-x-3 pt-4">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setShowEditModal(false);
-                      setSelectedRoom(null);
-                      resetForm();
-                    }}
-                    className="px-4 py-2 text-stone-700 bg-stone-100 rounded-md hover:bg-stone-200"
-                  >
-                    {t('common.cancel')}
-                  </button>
-                  <button
-                    type="submit"
-                    disabled={updateMutation.isPending}
-                    className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:opacity-50"
-                  >
-                    {updateMutation.isPending ? t('common.saving') : t('common.save')}
-                  </button>
-                </div>
-              </form>
-            </div>
+      <Modal
+        open={showEditModal && Boolean(selectedRoom)}
+        onClose={handleCancelEdit}
+        title={t('admin.booking.rooms.editRoom')}
+        size="md"
+        footer={
+          <div className="flex justify-end gap-3">
+            <Button type="button" variant="secondary" onClick={handleCancelEdit}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" form="room-edit-form" loading={updateMutation.isPending}>
+              {updateMutation.isPending ? t('common.saving') : t('common.save')}
+            </Button>
           </div>
-        </div>
-      )}
+        }
+      >
+        {selectedRoom && (
+          <RoomFormFields
+            formId="room-edit-form"
+            formData={formData}
+            setFormData={setFormData}
+            onSubmit={handleUpdate}
+            roomTypes={roomTypes}
+            activeToggleId="isActiveEdit"
+          />
+        )}
+      </Modal>
 
       {/* Delete Confirmation Modal */}
-      {showDeleteModal && selectedRoom && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-md w-full">
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-semibold text-red-600">{t('admin.booking.rooms.deleteRoom')}</h2>
-                <button
-                  onClick={() => {
-                    setShowDeleteModal(false);
-                    setSelectedRoom(null);
-                    setDeleteConfirmText('');
-                  }}
-                  className="text-stone-400 hover:text-stone-600"
-                >
-                  X
-                </button>
-              </div>
-
-              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
-                <div className="flex items-center mb-2">
-                  <span className="text-red-500 mr-2">!</span>
-                  <span className="font-medium text-red-800">{t('admin.booking.rooms.deleteWarning')}</span>
-                </div>
-                <div className="text-sm text-red-700">
-                  <p className="mb-2">{t('admin.booking.rooms.deleteConfirmText')}:</p>
-                  <p className="font-medium">{t('admin.booking.rooms.room')} &quot;{selectedRoom.roomNumber}&quot;</p>
-                </div>
-              </div>
-
-              <div className="mb-6">
-                <label className="block text-sm font-medium text-stone-700 mb-2">
-                  {t('admin.booking.rooms.typeToConfirm')} <span className="font-bold text-red-600">{t('admin.booking.rooms.deleteKeyword')}</span> {t('admin.booking.rooms.toConfirm')}:
-                </label>
-                <input
-                  type="text"
-                  value={deleteConfirmText}
-                  onChange={(e) => setDeleteConfirmText(e.target.value)}
-                  placeholder={t('admin.booking.rooms.deletePlaceholder')}
-                  className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
-                />
-              </div>
-
-              <div className="flex justify-end space-x-3">
-                <button
-                  onClick={() => {
-                    setShowDeleteModal(false);
-                    setSelectedRoom(null);
-                    setDeleteConfirmText('');
-                  }}
-                  className="px-4 py-2 text-stone-700 bg-stone-100 rounded-md hover:bg-stone-200"
-                >
-                  {t('common.cancel')}
-                </button>
-                <button
-                  onClick={handleDelete}
-                  disabled={deleteMutation.isPending || deleteConfirmText !== t('admin.booking.rooms.deleteKeyword')}
-                  className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {deleteMutation.isPending ? t('common.processing') : t('common.delete')}
-                </button>
-              </div>
-            </div>
+      <Modal
+        open={showDeleteModal && Boolean(selectedRoom)}
+        onClose={handleCancelDelete}
+        title={t('admin.booking.rooms.deleteRoom')}
+        size="sm"
+        footer={
+          <div className="flex justify-end gap-3">
+            <Button type="button" variant="secondary" onClick={handleCancelDelete}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteConfirmText !== t('admin.booking.rooms.deleteKeyword')}
+              loading={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? t('common.processing') : t('common.delete')}
+            </Button>
           </div>
-        </div>
-      )}
-    </div>
+        }
+      >
+        {selectedRoom && (
+          <>
+            <Card className="mb-4 border-error-200 bg-error-50">
+              <p className="mb-2 text-caption font-semibold text-error-700">
+                {t('admin.booking.rooms.deleteWarning')}
+              </p>
+              <p className="text-caption text-error-600">{t('admin.booking.rooms.deleteConfirmText')}:</p>
+              <p className="text-caption font-semibold text-error-700">
+                {t('admin.booking.rooms.room')} &quot;{selectedRoom.roomNumber}&quot;
+              </p>
+            </Card>
+
+            <FormField
+              label={`${t('admin.booking.rooms.typeToConfirm')} ${t('admin.booking.rooms.deleteKeyword')} ${t('admin.booking.rooms.toConfirm')}`}
+              htmlFor="room-delete-confirm-text"
+            >
+              <Input
+                id="room-delete-confirm-text"
+                type="text"
+                value={deleteConfirmText}
+                onChange={(e) => setDeleteConfirmText(e.target.value)}
+                placeholder={t('admin.booking.rooms.deletePlaceholder')}
+              />
+            </FormField>
+          </>
+        )}
+      </Modal>
+    </AppShell>
   );
 };
 

--- a/frontend/src/pages/admin/RoomTypeManagement.tsx
+++ b/frontend/src/pages/admin/RoomTypeManagement.tsx
@@ -2,7 +2,9 @@ import React, { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import DashboardButton from '../../components/navigation/DashboardButton';
+import AppShell from '../../components/layout/AppShell';
+import { Badge, Button, Card, EmptyState, FormField, Input, Modal, Select, Table, Textarea } from '../../components/ui';
+import type { TableColumn } from '../../components/ui';
 
 // Types based on backend schema
 interface RoomType {
@@ -63,107 +65,86 @@ const initialFormData: RoomTypeFormData = {
   sortOrder: 0,
 };
 
-interface RoomTypeFormProps {
+const CHECKBOX_CLASSES = 'h-4 w-4 rounded border-hairline-strong text-brand-600 focus:ring-brand-600';
+
+interface RoomTypeFormFieldsProps {
+  formId: string;
   formData: RoomTypeFormData;
   setFormData: React.Dispatch<React.SetStateAction<RoomTypeFormData>>;
   imageInput: string;
   setImageInput: React.Dispatch<React.SetStateAction<string>>;
   onSubmit: (e: React.FormEvent) => void;
-  onCancel: () => void;
   onAddImage: () => void;
   onRemoveImage: (imageUrl: string) => void;
   onAmenityToggle: (amenity: string) => void;
   activeToggleId: string;
-  submitLabel: string;
-  submitDisabled: boolean;
 }
 
-const RoomTypeForm: React.FC<RoomTypeFormProps> = ({
+const RoomTypeFormFields: React.FC<RoomTypeFormFieldsProps> = ({
+  formId,
   formData,
   setFormData,
   imageInput,
   setImageInput,
   onSubmit,
-  onCancel,
   onAddImage,
   onRemoveImage,
   onAmenityToggle,
   activeToggleId,
-  submitLabel,
-  submitDisabled,
 }) => {
   const { t } = useTranslation();
 
   return (
-    <form onSubmit={onSubmit} className="space-y-4">
-      {/* Name */}
-      <div>
-        <label className="block text-sm font-medium text-stone-700 mb-1">
-          {t('admin.booking.roomTypes.name')} *
-        </label>
-        <input
+    <form id={formId} onSubmit={onSubmit} className="space-y-4">
+      <FormField label={t('admin.booking.roomTypes.name')} htmlFor={`${formId}-name`} required>
+        <Input
+          id={`${formId}-name`}
           type="text"
           required
           value={formData.name}
           onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-          className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
         />
-      </div>
+      </FormField>
 
-      {/* Description */}
-      <div>
-        <label className="block text-sm font-medium text-stone-700 mb-1">
-          {t('admin.booking.roomTypes.description')}
-        </label>
-        <textarea
+      <FormField label={t('admin.booking.roomTypes.description')} htmlFor={`${formId}-description`}>
+        <Textarea
+          id={`${formId}-description`}
           value={formData.description}
           onChange={(e) => setFormData({ ...formData, description: e.target.value })}
           rows={3}
-          className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
         />
-      </div>
+      </FormField>
 
-      {/* Price and Max Guests */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label className="block text-sm font-medium text-stone-700 mb-1">
-            {t('admin.booking.roomTypes.pricePerNight')} (THB) *
-          </label>
-          <input
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <FormField label={`${t('admin.booking.roomTypes.pricePerNight')} (THB)`} htmlFor={`${formId}-price`} required>
+          <Input
+            id={`${formId}-price`}
             type="number"
             required
             min="0"
             step="0.01"
             value={formData.pricePerNight}
             onChange={(e) => setFormData({ ...formData, pricePerNight: parseFloat(e.target.value) || 0 })}
-            className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-stone-700 mb-1">
-            {t('admin.booking.roomTypes.maxGuests')} *
-          </label>
-          <input
+        </FormField>
+        <FormField label={t('admin.booking.roomTypes.maxGuests')} htmlFor={`${formId}-maxGuests`} required>
+          <Input
+            id={`${formId}-maxGuests`}
             type="number"
             required
             min="1"
             value={formData.maxGuests}
             onChange={(e) => setFormData({ ...formData, maxGuests: parseInt(e.target.value) || 1 })}
-            className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
-        </div>
+        </FormField>
       </div>
 
-      {/* Bed Type and Sort Order */}
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <div>
-          <label className="block text-sm font-medium text-stone-700 mb-1">
-            {t('admin.booking.roomTypes.bedType')}
-          </label>
-          <select
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <FormField label={t('admin.booking.roomTypes.bedType')} htmlFor={`${formId}-bedType`}>
+          <Select
+            id={`${formId}-bedType`}
             value={formData.bedType}
             onChange={(e) => setFormData({ ...formData, bedType: e.target.value as typeof formData.bedType })}
-            className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
           >
             <option value="">{t('admin.booking.roomTypes.selectBedType')}</option>
             {BED_TYPE_OPTIONS.map((type) => (
@@ -171,37 +152,31 @@ const RoomTypeForm: React.FC<RoomTypeFormProps> = ({
                 {t(`admin.booking.roomTypes.bedTypes.${type}`)}
               </option>
             ))}
-          </select>
-        </div>
-        <div>
-          <label className="block text-sm font-medium text-stone-700 mb-1">
-            {t('admin.booking.roomTypes.sortOrder')}
-          </label>
-          <input
+          </Select>
+        </FormField>
+        <FormField label={t('admin.booking.roomTypes.sortOrder')} htmlFor={`${formId}-sortOrder`}>
+          <Input
+            id={`${formId}-sortOrder`}
             type="number"
             min="0"
             value={formData.sortOrder}
             onChange={(e) => setFormData({ ...formData, sortOrder: parseInt(e.target.value) || 0 })}
-            className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
           />
-        </div>
+        </FormField>
       </div>
 
-      {/* Amenities */}
       <div>
-        <label className="block text-sm font-medium text-stone-700 mb-2">
-          {t('admin.booking.roomTypes.amenities')}
-        </label>
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+        <p className="mb-2 text-caption font-semibold text-ink">{t('admin.booking.roomTypes.amenities')}</p>
+        <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
           {AMENITIES_OPTIONS.map((amenity) => (
-            <label key={amenity} className="flex items-center space-x-2 cursor-pointer">
+            <label key={amenity} className="flex cursor-pointer items-center gap-2">
               <input
                 type="checkbox"
                 checked={formData.amenities.includes(amenity)}
                 onChange={() => onAmenityToggle(amenity)}
-                className="h-4 w-4 text-brand-600 focus:ring-brand-500 border-stone-300 rounded"
+                className={CHECKBOX_CLASSES}
               />
-              <span className="text-sm text-stone-700">
+              <span className="text-caption text-ink">
                 {t(`admin.booking.roomTypes.amenitiesList.${amenity}`)}
               </span>
             </label>
@@ -209,76 +184,47 @@ const RoomTypeForm: React.FC<RoomTypeFormProps> = ({
         </div>
       </div>
 
-      {/* Images */}
-      <div>
-        <label className="block text-sm font-medium text-stone-700 mb-1">
+      <div className="space-y-1.5">
+        <label htmlFor={`${formId}-imageInput`} className="text-caption font-semibold text-ink">
           {t('admin.booking.roomTypes.images')}
         </label>
-        <div className="flex space-x-2 mb-2">
-          <input
+        <div className="flex gap-2">
+          <Input
+            id={`${formId}-imageInput`}
             type="url"
             value={imageInput}
             onChange={(e) => setImageInput(e.target.value)}
             placeholder={t('admin.booking.roomTypes.imageUrlPlaceholder')}
-            className="flex-1 border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-500"
+            className="flex-1"
           />
-          <button
-            type="button"
-            onClick={onAddImage}
-            className="px-4 py-2 bg-stone-100 text-stone-700 rounded-md hover:bg-stone-200"
-          >
+          <Button type="button" variant="secondary" size="sm" onClick={onAddImage}>
             {t('admin.booking.roomTypes.addImage')}
-          </button>
+          </Button>
         </div>
         {formData.images.length > 0 && (
-          <div className="space-y-2">
-            {formData.images.map((url, index) => (
-              <div key={index} className="flex items-center space-x-2 bg-stone-50 p-2 rounded">
-                <span className="text-sm text-stone-600 truncate flex-1">{url}</span>
-                <button
-                  type="button"
-                  onClick={() => onRemoveImage(url)}
-                  className="text-red-500 hover:text-red-700"
-                >
+          <div className="space-y-2 pt-1">
+            {formData.images.map((url) => (
+              <div key={url} className="flex items-center gap-2 rounded-lg bg-surface-sunken p-2">
+                <span className="flex-1 truncate text-caption text-ink-muted">{url}</span>
+                <Button type="button" variant="ghost" size="sm" onClick={() => onRemoveImage(url)}>
                   {t('common.remove')}
-                </button>
+                </Button>
               </div>
             ))}
           </div>
         )}
       </div>
 
-      {/* Active Toggle */}
-      <div className="flex items-center space-x-2">
+      <label htmlFor={activeToggleId} className="flex items-center gap-2">
         <input
           type="checkbox"
           id={activeToggleId}
           checked={formData.isActive}
           onChange={(e) => setFormData({ ...formData, isActive: e.target.checked })}
-          className="h-4 w-4 text-brand-600 focus:ring-brand-500 border-stone-300 rounded"
+          className={CHECKBOX_CLASSES}
         />
-        <label htmlFor={activeToggleId} className="text-sm text-stone-700">
-          {t('admin.booking.roomTypes.isActive')}
-        </label>
-      </div>
-
-      {/* Actions */}
-      <div className="flex justify-end space-x-3 pt-4">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="px-4 py-2 text-stone-700 bg-stone-100 rounded-md hover:bg-stone-200"
-        >
-          {t('common.cancel')}
-        </button>
-        <button
-          type="submit"
-          disabled={submitDisabled}
-          className="px-4 py-2 bg-brand-600 text-white rounded-md hover:bg-brand-700 disabled:opacity-50"
-        >
-          {submitLabel}
-        </button>
-      </div>
+        <span className="text-caption text-ink">{t('admin.booking.roomTypes.isActive')}</span>
+      </label>
     </form>
   );
 };
@@ -370,6 +316,11 @@ const RoomTypeManagement: React.FC = () => {
     setShowCreateModal(true);
   }, [resetForm]);
 
+  const handleCancelCreate = useCallback(() => {
+    setShowCreateModal(false);
+    resetForm();
+  }, [resetForm]);
+
   const handleOpenEdit = useCallback((roomType: RoomType) => {
     setSelectedRoomType(roomType);
     setFormData({
@@ -386,10 +337,22 @@ const RoomTypeManagement: React.FC = () => {
     setShowEditModal(true);
   }, []);
 
+  const handleCancelEdit = useCallback(() => {
+    setShowEditModal(false);
+    setSelectedRoomType(null);
+    resetForm();
+  }, [resetForm]);
+
   const handleOpenDelete = useCallback((roomType: RoomType) => {
     setSelectedRoomType(roomType);
     setDeleteConfirmText('');
     setShowDeleteModal(true);
+  }, []);
+
+  const handleCancelDelete = useCallback(() => {
+    setShowDeleteModal(false);
+    setSelectedRoomType(null);
+    setDeleteConfirmText('');
   }, []);
 
   const handleCreate = useCallback((e: React.FormEvent) => {
@@ -468,314 +431,222 @@ const RoomTypeManagement: React.FC = () => {
     }).format(amount);
   };
 
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-stone-50 p-4">
-        <div className="max-w-6xl mx-auto">
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="animate-pulse space-y-4">
-              <div className="h-6 bg-stone-200 rounded w-1/4" />
-              <div className="space-y-3">
-                {[...Array(5)].map((_, i) => (
-                  <div key={i} className="h-16 bg-stone-200 rounded" />
-                ))}
-              </div>
-            </div>
-          </div>
+  const columns: TableColumn<RoomType>[] = [
+    {
+      key: 'name',
+      header: t('admin.booking.roomTypes.name'),
+      cell: (roomType) => (
+        <div>
+          <p className="text-body font-semibold text-ink">{roomType.name}</p>
+          {roomType.description && (
+            <p className="max-w-xs truncate text-fine text-ink-muted">{roomType.description}</p>
+          )}
         </div>
-      </div>
-    );
-  }
+      ),
+    },
+    {
+      key: 'price',
+      header: t('admin.booking.roomTypes.pricePerNight'),
+      cell: (roomType) => formatCurrency(roomType.pricePerNight),
+    },
+    {
+      key: 'maxGuests',
+      header: t('admin.booking.roomTypes.maxGuests'),
+      cell: (roomType) => `${roomType.maxGuests} ${t('admin.booking.roomTypes.guests')}`,
+    },
+    {
+      key: 'bedType',
+      header: t('admin.booking.roomTypes.bedType'),
+      cell: (roomType) => (roomType.bedType ? t(`admin.booking.roomTypes.bedTypes.${roomType.bedType}`) : '-'),
+    },
+    {
+      key: 'status',
+      header: t('admin.booking.roomTypes.status'),
+      cell: (roomType) => (
+        <Badge tone={roomType.isActive ? 'success' : 'neutral'}>
+          {roomType.isActive ? t('common.active') : t('common.inactive')}
+        </Badge>
+      ),
+    },
+    {
+      key: 'actions',
+      header: t('admin.booking.roomTypes.actions'),
+      cell: (roomType) => (
+        <div className="flex gap-3">
+          <Button variant="ghost" size="sm" onClick={() => handleOpenEdit(roomType)}>
+            {t('common.edit')}
+          </Button>
+          <Button variant="ghost" size="sm" onClick={() => handleOpenDelete(roomType)}>
+            {t('common.delete')}
+          </Button>
+        </div>
+      ),
+    },
+  ];
 
   return (
-    <div className="min-h-screen bg-stone-50">
-      {/* Header */}
-      <div className="bg-white shadow-sm">
-        <div className="max-w-6xl mx-auto p-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-bold text-stone-900">
-                {t('admin.booking.roomTypes.title')}
-              </h1>
-              <p className="text-stone-600 mt-1">
-                {t('admin.booking.roomTypes.subtitle')}
-              </p>
-            </div>
-            <div className="flex items-center space-x-3">
-              <button
-                onClick={handleOpenCreate}
-                className="inline-flex items-center font-medium bg-brand-600 text-white px-4 py-2 text-sm rounded-md hover:bg-brand-700 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-brand-500"
-              >
-                {t('admin.booking.roomTypes.createRoomType')}
-              </button>
-              <DashboardButton variant="outline" size="md" />
-            </div>
-          </div>
-        </div>
+    <AppShell variant="admin" title={t('admin.booking.roomTypes.title')}>
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <p className="text-caption text-ink-muted">{t('admin.booking.roomTypes.subtitle')}</p>
+        <Button onClick={handleOpenCreate}>{t('admin.booking.roomTypes.createRoomType')}</Button>
       </div>
 
-      {/* Content */}
-      <div className="max-w-6xl mx-auto p-4">
-        {error && (
-          <div className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6">
-            <div className="flex">
-              <div className="text-red-400 mr-3">!</div>
-              <div>
-                <h3 className="text-red-800 font-medium">{t('common.error')}</h3>
-                <p className="text-red-700 mt-1">{error.message}</p>
-              </div>
+      {error && (
+        <Card className="mb-6 border-error-200 bg-error-50">
+          <p className="text-caption font-semibold text-error-700">{t('common.error')}</p>
+          <p className="text-caption text-error-600">{error.message}</p>
+        </Card>
+      )}
+
+      <Table<RoomType>
+        aria-label={t('admin.booking.roomTypes.title')}
+        columns={columns}
+        rows={roomTypes ?? []}
+        rowKey={(roomType) => roomType.id}
+        loading={isLoading}
+        empty={
+          <EmptyState
+            title={t('admin.booking.roomTypes.noRoomTypes')}
+            description={t('admin.booking.roomTypes.noRoomTypesDescription')}
+          />
+        }
+        mobileCard={(roomType) => (
+          <div className="space-y-3">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-body font-semibold text-ink">{roomType.name}</p>
+              <Badge tone={roomType.isActive ? 'success' : 'neutral'}>
+                {roomType.isActive ? t('common.active') : t('common.inactive')}
+              </Badge>
+            </div>
+            <div className="flex items-center justify-between text-caption text-ink-muted">
+              <span>{formatCurrency(roomType.pricePerNight)}</span>
+              <span>{roomType.maxGuests} {t('admin.booking.roomTypes.guests')}</span>
+            </div>
+            <div className="flex gap-2 pt-1">
+              <Button variant="secondary" size="sm" onClick={() => handleOpenEdit(roomType)}>
+                {t('common.edit')}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => handleOpenDelete(roomType)}>
+                {t('common.delete')}
+              </Button>
             </div>
           </div>
         )}
-
-        {/* Room Types Table */}
-        <div className="bg-white rounded-lg shadow overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="min-w-full divide-y divide-stone-200">
-              <thead className="bg-stone-50">
-                <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.roomTypes.name')}
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.roomTypes.pricePerNight')}
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.roomTypes.maxGuests')}
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.roomTypes.bedType')}
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.roomTypes.status')}
-                  </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-stone-500 uppercase tracking-wider">
-                    {t('admin.booking.roomTypes.actions')}
-                  </th>
-                </tr>
-              </thead>
-              <tbody className="bg-white divide-y divide-stone-200">
-                {!roomTypes || roomTypes.length === 0 ? (
-                  <tr>
-                    <td colSpan={6} className="px-6 py-12 text-center">
-                      <div className="text-stone-500">
-                        <p className="text-lg font-medium">{t('admin.booking.roomTypes.noRoomTypes')}</p>
-                        <p className="text-sm mt-1">{t('admin.booking.roomTypes.noRoomTypesDescription')}</p>
-                      </div>
-                    </td>
-                  </tr>
-                ) : (
-                  roomTypes.map((roomType) => (
-                    <tr key={roomType.id} className="hover:bg-stone-50">
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div>
-                          <div className="text-sm font-medium text-stone-900">
-                            {roomType.name}
-                          </div>
-                          <div className="text-sm text-stone-500 truncate max-w-xs">
-                            {roomType.description}
-                          </div>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-stone-900">
-                          {formatCurrency(roomType.pricePerNight)}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-stone-900">
-                          {roomType.maxGuests} {t('admin.booking.roomTypes.guests')}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="text-sm text-stone-900">
-                          {roomType.bedType ? t(`admin.booking.roomTypes.bedTypes.${roomType.bedType}`) : '-'}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                          roomType.isActive
-                            ? 'bg-green-100 text-green-800'
-                            : 'bg-stone-100 text-stone-800'
-                        }`}
-                        >
-                          {roomType.isActive ? t('common.active') : t('common.inactive')}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                        <div className="flex space-x-2">
-                          <button
-                            onClick={() => handleOpenEdit(roomType as RoomType)}
-                            className="text-brand-600 hover:text-brand-900"
-                          >
-                            {t('common.edit')}
-                          </button>
-                          <button
-                            onClick={() => handleOpenDelete(roomType as RoomType)}
-                            className="text-red-600 hover:text-red-900"
-                          >
-                            {t('common.delete')}
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      </div>
+      />
 
       {/* Create Modal */}
-      {showCreateModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-semibold">{t('admin.booking.roomTypes.createRoomType')}</h2>
-                <button
-                  onClick={() => {
-                    setShowCreateModal(false);
-                    resetForm();
-                  }}
-                  className="text-stone-400 hover:text-stone-600"
-                >
-                  X
-                </button>
-              </div>
-
-              <RoomTypeForm
-                formData={formData}
-                setFormData={setFormData}
-                imageInput={imageInput}
-                setImageInput={setImageInput}
-                onSubmit={handleCreate}
-                onCancel={() => {
-                  setShowCreateModal(false);
-                  resetForm();
-                }}
-                onAddImage={handleAddImage}
-                onRemoveImage={handleRemoveImage}
-                onAmenityToggle={handleAmenityToggle}
-                activeToggleId="isActive"
-                submitLabel={createMutation.isPending ? t('common.processing') : t('common.create')}
-                submitDisabled={createMutation.isPending}
-              />
-            </div>
+      <Modal
+        open={showCreateModal}
+        onClose={handleCancelCreate}
+        title={t('admin.booking.roomTypes.createRoomType')}
+        size="lg"
+        footer={
+          <div className="flex justify-end gap-3">
+            <Button type="button" variant="secondary" onClick={handleCancelCreate}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" form="room-type-create-form" loading={createMutation.isPending}>
+              {createMutation.isPending ? t('common.processing') : t('common.create')}
+            </Button>
           </div>
-        </div>
-      )}
+        }
+      >
+        <RoomTypeFormFields
+          formId="room-type-create-form"
+          formData={formData}
+          setFormData={setFormData}
+          imageInput={imageInput}
+          setImageInput={setImageInput}
+          onSubmit={handleCreate}
+          onAddImage={handleAddImage}
+          onRemoveImage={handleRemoveImage}
+          onAmenityToggle={handleAmenityToggle}
+          activeToggleId="isActive"
+        />
+      </Modal>
 
       {/* Edit Modal */}
-      {showEditModal && selectedRoomType && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-2xl w-full max-h-[90vh] overflow-y-auto">
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-semibold">{t('admin.booking.roomTypes.editRoomType')}</h2>
-                <button
-                  onClick={() => {
-                    setShowEditModal(false);
-                    setSelectedRoomType(null);
-                    resetForm();
-                  }}
-                  className="text-stone-400 hover:text-stone-600"
-                >
-                  X
-                </button>
-              </div>
-
-              <RoomTypeForm
-                formData={formData}
-                setFormData={setFormData}
-                imageInput={imageInput}
-                setImageInput={setImageInput}
-                onSubmit={handleUpdate}
-                onCancel={() => {
-                  setShowEditModal(false);
-                  setSelectedRoomType(null);
-                  resetForm();
-                }}
-                onAddImage={handleAddImage}
-                onRemoveImage={handleRemoveImage}
-                onAmenityToggle={handleAmenityToggle}
-                activeToggleId="isActiveEdit"
-                submitLabel={updateMutation.isPending ? t('common.saving') : t('common.save')}
-                submitDisabled={updateMutation.isPending}
-              />
-            </div>
+      <Modal
+        open={showEditModal && Boolean(selectedRoomType)}
+        onClose={handleCancelEdit}
+        title={t('admin.booking.roomTypes.editRoomType')}
+        size="lg"
+        footer={
+          <div className="flex justify-end gap-3">
+            <Button type="button" variant="secondary" onClick={handleCancelEdit}>
+              {t('common.cancel')}
+            </Button>
+            <Button type="submit" form="room-type-edit-form" loading={updateMutation.isPending}>
+              {updateMutation.isPending ? t('common.saving') : t('common.save')}
+            </Button>
           </div>
-        </div>
-      )}
+        }
+      >
+        {selectedRoomType && (
+          <RoomTypeFormFields
+            formId="room-type-edit-form"
+            formData={formData}
+            setFormData={setFormData}
+            imageInput={imageInput}
+            setImageInput={setImageInput}
+            onSubmit={handleUpdate}
+            onAddImage={handleAddImage}
+            onRemoveImage={handleRemoveImage}
+            onAmenityToggle={handleAmenityToggle}
+            activeToggleId="isActiveEdit"
+          />
+        )}
+      </Modal>
 
       {/* Delete Confirmation Modal */}
-      {showDeleteModal && selectedRoomType && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-md w-full">
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-xl font-semibold text-red-600">{t('admin.booking.roomTypes.deleteRoomType')}</h2>
-                <button
-                  onClick={() => {
-                    setShowDeleteModal(false);
-                    setSelectedRoomType(null);
-                    setDeleteConfirmText('');
-                  }}
-                  className="text-stone-400 hover:text-stone-600"
-                >
-                  X
-                </button>
-              </div>
-
-              <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-md">
-                <div className="flex items-center mb-2">
-                  <span className="text-red-500 mr-2">!</span>
-                  <span className="font-medium text-red-800">{t('admin.booking.roomTypes.deleteWarning')}</span>
-                </div>
-                <div className="text-sm text-red-700">
-                  <p className="mb-2">{t('admin.booking.roomTypes.deleteConfirmText')}:</p>
-                  <p className="font-medium">&quot;{selectedRoomType.name}&quot;</p>
-                </div>
-              </div>
-
-              <div className="mb-6">
-                <label className="block text-sm font-medium text-stone-700 mb-2">
-                  {t('admin.booking.roomTypes.typeToConfirm')} <span className="font-bold text-red-600">{t('admin.booking.roomTypes.deleteKeyword')}</span> {t('admin.booking.roomTypes.toConfirm')}:
-                </label>
-                <input
-                  type="text"
-                  value={deleteConfirmText}
-                  onChange={(e) => setDeleteConfirmText(e.target.value)}
-                  placeholder={t('admin.booking.roomTypes.deletePlaceholder')}
-                  className="w-full border border-stone-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-red-500"
-                />
-              </div>
-
-              <div className="flex justify-end space-x-3">
-                <button
-                  onClick={() => {
-                    setShowDeleteModal(false);
-                    setSelectedRoomType(null);
-                    setDeleteConfirmText('');
-                  }}
-                  className="px-4 py-2 text-stone-700 bg-stone-100 rounded-md hover:bg-stone-200"
-                >
-                  {t('common.cancel')}
-                </button>
-                <button
-                  onClick={handleDelete}
-                  disabled={deleteMutation.isPending || deleteConfirmText !== t('admin.booking.roomTypes.deleteKeyword')}
-                  className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {deleteMutation.isPending ? t('common.processing') : t('common.delete')}
-                </button>
-              </div>
-            </div>
+      <Modal
+        open={showDeleteModal && Boolean(selectedRoomType)}
+        onClose={handleCancelDelete}
+        title={t('admin.booking.roomTypes.deleteRoomType')}
+        size="sm"
+        footer={
+          <div className="flex justify-end gap-3">
+            <Button type="button" variant="secondary" onClick={handleCancelDelete}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteConfirmText !== t('admin.booking.roomTypes.deleteKeyword')}
+              loading={deleteMutation.isPending}
+            >
+              {deleteMutation.isPending ? t('common.processing') : t('common.delete')}
+            </Button>
           </div>
-        </div>
-      )}
-    </div>
+        }
+      >
+        {selectedRoomType && (
+          <>
+            <Card className="mb-4 border-error-200 bg-error-50">
+              <p className="mb-2 text-caption font-semibold text-error-700">
+                {t('admin.booking.roomTypes.deleteWarning')}
+              </p>
+              <p className="text-caption text-error-600">{t('admin.booking.roomTypes.deleteConfirmText')}:</p>
+              <p className="text-caption font-semibold text-error-700">&quot;{selectedRoomType.name}&quot;</p>
+            </Card>
+
+            <FormField
+              label={`${t('admin.booking.roomTypes.typeToConfirm')} ${t('admin.booking.roomTypes.deleteKeyword')} ${t('admin.booking.roomTypes.toConfirm')}`}
+              htmlFor="delete-confirm-text"
+            >
+              <Input
+                id="delete-confirm-text"
+                type="text"
+                value={deleteConfirmText}
+                onChange={(e) => setDeleteConfirmText(e.target.value)}
+                placeholder={t('admin.booking.roomTypes.deletePlaceholder')}
+              />
+            </FormField>
+          </>
+        )}
+      </Modal>
+    </AppShell>
   );
 };
 

--- a/frontend/src/pages/admin/__tests__/BookingEditModal.test.tsx
+++ b/frontend/src/pages/admin/__tests__/BookingEditModal.test.tsx
@@ -307,7 +307,8 @@ describe('BookingEditModal - Cancel Tab', () => {
   });
 
   describe('Already cancelled booking', () => {
-    it('should show disabled state with message for already cancelled booking', () => {
+    it('should keep the Cancel tab unreachable for an already cancelled booking', async () => {
+      const user = userEvent.setup();
       render(
         <BookingEditModal
           booking={mockCancelledBooking}
@@ -318,16 +319,18 @@ describe('BookingEditModal - Cancel Tab', () => {
         { wrapper }
       );
 
-      // Cancel tab should be disabled
-      const allButtons = screen.getAllByRole('button');
-      const cancelTabButton = allButtons.find(btn => btn.textContent?.includes('Cancel'));
+      // TabNav has no per-item disabled state, so the old disabled <button>
+      // is now a guard in the tab-change handler — clicking the Cancel tab
+      // while the booking is already cancelled must not activate it.
+      const cancelTabButton = screen.getByRole('tab', { name: /Cancel/ });
+      await user.click(cancelTabButton);
 
-      if (cancelTabButton) {
-        expect(cancelTabButton).toBeDisabled();
-      }
+      expect(cancelTabButton).toHaveAttribute('aria-selected', 'false');
+      expect(screen.queryByPlaceholderText('Enter the reason for cancellation...')).not.toBeInTheDocument();
     });
 
     it('should display already cancelled message when viewing cancel tab for cancelled booking', async () => {
+      const user = userEvent.setup();
       render(
         <BookingEditModal
           booking={mockCancelledBooking}
@@ -338,14 +341,13 @@ describe('BookingEditModal - Cancel Tab', () => {
         { wrapper }
       );
 
-      // The cancel tab should be disabled for cancelled bookings
-      const tabs = screen.getAllByRole('button');
-      const cancelTab = tabs.find(tab => tab.textContent?.includes('Cancel') && tab.classList.contains('border-b-2'));
+      // The cancel tab stays unreachable for cancelled bookings, so the
+      // "already cancelled" panel behind it never renders either.
+      const cancelTabButton = screen.getByRole('tab', { name: /Cancel/ });
+      await user.click(cancelTabButton);
 
-      // Verify the tab is in a disabled state (has disabled styling)
-      if (cancelTab) {
-        expect(cancelTab).toHaveClass('cursor-not-allowed');
-      }
+      expect(cancelTabButton).toHaveAttribute('aria-selected', 'false');
+      expect(screen.queryByText('This booking has already been cancelled')).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/admin/__tests__/BookingManagement.test.tsx
+++ b/frontend/src/pages/admin/__tests__/BookingManagement.test.tsx
@@ -57,9 +57,14 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-// Mock DashboardButton
-vi.mock('../../../components/navigation/DashboardButton', () => ({
-  default: () => <div data-testid="dashboard-button">Dashboard</div>,
+// Mock AppShell (admin chrome renders DashboardButton/nav internally and needs a Router)
+vi.mock('../../../components/layout/AppShell', () => ({
+  default: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ),
 }));
 
 // Mock SlipViewerSidebar
@@ -127,9 +132,11 @@ describe('BookingManagement', () => {
     it('renders no bookings message when list is empty', async () => {
       render(<BookingManagement />, { wrapper });
 
-      // The stub queryFn returns empty bookings, so we should see the empty state
+      // The stub queryFn returns empty bookings, so we should see the empty
+      // state. The Table primitive renders the empty node in both the
+      // desktop and mobile layouts, so it appears twice in the DOM.
       await waitFor(() => {
-        expect(screen.getByText('No bookings found')).toBeInTheDocument();
+        expect(screen.getAllByText('No bookings found').length).toBeGreaterThan(0);
       });
     });
   });

--- a/frontend/src/pages/admin/__tests__/RoomManagement.test.tsx
+++ b/frontend/src/pages/admin/__tests__/RoomManagement.test.tsx
@@ -55,9 +55,14 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-// Mock DashboardButton
-vi.mock('../../../components/navigation/DashboardButton', () => ({
-  default: () => <div data-testid="dashboard-button">Dashboard</div>,
+// Mock AppShell (admin chrome renders DashboardButton/nav internally and needs a Router)
+vi.mock('../../../components/layout/AppShell', () => ({
+  default: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ),
 }));
 
 // Import component after mocks
@@ -101,9 +106,11 @@ describe('RoomManagement', () => {
     it('renders no rooms message when list is empty', async () => {
       render(<RoomManagement />, { wrapper });
 
-      // The stub queryFn returns [], so we should see the empty state
+      // The stub queryFn returns [], so we should see the empty state.
+      // The Table primitive renders the empty node in both the desktop and
+      // mobile layouts, so it appears twice in the DOM.
       await waitFor(() => {
-        expect(screen.getByText('No rooms found')).toBeInTheDocument();
+        expect(screen.getAllByText('No rooms found').length).toBeGreaterThan(0);
       });
     });
   });

--- a/frontend/src/pages/admin/__tests__/RoomTypeManagement.test.tsx
+++ b/frontend/src/pages/admin/__tests__/RoomTypeManagement.test.tsx
@@ -56,9 +56,14 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-// Mock DashboardButton
-vi.mock('../../../components/navigation/DashboardButton', () => ({
-  default: () => <div data-testid="dashboard-button">Dashboard</div>,
+// Mock AppShell (admin chrome renders DashboardButton/nav internally and needs a Router)
+vi.mock('../../../components/layout/AppShell', () => ({
+  default: ({ children, title }: { children: React.ReactNode; title: string }) => (
+    <div>
+      <h1>{title}</h1>
+      {children}
+    </div>
+  ),
 }));
 
 // Import component after mocks
@@ -102,9 +107,11 @@ describe('RoomTypeManagement', () => {
     it('renders no room types message when list is empty', async () => {
       render(<RoomTypeManagement />, { wrapper });
 
-      // The stub queryFn returns [], so we should see the empty state
+      // The stub queryFn returns [], so we should see the empty state.
+      // The Table primitive renders the empty node in both the desktop and
+      // mobile layouts, so it appears twice in the DOM.
       await waitFor(() => {
-        expect(screen.getByText('No room types found')).toBeInTheDocument();
+        expect(screen.getAllByText('No room types found').length).toBeGreaterThan(0);
       });
     });
   });


### PR DESCRIPTION
## Summary

Admin wave 3 of 3 — the hottest ops tooling in the app (room inventory, availability calendar, booking management, slip verification). Zero-logic-change migration onto the shared admin design system built in earlier waves.

- **RoomTypeManagement / RoomManagement**: hand-rolled header chrome → `AppShell variant="admin"`; hand-rolled `<table>` → `Table` primitive with mobile-card reflow (title/meta/badge/action); filter toolbar + modals (create/edit/delete) → `Card`/`Input`/`Select`/`FormField`/`Modal`.
- **RoomAvailability** (the one exception — a calendar grid, not a row table): grid layout preserved as-is, **not** card-reflowed. First (room) column is now `sticky left-0 z-10 bg-surface-card` inside `overflow-x-auto`; header row sunken; cell colors tokenized (success/error/brand); interactive day cells bumped to `h-11 w-11` (44px tap targets). Shell + toolbar/legend recipe applied around the grid.
- **BookingManagement**: status filter strip → `TabNav`; bookings table → `Table` primitive with sortable headers, `Badge` tones (confirmed→success, cancelled→error, completed→brand; slip/admin status pending→warning, verified→success, needs_action/failed→error, matching the tone convention already established in `MyBookingsPage`). Row-tap now opens the edit flow directly (`Table onRowClick` → `handleEditBooking`), replacing the old click-to-preview/double-click-to-edit split — Table only exposes one row-activation event, so this consolidates cleanly onto a single, more discoverable interaction. Per-row Verify/Needs-Action/Edit icon buttons kept, bumped to 44px, `stopPropagation` preserved so they don't also trigger the row click.
- **BookingEditModal**: hand-rolled centered overlay → `Modal` primitive, `size="lg"` (its `max-w-2xl` desktop width already matched the old markup almost exactly, so centered was the least-invasive presentation choice over a side panel), default `sheet` mobile presentation for a bottom-sheet on small screens. Tab strip → `TabNav`. Since `TabNav` has no per-item disabled state, the old `disabled` Cancel-tab button becomes a guard in the tab-change handler (clicking Cancel while a booking is already cancelled never activates the tab — same unreachable end state as before, just implemented against the shared primitive).
- **SlipViewerSidebar**: all zoom/gallery/fullscreen-viewer logic is byte-identical — only chrome changed (hairline borders, `bg-ink/40 backdrop-blur-sm` scrim on the two dialog-style overlays, `bg-ink` solid backdrop kept for the true fullscreen photo lightbox, `Badge` tones for slip/admin status, all buttons bumped to ≥44px).

**Zero logic/API changes.** Every `useState`/`useCallback`/`useEffect`, every `useQuery`/`useMutation` (queryKey, queryFn, mutationFn, onSuccess, onError), and every handler body is untouched — verified by re-reading the diff and by an independent second-pass diff review that found no logic deltas across all six files (the row-tap→edit rewire in BookingManagement is the one intentional, explicitly-scoped interaction change called out above).

## Ratchet

`node scripts/check-design.cjs` — no pattern increased anywhere; three patterns dropped and the baseline was ratcheted down accordingly:

| pattern | before | after |
|---|---|---|
| `font-medium` | 390 | 285 |
| `legacy-shadows` | 167 | 148 |
| `off-grammar-radii` | 240 | 167 |

(`cool-grays`, `font-extrabold`, `oversized-titles`, `hardcoded-hex` unchanged.)

## Test changes

- `RoomTypeManagement.test.tsx`, `RoomManagement.test.tsx`, `BookingManagement.test.tsx`: swapped the `DashboardButton` mock for an `AppShell` mock (same pattern already used in `MyBookingsPage.test.tsx` — admin chrome now renders `DashboardButton`/nav internally and needs a Router the unit tests don't provide); updated empty-state assertions to `getAllByText(...).length > 0` since the `Table` primitive renders the empty node in both the desktop and mobile layouts.
- `BookingEditModal.test.tsx`: the two "already cancelled" tests asserted on the *old* hand-rolled `disabled`/`border-b-2`/`cursor-not-allowed` markup, which no longer exists once the tab strip is a `TabNav`. Rewrote both to assert the actual preserved behavior instead — clicking the Cancel tab while a booking is already cancelled leaves `aria-selected="false"` and never reveals the cancel-tab content — rather than deleting or faking them green.

## Test plan

- [x] `npm run lint` (eslint + design ratchet) — 0 errors, only pre-existing warnings
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 2107/2107 passing across 81 files (224 in the touched admin suites)
- [x] `npm run check:translations` — no missing keys (no new labels introduced)
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014po1W81GnccxF16Fuy5fom