### PR TITLE
test(e2e): update browser nav specs for AppShell navigation

### DIFF
--- a/frontend/src/components/layout/GuestTopBar.tsx
+++ b/frontend/src/components/layout/GuestTopBar.tsx
@@ -36,7 +36,11 @@ export default function GuestTopBar({ title }: GuestTopBarProps) {
       data-testid="guest-top-bar"
     >
       <div className="mx-auto flex h-12 max-w-page items-center justify-between gap-4 px-4 pt-[env(safe-area-inset-top)] sm:px-6">
-        <Link to="/dashboard" className="flex shrink-0 items-center gap-2">
+        <Link
+          to="/dashboard"
+          className="flex shrink-0 items-center gap-2"
+          data-testid="guest-top-bar-logo"
+        >
           <BrandLogo variant="monogram" />
           <BrandLogo variant="wordmark" className="hidden sm:block" />
         </Link>

--- a/tests/navigation.browser.spec.ts
+++ b/tests/navigation.browser.spec.ts
@@ -24,7 +24,8 @@ test.describe('Navigation (browser)', () => {
     await loginViaUI(page, user.email, user.password);
     await page.goto('/profile');
     await page.waitForLoadState('networkidle');
-    await page.getByTestId('nav-dashboard').click();
+    // Persistent nav moved into the AppShell top bar; the brand logo links home.
+    await page.getByTestId('guest-top-bar-logo').click();
 
     await expect(page).toHaveURL(/\/dashboard/);
   });

--- a/tests/page-loading.browser.spec.ts
+++ b/tests/page-loading.browser.spec.ts
@@ -80,8 +80,8 @@ test.describe('Page loading (browser)', () => {
     await page.goto('/coupons');
     await page.waitForLoadState('networkidle');
 
-    // Page should render without crashing (CouponWallet uses h1 heading, not <main>)
-    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({ timeout: 10000 });
+    // Page should render without crashing (AppShell provides the <main> landmark)
+    await expect(page.getByRole('main')).toBeVisible({ timeout: 10000 });
 
     expect(errors).toHaveLength(0);
   });


### PR DESCRIPTION
Fixes the two Browser E2E specs that went red after the UI overhaul moved persistent guest navigation into the `AppShell` top bar (non-gating suite, so it never blocked the deploy — this restores it to green).

## What broke & the fix
- **navigation "profile → dashboard"** clicked `nav-dashboard` (the old `DashboardButton`, removed from guest pages). Now clicks the top-bar brand logo (which links to `/dashboard`). Adds a stable `data-testid="guest-top-bar-logo"` on the logo `Link`, mirroring the existing `guest-top-bar-profile-chip`.
- **page-loading "Coupons page loads"** asserted a level-1 heading; `CouponWallet` now renders inside `AppShell`, whose `<main>` landmark is the stable render signal (matching the bookings spec).

## Verification (local, real stack on E2E ports)
- Browser project: **29 passed / 0 failed** (was 2 failed), 1 skipped.
- Frontend layout unit tests (31), `npm run lint` (+ design ratchet), `tsc --noEmit` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)