### PR TITLE
fix(backend): stop metrics recorder binding :9000 (integration-test flake)

### DIFF
--- a/backend-rust/src/routes/mod.rs
+++ b/backend-rust/src/routes/mod.rs
@@ -152,7 +152,29 @@ pub fn create_router(state: AppState) -> Router {
     // proxies `/api` and `/storage` to the backend, so `/metrics` is reachable
     // only inside the Docker network (e.g. a Prometheus sidecar scraping
     // `backend:4001/metrics`), never from the public internet.
-    let (prometheus_layer, metric_handle) = axum_prometheus::PrometheusMetricLayer::pair();
+    // Install the recorder WITHOUT the exporter's HTTP listener. The convenience
+    // `PrometheusMetricLayer::pair()` internally calls `PrometheusBuilder::build()`,
+    // whose default config binds an HTTP listener on 0.0.0.0:9000 and then hands
+    // back an exporter future that axum-prometheus discards — so the port is
+    // bound, never served (we expose metrics via the `/metrics` route below), and
+    // dropped. Harmless-looking in prod, but under parallel test processes the
+    // bind races → `FailedToCreateHTTPListener("Address already in use")` and a
+    // flaky integration-suite failure. `install_recorder()` installs the same
+    // global recorder with no listener; the layer + handle below are the exact
+    // pieces `pair()` returns (see axum-prometheus docs).
+    let metric_handle = {
+        use axum_prometheus::metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
+        PrometheusBuilder::new()
+            .upkeep_timeout(std::time::Duration::from_secs(5))
+            .set_buckets_for_metric(
+                Matcher::Full(axum_prometheus::AXUM_HTTP_REQUESTS_DURATION_SECONDS.to_string()),
+                axum_prometheus::utils::SECONDS_DURATION_BUCKETS,
+            )
+            .expect("valid metrics bucket configuration")
+            .install_recorder()
+            .expect("failed to install Prometheus recorder")
+    };
+    let prometheus_layer = axum_prometheus::PrometheusMetricLayer::new();
 
     app.layer(Extension(jwt_secret))
         .layer(prometheus_layer)


### PR DESCRIPTION
## Root cause (not the test — the app)
The intermittent CI failure `Failed to build metrics recorder: FailedToCreateHTTPListener("Address already in use (os error 98)")` — which killed whichever integration test happened to build its `TestApp` at the wrong moment (last seen: `test_update_profile`) — comes from `create_router`.

`axum_prometheus::PrometheusMetricLayer::pair()` builds its handle through `PrometheusBuilder::build()`, whose **default** exporter config binds an HTTP listener on `0.0.0.0:9000`. axum-prometheus then **discards** the exporter future, so that port is bound, never served (the app already exposes metrics via its own `/metrics` route), and dropped. Under nextest's parallel test processes, two `TestApp`s race to bind `:9000` → the panic.

So the earlier "give it a unique email / transactional DB" idea wouldn't have helped — the email was a red herring; the panic is in the metrics plumbing, and it can strike *any* TestApp-building test.

## Fix
Replace `pair()` with an explicit `PrometheusBuilder … .install_recorder()` (installs the global recorder, **no** HTTP listener), preserving the exact config `pair()` used (5s upkeep + the axum-prometheus duration-histogram buckets), paired with `PrometheusMetricLayer::new()`. Strictly better in prod too: removes a bound-then-dropped redundant listener.

## Verification (local)
- Compiles (`cargo check`).
- `/metrics` renders identical series: `axum_http_requests_total` / `_pending` / `_duration_seconds` with the same bucket boundaries.
- **Nothing listens on `:9000`** after startup (was transiently bound before).
- No dependency or SQL query changes.

CI's full nextest suite is the final proof the flake is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)