### PR TITLE
fix(frontend): migrate to react-router v8 — resolves the RSC-mode CSRF advisory

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,7 @@
         "react-hot-toast": "^2.4.1",
         "react-i18next": "^16.5.0",
         "react-icons": "^5.5.0",
-        "react-router-dom": "^7.15.0",
+        "react-router": "^8.3.0",
         "tailwind-merge": "^3.6.0",
         "zod": "^4.1.13",
         "zustand": "^4.4.7"
@@ -5912,18 +5912,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cookie": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
-      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
+    "node_modules/cookie-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-3.1.1.tgz",
+      "integrity": "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==",
+      "license": "MIT"
     },
     "node_modules/core-js-compat": {
       "version": "3.47.0",
@@ -9611,9 +9604,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -9631,16 +9624,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.8"
       }
     },
     "node_modules/react-hook-form": {
@@ -9731,41 +9724,24 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-8.3.0.tgz",
+      "integrity": "sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==",
       "license": "MIT",
       "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
+        "cookie-es": "^3.1.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.22.0"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": ">=19.2.7",
+        "react-dom": ">=19.2.7"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.18.1"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -10182,12 +10158,6 @@
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
     "react-hot-toast": "^2.4.1",
     "react-i18next": "^16.5.0",
     "react-icons": "^5.5.0",
-    "react-router-dom": "^7.15.0",
+    "react-router": "^8.3.0",
     "tailwind-merge": "^3.6.0",
     "zod": "^4.1.13",
     "zustand": "^4.4.7"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router';
 import { Toaster } from 'react-hot-toast';
 // Removed unused useTranslation import
 import { Suspense, lazy } from 'react';

--- a/frontend/src/components/admin/__tests__/AdminPortalBand.test.tsx
+++ b/frontend/src/components/admin/__tests__/AdminPortalBand.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { render, fireEvent, screen } from '@testing-library/react';
-import { MemoryRouter, useNavigate } from 'react-router-dom';
+import { MemoryRouter, useNavigate } from 'react-router';
 import AdminPortalBand from '../AdminPortalBand';
 
 const HF_BAR_SCRIPT_SELECTOR = 'script[data-hf-bar-script]';

--- a/frontend/src/components/auth/ProtectedRoute.tsx
+++ b/frontend/src/components/auth/ProtectedRoute.tsx
@@ -1,4 +1,4 @@
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, useLocation } from 'react-router';
 import { useAuthStore } from '../../store/authStore';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { logger } from '../../utils/logger';

--- a/frontend/src/components/auth/__tests__/ProtectedRoute.test.tsx
+++ b/frontend/src/components/auth/__tests__/ProtectedRoute.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
-import { BrowserRouter, MemoryRouter } from 'react-router-dom';
+import { BrowserRouter, MemoryRouter } from 'react-router';
 import ProtectedRoute from '../ProtectedRoute';
 import { useAuthStore } from '../../../store/authStore';
 
@@ -9,9 +9,9 @@ vi.mock('../../../store/authStore', () => ({
   useAuthStore: vi.fn(),
 }));
 
-// Mock react-router-dom Navigate component
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+// Mock react-router Navigate component
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     Navigate: ({ to }: { to: string }) => <div data-testid="navigate-mock">{to}</div>,

--- a/frontend/src/components/auth/__tests__/SessionManager.test.tsx
+++ b/frontend/src/components/auth/__tests__/SessionManager.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import SessionManager from '../SessionManager';
 import { useAuthStore } from '../../../store/authStore';
 import * as notificationManager from '../../../utils/notificationManager';
@@ -10,8 +10,8 @@ vi.mock('../../../store/authStore', () => ({
   useAuthStore: vi.fn(),
 }));
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => vi.fn(),

--- a/frontend/src/components/common/EmailDisplay.tsx
+++ b/frontend/src/components/common/EmailDisplay.tsx
@@ -1,5 +1,5 @@
 // React import removed as it's not needed in newer React versions
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { FiMail } from 'react-icons/fi';
 

--- a/frontend/src/components/common/__tests__/EmailDisplay.test.tsx
+++ b/frontend/src/components/common/__tests__/EmailDisplay.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import EmailDisplay from '../EmailDisplay';
 
 // Mock react-i18next

--- a/frontend/src/components/layout/AdminNavRail.tsx
+++ b/frontend/src/components/layout/AdminNavRail.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { cn } from '../ui/cn';
 

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import ProfileCompletionBanner from '../profile/ProfileCompletionBanner';
 import { BrandLogo } from '../brand/BrandLogo';

--- a/frontend/src/components/layout/GuestTabBar.tsx
+++ b/frontend/src/components/layout/GuestTabBar.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   FiHome,

--- a/frontend/src/components/layout/GuestTopBar.tsx
+++ b/frontend/src/components/layout/GuestTopBar.tsx
@@ -1,4 +1,4 @@
-import { Link, NavLink } from 'react-router-dom';
+import { Link, NavLink } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { FiUser } from 'react-icons/fi';
 import { BrandLogo } from '../brand/BrandLogo';

--- a/frontend/src/components/layout/MinimalShell.tsx
+++ b/frontend/src/components/layout/MinimalShell.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { BrandLogo } from '../brand/BrandLogo';
 import LanguageSwitcher from '../LanguageSwitcher';

--- a/frontend/src/components/layout/__tests__/AdminNavRail.test.tsx
+++ b/frontend/src/components/layout/__tests__/AdminNavRail.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import AdminNavRail from '../AdminNavRail';
 
 vi.mock('react-i18next', () => ({

--- a/frontend/src/components/layout/__tests__/AdminTopBar.test.tsx
+++ b/frontend/src/components/layout/__tests__/AdminTopBar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import AdminTopBar from '../AdminTopBar';
 
 vi.mock('react-i18next', () => ({

--- a/frontend/src/components/layout/__tests__/AppShell.test.tsx
+++ b/frontend/src/components/layout/__tests__/AppShell.test.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import AppShell from '../AppShell';
 
 vi.mock('react-i18next', () => ({

--- a/frontend/src/components/layout/__tests__/GuestTabBar.test.tsx
+++ b/frontend/src/components/layout/__tests__/GuestTabBar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import GuestTabBar from '../GuestTabBar';
 
 vi.mock('react-i18next', () => ({

--- a/frontend/src/components/layout/__tests__/GuestTopBar.test.tsx
+++ b/frontend/src/components/layout/__tests__/GuestTopBar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import GuestTopBar from '../GuestTopBar';
 
 vi.mock('react-i18next', () => ({

--- a/frontend/src/components/layout/__tests__/MinimalShell.test.tsx
+++ b/frontend/src/components/layout/__tests__/MinimalShell.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import MinimalShell from '../MinimalShell';
 
 vi.mock('react-i18next', () => ({

--- a/frontend/src/components/navigation/DashboardButton.tsx
+++ b/frontend/src/components/navigation/DashboardButton.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 
 interface DashboardButtonProps {

--- a/frontend/src/components/navigation/__tests__/DashboardButton.test.tsx
+++ b/frontend/src/components/navigation/__tests__/DashboardButton.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter } from 'react-router';
 import DashboardButton from '../DashboardButton';
 
 // Mock dependencies
@@ -14,8 +14,8 @@ const mockTranslate = vi.fn((key: string) => {
   return translations[key] || key;
 });
 
-vi.mock('react-router-dom', async () => {
-  const actual = await vi.importActual('react-router-dom');
+vi.mock('react-router', async () => {
+  const actual = await vi.importActual('react-router');
   return {
     ...actual,
     useNavigate: () => mockNavigate,

--- a/frontend/src/components/ui/PageHeader.tsx
+++ b/frontend/src/components/ui/PageHeader.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { FiChevronLeft } from 'react-icons/fi';
 import { cn } from './cn';
 

--- a/frontend/src/components/ui/TabNav.tsx
+++ b/frontend/src/components/ui/TabNav.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { NavLink } from 'react-router-dom';
+import { NavLink } from 'react-router';
 import { Badge } from './Badge';
 import { cn } from './cn';
 

--- a/frontend/src/components/ui/__tests__/PageHeader.test.tsx
+++ b/frontend/src/components/ui/__tests__/PageHeader.test.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { PageHeader } from '../PageHeader';
 import type { PageHeaderDensity } from '../PageHeader';
 

--- a/frontend/src/components/ui/__tests__/TabNav.test.tsx
+++ b/frontend/src/components/ui/__tests__/TabNav.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { TabNav } from '../TabNav';
 import type { TabItem, TabLinkItem } from '../TabNav';
 

--- a/frontend/src/hooks/useAdminPortalBand.ts
+++ b/frontend/src/hooks/useAdminPortalBand.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation } from 'react-router';
 
 const HF_BAR_HOST_ID = 'hf-bar-host';
 const HF_BAR_SCRIPT_SRC = 'https://erp.thehfhotel.org/shell/hf-bar.js';

--- a/frontend/src/hooks/useAuthRedirect.ts
+++ b/frontend/src/hooks/useAuthRedirect.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router';
 import { useAuthStore } from '../store/authStore';
 
 /**

--- a/frontend/src/hooks/useSessionTimeout.ts
+++ b/frontend/src/hooks/useSessionTimeout.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useAuthStore } from '../store/authStore';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { notify } from '../utils/notificationManager';
 
 const INACTIVITY_TIMEOUT = 30 * 60 * 1000; // 30 minutes

--- a/frontend/src/pages/BookingPage.tsx
+++ b/frontend/src/pages/BookingPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import { FiCalendar, FiUsers, FiCheck, FiUpload, FiX, FiCheckCircle, FiClock, FiAlertCircle, FiMapPin } from 'react-icons/fi';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import QRCode from 'qrcode';

--- a/frontend/src/pages/MyBookingsPage.tsx
+++ b/frontend/src/pages/MyBookingsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router';
 import { FiCalendar, FiUsers, FiStar, FiAlertCircle, FiPlus, FiChevronRight, FiX, FiUpload, FiCheckCircle, FiClock, FiDollarSign, FiDownload } from 'react-icons/fi';
 import AppShell from '../components/layout/AppShell';
 import {

--- a/frontend/src/pages/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import AppShell from '../components/layout/AppShell';
 import { Card } from '../components/ui';
 

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';

--- a/frontend/src/pages/__tests__/BookingPage.test.tsx
+++ b/frontend/src/pages/__tests__/BookingPage.test.tsx
@@ -80,7 +80,7 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-vi.mock('react-router-dom', () => ({
+vi.mock('react-router', () => ({
   useNavigate: () => vi.fn(),
 }));
 

--- a/frontend/src/pages/__tests__/DashboardPage.test.tsx
+++ b/frontend/src/pages/__tests__/DashboardPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { tierTheme } from '../../utils/tierTheme';
 

--- a/frontend/src/pages/__tests__/MyBookingsPage.test.tsx
+++ b/frontend/src/pages/__tests__/MyBookingsPage.test.tsx
@@ -164,8 +164,8 @@ vi.mock('react-i18next', () => ({
   }),
 }));
 
-// Mock react-router-dom
-vi.mock('react-router-dom', () => ({
+// Mock react-router
+vi.mock('react-router', () => ({
   Link: ({ children, to, ...props }: { children: React.ReactNode; to: string }) => (
     <a href={to} {...props}>{children}</a>
   ),

--- a/frontend/src/pages/admin/SurveyAnalytics.tsx
+++ b/frontend/src/pages/admin/SurveyAnalytics.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   FiDownload,

--- a/frontend/src/pages/admin/SurveyBuilder.tsx
+++ b/frontend/src/pages/admin/SurveyBuilder.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 // Fixed JSX warning - cache refresh trigger
-import { useNavigate, useParams, useLocation } from 'react-router-dom';
+import { useNavigate, useParams, useLocation } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { FiPlus, FiSave, FiEye } from 'react-icons/fi';
 import { Survey, SurveyQuestion, CreateSurveyRequest, QuestionType, SurveyAccessType, SurveyStatus } from '../../types/survey';

--- a/frontend/src/pages/admin/SurveyInvitations.tsx
+++ b/frontend/src/pages/admin/SurveyInvitations.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
   FiSend,

--- a/frontend/src/pages/admin/SurveyManagement.tsx
+++ b/frontend/src/pages/admin/SurveyManagement.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { FiPlus, FiEdit, FiTrash2, FiEye, FiBarChart, FiDownload, FiFileText, FiMail, FiGlobe, FiLock, FiGift } from 'react-icons/fi';
 import { Survey } from '../../types/survey';
 import { surveyService } from '../../services/surveyService';

--- a/frontend/src/pages/admin/SurveyPreview.tsx
+++ b/frontend/src/pages/admin/SurveyPreview.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { Survey } from '../../types/survey';
 import { surveyService } from '../../services/surveyService';

--- a/frontend/src/pages/admin/SurveyTemplates.tsx
+++ b/frontend/src/pages/admin/SurveyTemplates.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, type KeyboardEvent } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router';
 import {
   FiFileText,
   FiStar,

--- a/frontend/src/pages/auth/LoginPage.tsx
+++ b/frontend/src/pages/auth/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';

--- a/frontend/src/pages/auth/OAuthSuccessPage.tsx
+++ b/frontend/src/pages/auth/OAuthSuccessPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router';
 import { useAuthStore } from '../../store/authStore';
 import { notify } from '../../utils/notificationManager';
 import { API_BASE_URL } from '../../utils/apiConfig';

--- a/frontend/src/pages/auth/RegisterPage.tsx
+++ b/frontend/src/pages/auth/RegisterPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';

--- a/frontend/src/pages/auth/ResetPasswordPage.tsx
+++ b/frontend/src/pages/auth/ResetPasswordPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';

--- a/frontend/src/pages/dashboard/NavTile.tsx
+++ b/frontend/src/pages/dashboard/NavTile.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { FiChevronRight } from 'react-icons/fi';
 import { Card } from '../../components/ui/Card';

--- a/frontend/src/pages/dashboard/__tests__/NavTile.test.tsx
+++ b/frontend/src/pages/dashboard/__tests__/NavTile.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter } from 'react-router';
 import { FiCreditCard } from 'react-icons/fi';
 import NavTile from '../NavTile';
 import type { NavCardDef } from '../navCards';

--- a/frontend/src/pages/surveys/SurveyDetailsPage.tsx
+++ b/frontend/src/pages/surveys/SurveyDetailsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { FiArrowLeft, FiCalendar, FiUsers, FiEye, FiHelpCircle, FiActivity } from 'react-icons/fi';
 import { Survey } from '../../types/survey';

--- a/frontend/src/pages/surveys/SurveyList.tsx
+++ b/frontend/src/pages/surveys/SurveyList.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { FiUsers, FiEye, FiCalendar, FiRefreshCw, FiClipboard } from 'react-icons/fi';
 import { Survey } from '../../types/survey';

--- a/frontend/src/pages/surveys/TakeSurvey.tsx
+++ b/frontend/src/pages/surveys/TakeSurvey.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { SurveyQuestion } from '../../types/survey';
 import { surveyService } from '../../services/surveyService';

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -146,7 +146,7 @@ export default defineConfig({
       output: {
         manualChunks: {
           vendor: ['react', 'react-dom'],
-          router: ['react-router-dom'],
+          router: ['react-router'],
           ui: ['react-icons', 'react-hot-toast']
         }
       }


### PR DESCRIPTION
## What

Migrates `react-router-dom@7.18.1` → `react-router@8.3.0`, resolving **GHSA-qwww-vcr4-c8h2** (RSC-mode CSRF, high) — the last open Dependabot alert. No 7.x backport exists; 8.3.0 is the patched line (#321 has the full analysis).

## How

v8 removes the `react-router-dom` package; everything we use exports from `react-router`. The change is purely mechanical:
- 47 import sites + 5 vitest mocks (`vi.mock`/`vi.importActual`) + the vite `manualChunks` router entry: `'react-router-dom'` → `'react-router'`
- `package.json`: drop `react-router-dom`, add `react-router@^8.3.0`
- React 19.2.3 → 19.2.8 (v8 peer requires ≥19.2.7)

The app uses declarative mode only (`BrowserRouter`/`Routes`/`Link`/hooks) — none of the v8-removed surfaces (future flags, `meta` `data` fields, `RouterProvider`, framework mode) are in use. Baselines already met: Vite 7.3, Node ≥24, ESM fine under Vite.

## Verification (local)
- `npm run lint` — 0 errors, design ratchet OK
- `npm run typecheck` — clean
- `npm run test` — 2088/2088 passed
- `npm run build` — production build OK, router chunk emitted (43.8 kB)
- `npm audit` — **0 vulnerabilities**

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015btC9bN9T6aWu46k1oBTb1