### PR TITLE
fix(docker): refresh frontend nginx:alpine digest — clears 29 Trivy image CVEs

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -52,13 +52,13 @@ RUN test -f dist/index.html && \
 # =============================================================================
 # STAGE 3: Production runtime (nginx - minimal)
 # =============================================================================
-FROM nginx:alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa AS production
+FROM nginx:alpine@sha256:4a73073bd557c65b759505da037898b61f1be6cbcc3c2c3aeac22d2a470c1752 AS production
 
 # Refreshed base digest + apk upgrade to pull patched Alpine packages. Bumping
 # the FROM digest is what makes the upgrade effective: it invalidates the cached
-# upgrade layer so the rebuild fetches the latest libssl3/libcrypto3/libexpat
-# (resolving the OpenSSL + expat CVE cluster Trivy was flagging at 3.5.6-r0 /
-# 2.7.5-r0).
+# upgrade layer so the rebuild fetches the latest patched packages (this round:
+# libexpat 2.8.2, curl/libcurl 8.20.0, c-ares 1.34.8 — the 29-CVE cluster Trivy
+# flagged against 2.8.1-r0 / 8.19.0-r0 / 1.34.6-r0).
 RUN apk upgrade --no-cache
 
 COPY --from=builder /app/dist /usr/share/nginx/html


### PR DESCRIPTION
All 29 open Trivy code-scanning alerts against the frontend image are OS packages in the stale pinned `nginx:alpine` base: **libexpat 2.8.1-r0** (13 CVEs, 3 high), **curl/libcurl 8.19.0-r0** (16 CVEs, 4 high), **c-ares 1.34.6-r0** (1 high). All have fixed versions in current Alpine repos (2.8.2 / 8.20.0 / 1.34.8).

The Dockerfile already runs `apk upgrade --no-cache` in the production stage — but as its own comment documents, the upgrade layer is cache-keyed on the FROM digest, so refreshing the digest is what actually activates it. This bumps `54f2a904…` → `4a73073b…` (current `nginx:alpine`).

After merge, the main pipeline rebuilds and pushes the image, and the Trivy image scan (workflow_run) re-scans it — the 29 alerts auto-close once the scan sees the patched packages.

The remaining 2 code-scanning alerts (test-only RSA key in `cf_access.rs` `#[cfg(test)]`, test-harness password in `tests/common/mod.rs`) were dismissed as "used in tests" with justification comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015btC9bN9T6aWu46k1oBTb1