### PR TITLE
improve(security): Scorecard follow-ups — pin Dockerfile.ci, job-scope CI write permissions

### DIFF
--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -19,13 +19,11 @@ concurrency:
   group: ci-build-${{ github.ref }}
   cancel-in-progress: true
 
+# Keep the default token read-only; the two jobs that write (GHCR push,
+# staging-failure issue) scope their own permissions at job level.
 permissions:
   contents: read
   actions: read
-  packages: write
-  # Needed by the verify-staging-on-failure job below so a red staging
-  # deploy surfaces as a GitHub issue, not just a tab nobody opens.
-  issues: write
 
 env:
   NODE_VERSION: '24'

--- a/backend-rust/Dockerfile.ci
+++ b/backend-rust/Dockerfile.ci
@@ -46,7 +46,7 @@
 # Source is vendored inline (not COPY'd from context) because the workflow
 # build context is `./backend-binary`, which contains only the pre-built
 # loyalty-backend binary. Keep this in sync with src/bin/healthcheck.rs.
-FROM rust:1.97-slim AS hc-builder
+FROM rust:1.97-slim@sha256:5c6f46a6e4472ab1ca7ba7d494e6677f2f219ebc02f32025d3986f057635ec9c AS hc-builder
 
 WORKDIR /hc
 
@@ -109,7 +109,7 @@ RUN cargo build --release --target-dir /hc/target
 # -----------------------------------------------------------------------------
 # See the long comment in backend-rust/Dockerfile (Stage 5) for the full
 # rationale on what cc-debian12 ships and why it's safe for this binary.
-FROM gcr.io/distroless/cc-debian12 AS runner
+FROM gcr.io/distroless/cc-debian12@sha256:aa0b7af67fa8211751ea6e00baa8373ba56cc1417ffc986ec9619bd0e1556b56 AS runner
 
 WORKDIR /app
 


### PR DESCRIPTION
Fixes the 3 actionable findings from Scorecard's first run (#329):

- `backend-rust/Dockerfile.ci`: `rust:1.97-slim` and `gcr.io/distroless/cc-debian12` now digest-pinned (same digests as the main Dockerfile / Scorecard's remediation tip).
- `ci-build-e2e.yml`: top-level `packages: write` + `issues: write` removed — the Build & Push job and the staging-failure notifier already declare exactly those permissions at job level, so all other jobs drop to a read-only token.

The remaining heuristic alerts (workflow_run checkout of main-only SHAs, nginx h2c already mitigated by the `$connection_upgrade` map, root user in dev-only/nginx-master containers, path-join in repo-walking build scripts) are dismissed with per-alert justifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015btC9bN9T6aWu46k1oBTb1