### PR TITLE
fix(ci): npm ci fallback when frontend deps cache restore misses

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -86,11 +86,20 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore frontend dependencies
+        id: deps-cache
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: frontend/node_modules
           key: ${{ needs.prepare.outputs.frontend-cache-key }}
-          fail-on-cache-miss: true
+
+      # The Prepare Workspace cache save can be rejected by the Actions cache
+      # service under load ("rate limit ... unable to reserve cache"), which
+      # used to hard-fail this job via fail-on-cache-miss. Fall back to a
+      # fresh install instead — slower, but never a spurious red.
+      - name: Install frontend dependencies (cache-miss fallback)
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        working-directory: ./frontend
+        run: npm ci
 
       - name: TypeScript check
         working-directory: ./frontend
@@ -121,11 +130,20 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Restore frontend dependencies
+        id: deps-cache
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: frontend/node_modules
           key: ${{ needs.prepare.outputs.frontend-cache-key }}
-          fail-on-cache-miss: true
+
+      # The Prepare Workspace cache save can be rejected by the Actions cache
+      # service under load ("rate limit ... unable to reserve cache"), which
+      # used to hard-fail this job via fail-on-cache-miss. Fall back to a
+      # fresh install instead — slower, but never a spurious red.
+      - name: Install frontend dependencies (cache-miss fallback)
+        if: steps.deps-cache.outputs.cache-hit != 'true'
+        working-directory: ./frontend
+        run: npm ci
 
       - name: Run unit tests
         working-directory: ./frontend


### PR DESCRIPTION
The `Prepare Workspace` → downstream-jobs cache handoff breaks whenever the Actions cache service rate-limits the save ("unable to reserve cache"): `fail-on-cache-miss: true` then kills `Lint Frontend` and `Frontend Unit Tests` for reasons unrelated to the change under test. This has caused six spurious reds today across the Dependabot PR burst (each needing a manual full rerun).

Change: restore becomes best-effort, and a fallback step runs `npm ci` in `frontend/` only when the cache missed. Hot path unchanged; degraded path costs ~1 min instead of a red run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015btC9bN9T6aWu46k1oBTb1