### PR TITLE
fix(ci): implement remaining workflow audit findings + pin the deploy transport

### DIFF
--- a/.github/actions/evergreen-ssh/action.yml
+++ b/.github/actions/evergreen-ssh/action.yml
@@ -1,0 +1,63 @@
+name: "Set up SSH access to evergreen"
+description: >-
+  Install a version-pinned, checksum-verified cloudflared and write the deploy
+  key + known_hosts, ready for `ssh -o ProxyCommand="cloudflared access ssh"`.
+
+  This binary is the ProxyCommand that terminates and relays every SSH session
+  carrying production secrets (JWT/session/DB/OAuth/SMTP) and the encrypted
+  production database dump. It was previously fetched from the MUTABLE
+  `releases/latest` URL with no pin and no integrity check, at four separate
+  call sites — the one unpinned supply-chain input on the most sensitive path,
+  while every GitHub Action in the repo is SHA-pinned.
+
+  Pinning also removes an availability risk: a `releases/latest` fetch that
+  404s or rate-limits used to fail production deploys for reasons unrelated to
+  the code.
+
+  To bump: change CLOUDFLARED_VERSION below, download the asset, and record its
+  sha256 in CLOUDFLARED_SHA256. Both live here only — one file, not four.
+
+inputs:
+  ssh-key:
+    description: "Private deploy key (pass secrets.EVERGREEN_DEPLOY_SSH_KEY)."
+    required: true
+  host-key:
+    description: "known_hosts entry for evergreen (pass secrets.EVERGREEN_HOST_KEY)."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Install cloudflared (pinned + verified)
+      shell: bash
+      env:
+        CLOUDFLARED_VERSION: "2026.7.3"
+        CLOUDFLARED_SHA256: "9d71c677db00134c1bd4144b7783486b654ad281b1ea62b4972098d19f770f17"
+      run: |
+        set -euo pipefail
+        url="https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64"
+        echo "Fetching pinned cloudflared ${CLOUDFLARED_VERSION}"
+        curl -fsSL --retry 3 --retry-connrefused "$url" -o /tmp/cloudflared
+
+        # Verify BEFORE install. A mismatch means the pinned asset changed
+        # underneath us — refuse rather than run an unknown binary as the
+        # transport for production credentials.
+        echo "${CLOUDFLARED_SHA256}  /tmp/cloudflared" | sha256sum -c - || {
+          echo "::error::cloudflared checksum mismatch for ${CLOUDFLARED_VERSION}."
+          echo "Expected ${CLOUDFLARED_SHA256}, got $(sha256sum /tmp/cloudflared | cut -d' ' -f1)."
+          exit 1
+        }
+
+        sudo install -m 755 /tmp/cloudflared /usr/local/bin/cloudflared
+        cloudflared --version
+
+    - name: Install SSH key + known_hosts
+      shell: bash
+      env:
+        SSH_KEY: ${{ inputs.ssh-key }}
+        HOST_KEY: ${{ inputs.host-key }}
+      run: |
+        set -euo pipefail
+        mkdir -p ~/.ssh && chmod 700 ~/.ssh
+        printf '%s\n' "$SSH_KEY"  > ~/.ssh/deploy_key  && chmod 600 ~/.ssh/deploy_key
+        printf '%s\n' "$HOST_KEY" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts

--- a/.github/actions/start-app-stack/action.yml
+++ b/.github/actions/start-app-stack/action.yml
@@ -143,16 +143,25 @@ runs:
         # Registration is idempotent from this script's point of view: a 4xx
         # because the user already exists is fine, so failures are tolerated
         # per-user rather than failing the job.
+        # Distinguish "already exists" from "the backend is broken". Swallowing
+        # every non-2xx meant a 500 or a refused connection produced an unseeded
+        # stack and a pile of confusing auth-spec failures later, with the
+        # seeding step itself reporting success.
         seed() {
-          local email="$1" password="$2" first="$3" last="$4"
-          if curl -sf -X POST "http://localhost:${BACKEND_PORT}/api/auth/register" \
-              -H "Content-Type: application/json" \
-              -d "{\"email\":\"${email}\",\"password\":\"${password}\",\"firstName\":\"${first}\",\"lastName\":\"${last}\"}" \
-              >/dev/null; then
-            echo "Created ${email}"
-          else
-            echo "${email} may already exist"
-          fi
+          local email="$1" password="$2" first="$3" last="$4" code
+          code=$(curl -s -o /dev/null -w '%{http_code}' \
+            -X POST "http://localhost:${BACKEND_PORT}/api/auth/register" \
+            -H "Content-Type: application/json" \
+            -d "{\"email\":\"${email}\",\"password\":\"${password}\",\"firstName\":\"${first}\",\"lastName\":\"${last}\"}" \
+            || echo "000")
+
+          case "$code" in
+            2??)     echo "Created ${email}" ;;
+            409|422) echo "${email} already exists (HTTP ${code})" ;;
+            400)     echo "${email} rejected as duplicate/invalid (HTTP 400)" ;;
+            000)     echo "::error::Could not reach the backend while seeding ${email}"; return 1 ;;
+            *)       echo "::error::Seeding ${email} failed with HTTP ${code}"; return 1 ;;
+          esac
         }
 
         # Passwords are NOT uniform — the two guest users and the admin differ,

--- a/.github/workflows/backup-production.yml
+++ b/.github/workflows/backup-production.yml
@@ -17,24 +17,40 @@ name: Backup Production Database
 # Actions → Repository secrets):
 #   - EVERGREEN_DEPLOY_SSH_KEY    (existing — reused from deploy.yml)
 #   - EVERGREEN_HOST_KEY          (existing — reused from deploy.yml)
-#   - POSTGRES_USER               (existing — for pg_dump auth)
-#   - POSTGRES_PASSWORD           (existing — for pg_dump auth)
+#   - POSTGRES_USER               (existing — the role pg_dump connects as)
 #   - POSTGRES_DB                 (existing — DB name)
 #   - BACKUP_AGE_RECIPIENT        (new — age public key, single line
 #                                  starting with `age1...`)
 #   - BACKUP_S3_BUCKET            (new — bucket name)
 #   - BACKUP_S3_ENDPOINT          (new — e.g. `https://<account>.r2.cloudflarestorage.com`
 #                                  for R2, `https://s3.us-east-005.backblazeb2.com` for
-#                                  Backblaze B2, or omit for AWS S3)
+#                                  Backblaze B2, or omit for AWS S3 — OPTIONAL,
+#                                  the only one that may legitimately be empty)
 #   - BACKUP_S3_REGION            (new — e.g. `auto` for R2, `us-east-005` for B2)
 #   - BACKUP_S3_ACCESS_KEY_ID     (new)
 #   - BACKUP_S3_SECRET_ACCESS_KEY (new)
 #
-# The daily schedule is always enabled. Until the BACKUP_* secrets are wired
-# the `backup` job is cleanly SKIPPED (a green no-op with a notice) by the
-# `check-config` gate below — no nightly failures — and it starts running
-# automatically the moment the secrets land. See docs/restore-runbook.md for
-# the secret-wiring follow-up checklist.
+# POSTGRES_PASSWORD is deliberately NOT used here: pg_dump runs *inside* the
+# postgres container over the unix socket, which the image's default pg_hba
+# grants `trust` (docs/restore-runbook.md drives psql the same way, with no
+# password). The old `PGPASSWORD='…'` prefix set the environment of the docker
+# *client* — `docker exec` does not forward host env into the container, so
+# pg_dump never saw it — while putting the plaintext production DB password
+# into evergreen's process list.
+#
+# Enablement (repo Settings → Secrets and variables → Actions → Variables):
+#   - BACKUP_ENABLED = "true" once the BACKUP_* secrets are wired.
+#       unset / anything else → a missing secret SKIPS the backup with a
+#                               warning (bootstrap mode: the schedule can stay
+#                               enabled before launch without nightly reds).
+#       "true"                → a missing secret is a HARD FAILURE that files
+#                               an issue. Without this switch, a renamed or
+#                               rotated secret silently turns the nightly
+#                               backup into a permanently green no-op, which
+#                               is indistinguishable from a working backup —
+#                               and the discovery moment is a restore.
+#     Flip this to `true` in the same change that wires the secrets; see the
+#     checklist in docs/restore-runbook.md.
 
 on:
   schedule:
@@ -43,8 +59,22 @@ on:
     - cron: '0 18 * * *'
   workflow_dispatch: {}
 
+# Serialize against anything else that mutates the production database.
+# `pg_dump` holds ACCESS SHARE on every table for the full length of the
+# stream; a production deploy applies migrations at backend startup
+# (`sqlx::migrate!()`), and an ALTER/CREATE INDEX waiting on ACCESS EXCLUSIVE
+# blocks every reader queued behind it — so an overlapping dump and deploy
+# stalls live traffic until the dump finishes. That was a working-hours-only
+# risk while production required a human approver; with unattended production
+# deploys it is one timing coincidence away.
+#
+# NOTE: a concurrency group is a repo-wide name, not a per-workflow one.
+# deploy.yml's deploy-production job must join THIS SAME group for the mutual
+# exclusion to actually exist; until it does, this group only serializes
+# backup runs against each other (which is what the old `backup-production`
+# group did anyway, so nothing regresses in the meantime).
 concurrency:
-  group: backup-production
+  group: production-mutation
   cancel-in-progress: false
 
 permissions:
@@ -52,10 +82,17 @@ permissions:
   actions: read
 
 jobs:
-  # Gate the backup on whether the BACKUP_* secrets exist. This lets the daily
-  # schedule stay enabled: until the secrets are wired the backup job is
-  # skipped (a green no-op with a notice) instead of failing every night, and
-  # the moment the secrets land the daily backup starts running on its own.
+  # Gate the backup on whether EVERY required secret exists — not just two of
+  # them. A half-wired config (bucket set, credentials missing) used to pass
+  # this gate and fail 20 minutes later, after the dump had already been taken.
+  #
+  # Two modes, selected by the BACKUP_ENABLED repo variable (see header):
+  #   BACKUP_ENABLED != 'true'  → missing secrets SKIP the job (warning + step
+  #                               summary), so the daily schedule can stay
+  #                               enabled before the secrets are wired.
+  #   BACKUP_ENABLED == 'true'  → missing secrets FAIL the job, because once
+  #                               backups are declared live a silent skip is a
+  #                               data-loss risk wearing a green tick.
   check-config:
     name: "Check backup config"
     runs-on: ubuntu-latest
@@ -66,15 +103,56 @@ jobs:
       - name: Detect backup secrets
         id: check
         env:
-          BACKUP_S3_BUCKET: ${{ secrets.BACKUP_S3_BUCKET }}
-          BACKUP_AGE_RECIPIENT: ${{ secrets.BACKUP_AGE_RECIPIENT }}
+          BACKUP_ENABLED:              ${{ vars.BACKUP_ENABLED }}
+          EVERGREEN_DEPLOY_SSH_KEY:    ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
+          EVERGREEN_HOST_KEY:          ${{ secrets.EVERGREEN_HOST_KEY }}
+          POSTGRES_USER:               ${{ secrets.POSTGRES_USER }}
+          POSTGRES_DB:                 ${{ secrets.POSTGRES_DB }}
+          BACKUP_AGE_RECIPIENT:        ${{ secrets.BACKUP_AGE_RECIPIENT }}
+          BACKUP_S3_BUCKET:            ${{ secrets.BACKUP_S3_BUCKET }}
+          BACKUP_S3_REGION:            ${{ secrets.BACKUP_S3_REGION }}
+          BACKUP_S3_ACCESS_KEY_ID:     ${{ secrets.BACKUP_S3_ACCESS_KEY_ID }}
+          BACKUP_S3_SECRET_ACCESS_KEY: ${{ secrets.BACKUP_S3_SECRET_ACCESS_KEY }}
         run: |
-          if [ -n "${BACKUP_S3_BUCKET:-}" ] && [ -n "${BACKUP_AGE_RECIPIENT:-}" ]; then
+          set -euo pipefail
+
+          # BACKUP_S3_ENDPOINT is intentionally not in this list: empty means
+          # "plain AWS S3", so it cannot be distinguished from unset.
+          # A missing secret renders as an empty string, never as unset — so
+          # `-n` is the only usable check here, `-v`/`set -u` would not trip.
+          MISSING=()
+          for v in EVERGREEN_DEPLOY_SSH_KEY EVERGREEN_HOST_KEY \
+                   POSTGRES_USER POSTGRES_DB \
+                   BACKUP_AGE_RECIPIENT BACKUP_S3_BUCKET BACKUP_S3_REGION \
+                   BACKUP_S3_ACCESS_KEY_ID BACKUP_S3_SECRET_ACCESS_KEY; do
+            [ -n "${!v:-}" ] || MISSING+=("$v")
+          done
+
+          if [ ${#MISSING[@]} -eq 0 ]; then
             echo "configured=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Backup secrets not configured yet — skipping backup. Wire BACKUP_* secrets (see docs/restore-runbook.md) to enable daily backups."
-            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "All required backup secrets are present."
+            exit 0
           fi
+
+          # Not configured. Make that visible in the run itself — a scheduled
+          # run's only readers are the Actions list and this summary.
+          echo "configured=false" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Production Backup — NOT RUN"
+            echo ""
+            echo "Missing secret(s): \`${MISSING[*]}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${BACKUP_ENABLED:-}" = "true" ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "Backups are declared live (\`BACKUP_ENABLED=true\`), so this is a **failure**, not a skip." >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::Backups are enabled but required secret(s) are missing: ${MISSING[*]}"
+            exit 1
+          fi
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Bootstrap mode (\`BACKUP_ENABLED\` is not \`true\`) — skipped, not failed. Wire the secrets (see \`docs/restore-runbook.md\`), then set the \`BACKUP_ENABLED\` repo variable to \`true\`." >> "$GITHUB_STEP_SUMMARY"
+          echo "::warning::Backup secrets not configured yet (missing: ${MISSING[*]}) — skipping backup. Wire BACKUP_* secrets (see docs/restore-runbook.md) to enable daily backups."
 
   backup:
     name: "Backup Production DB"
@@ -99,29 +177,24 @@ jobs:
           age --version
           aws --version
 
-      - name: Install cloudflared
-        # Reaches evergreen via the same `asgard` tunnel the operators use
-        # for daily SSH. No CF Access app gates evergreen, so no service token.
-        run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
-            -o /tmp/cloudflared
-          sudo install -m 755 /tmp/cloudflared /usr/local/bin/cloudflared
-          cloudflared --version
+      # This job had no checkout at all; fetch just the composite action.
+      - name: Checkout SSH action
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/evergreen-ssh
+          sparse-checkout-cone-mode: false
 
-      - name: Install SSH key + known_hosts
-        env:
-          SSH_KEY:  ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
-          HOST_KEY: ${{ secrets.EVERGREEN_HOST_KEY }}
-        run: |
-          mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          printf '%s\n' "$SSH_KEY"  > ~/.ssh/deploy_key  && chmod 600 ~/.ssh/deploy_key
-          printf '%s\n' "$HOST_KEY" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+      - name: Set up SSH access to evergreen
+        uses: ./.github/actions/evergreen-ssh
+        with:
+          ssh-key: ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
+          host-key: ${{ secrets.EVERGREEN_HOST_KEY }}
 
       - name: Stream pg_dump to runner and encrypt
         id: dump
         env:
           POSTGRES_USER:        ${{ secrets.POSTGRES_USER }}
-          POSTGRES_PASSWORD:    ${{ secrets.POSTGRES_PASSWORD }}
           POSTGRES_DB:          ${{ secrets.POSTGRES_DB }}
           BACKUP_AGE_RECIPIENT: ${{ secrets.BACKUP_AGE_RECIPIENT }}
         run: |
@@ -131,20 +204,34 @@ jobs:
           echo "backup_name=$BACKUP_NAME" >> "$GITHUB_OUTPUT"
 
           # Stream pg_dump through gzip on the remote, pipe over SSH to the
-          # runner, then encrypt to disk with age. The DB password is passed
-          # over the SSH session via env so it never appears in `ps`.
+          # runner, then encrypt to disk with age — the plaintext dump never
+          # lands on either filesystem.
           #
-          # `docker compose exec -T` (no TTY) is required so the SSH stdout
-          # stays binary-clean for the gzip stream.
+          # `docker exec -i` (no TTY) is required so the SSH stdout stays
+          # binary-clean for the gzip stream.
+          #
+          # `bash -c 'set -o pipefail; …'` is load-bearing, not decoration:
+          # the local `set -o pipefail` above governs only the runner's shell.
+          # Without pipefail on the REMOTE side, `pg_dump | gzip` exits with
+          # gzip's status, and gzip writes a structurally valid trailer over a
+          # truncated stream — so a pg_dump killed mid-dump (OOM, lock or
+          # statement timeout, connection reset, disk pressure) would upload an
+          # unrestorable partial backup and report success. `bash -c` rather
+          # than a bare `set -o pipefail;` prefix because `pipefail` is not
+          # POSIX and the remote login shell is not guaranteed to be bash.
+          #
+          # No PGPASSWORD: see the header note — pg_dump authenticates over the
+          # container's unix socket (`trust`), and the old prefix leaked the
+          # production password into evergreen's argv without ever reaching
+          # pg_dump.
           ssh -i ~/.ssh/deploy_key \
               -o StrictHostKeyChecking=yes \
               -o UserKnownHostsFile=~/.ssh/known_hosts \
               -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
-              -o SendEnv=PGPASSWORD \
               deploy@evergreen.thehfhotel.org \
-              "PGPASSWORD='${POSTGRES_PASSWORD}' docker exec -i loyalty_postgres_production \
-                pg_dump -U '${POSTGRES_USER}' -d '${POSTGRES_DB}' --no-owner --no-acl \
-                | gzip -9" \
+              "bash -c 'set -o pipefail; docker exec -i loyalty_postgres_production \
+                pg_dump -U \"${POSTGRES_USER}\" -d \"${POSTGRES_DB}\" --no-owner --no-acl \
+                | gzip -9'" \
             | age --recipient "$BACKUP_AGE_RECIPIENT" --output "/tmp/$BACKUP_NAME"
 
           BACKUP_SIZE=$(stat -c%s "/tmp/$BACKUP_NAME")
@@ -177,14 +264,96 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          JOB_STATUS:   ${{ job.status }}
+          TRIGGER:      ${{ github.event_name }}
+          BACKUP_NAME:  ${{ steps.dump.outputs.backup_name }}
+          BACKUP_SIZE:  ${{ steps.dump.outputs.backup_size_bytes }}
         run: |
+          set -euo pipefail
+          # `if: always()` means this also renders for failed runs, where the
+          # dump step's outputs are empty — branch on job.status so a failure
+          # says so instead of rendering as a successful backup with blank
+          # fields. The destination bucket is a secret and this repo is public,
+          # so the summary names the variable, never its value.
           {
             echo "## Production Backup"
             echo ""
-            echo "- Trigger: \`${{ github.event_name }}\`"
-            echo "- Backup name: \`${{ steps.dump.outputs.backup_name }}\`"
-            echo "- Size: \`${{ steps.dump.outputs.backup_size_bytes }}\` bytes"
-            echo "- Destination: \`s3://\${BACKUP_S3_BUCKET}/daily/\`"
+            echo "- Trigger: \`${TRIGGER}\`"
+            if [ "$JOB_STATUS" = "success" ]; then
+              echo "- Result: **uploaded**"
+              echo "- Backup name: \`${BACKUP_NAME:-unknown}\`"
+              echo "- Size: \`${BACKUP_SIZE:-unknown}\` bytes"
+              echo "- Destination: \`daily/\` prefix of the \`BACKUP_S3_BUCKET\` bucket"
+            else
+              echo "- Result: **FAILED** (job status: \`${JOB_STATUS}\`) — no usable backup was produced by this run"
+              echo "- Dump reached: name=\`${BACKUP_NAME:-none}\` size=\`${BACKUP_SIZE:-none}\`"
+            fi
             echo ""
             echo "See \`docs/restore-runbook.md\` for restore instructions."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # File (or comment on) a GitHub issue when the nightly backup does not
+  # produce a backup. This workflow protects the only off-host copy of
+  # production data and runs at 01:00 ICT when nobody is watching; without
+  # this, an expired SSH key / renamed container / rotated S3 credential is
+  # discovered during a restore. Mirrors cargo-audit.yml's notify-on-failure.
+  notify-on-failure:
+    name: "Notify on backup failure"
+    runs-on: ubuntu-latest
+    # check-config must be in `needs` too: its hard-fail path (BACKUP_ENABLED
+    # true + a missing secret) skips `backup`, and with `needs: [backup]`
+    # alone this job would be skipped along with it.
+    needs: [check-config, backup]
+    # `cancelled()` as well as `failure()`: a run evicted from the
+    # `production-mutation` queue took no backup that night, and silence there
+    # is indistinguishable from success. A clean skip (secrets not wired,
+    # BACKUP_ENABLED not set) is neither, so it stays quiet.
+    if: failure() || cancelled()
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: File or update backup-failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPO:     ${{ github.repository }}
+          TRIGGER:  ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          TITLE="Production backup failing"
+          EXISTING=$(gh issue list -R "$REPO" \
+            --search "$TITLE in:title is:open" \
+            --json number --jq '.[0].number // empty')
+
+          BODY=$(cat <<EOF
+          The \`Backup Production Database\` workflow did not produce a backup.
+
+          - Run: $RUN_URL
+          - Triggered: \`$TRIGGER\`
+
+          This is the ONLY off-host copy of production data — until it is green
+          again there is no fresh restore point. Treat it as urgent and do not
+          close this issue until a nightly run has uploaded a dump.
+
+          Usual causes: expired \`EVERGREEN_DEPLOY_SSH_KEY\`, the postgres
+          container renamed or down, rotated \`BACKUP_S3_*\` credentials, or
+          evergreen disk/memory pressure killing \`pg_dump\` mid-stream.
+
+          See \`docs/restore-runbook.md\`.
+          EOF
+          )
+
+          if [ -n "${EXISTING:-}" ]; then
+            gh issue comment "$EXISTING" -R "$REPO" --body "$BODY"
+            echo "Updated existing issue #$EXISTING"
+          else
+            # No --label: keep this independent of label configuration; label
+            # after triage instead of depending on a label that may not exist.
+            gh issue create -R "$REPO" \
+              --title "$TITLE" \
+              --body "$BODY"
+            echo "Filed new backup-failure issue"
+          fi

--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -34,9 +34,12 @@ on:
       - 'backend-rust/Cargo.toml'
   workflow_dispatch: {}
 
+# Least privilege at workflow scope: the `audit` job only checks out code and
+# runs a third-party-installed binary over the dependency tree, so it must not
+# inherit a token that can write issues. `notify-on-failure` declares its own
+# `issues: write` at job level (see below), which is the only place it is needed.
 permissions:
   contents: read
-  issues: write
 
 jobs:
   audit:
@@ -46,14 +49,28 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
+        # NOTE: upstream publishes only branch refs (`stable`, `1.93.0`, …) and a
+        # single stale `v1` tag — there is no semver release to name here, so the
+        # trailing comment cannot be a version and Dependabot cannot bump this pin.
+        # Do NOT "fix" it to `# v1`: that tag is ~1y behind this `stable` head and
+        # re-pinning would be a downgrade. Keep in lockstep with ci-build-e2e.yml.
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable branch (toolchain set via with:)
         with:
           toolchain: '1.93'
 
       - name: Install cargo-audit
-        uses: taiki-e/install-action@b3d3b86298745e7ee31467554af349ac2c5cec48 # cargo-audit tag
+        # Pinned to the released `v2` SHA rather than the moving `cargo-audit`
+        # alias tag: Dependabot resolves a SHA pin's version from the trailing
+        # comment, so a non-version comment ("cargo-audit tag") meant this pin
+        # silently never got security updates. The alias commit differs from the
+        # release only by defaulting `tool: cargo-audit`, which is set explicitly
+        # below — so this is behaviour-identical and shares the SHA already used
+        # in ci-build-e2e.yml.
+        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2
         with:
           tool: cargo-audit
 

--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -51,6 +51,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable branch (toolchain set via with:)
@@ -104,6 +106,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable branch (toolchain set via with:)
@@ -137,7 +141,11 @@ jobs:
 
       - name: Install cargo-nextest
         if: steps.cache-nextest.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@c295c25a8d3df7288fa86db860a4f8062bf76ad8 # nextest tag
+        # Pinned to the released `v2` SHA, not the moving `nextest` alias tag:
+        # Dependabot resolves a SHA pin's version from the trailing comment, so
+        # "# nextest tag" meant this pin could never receive security updates.
+        # The alias only presets `tool: nextest`, which is set explicitly below.
+        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2
         with:
           tool: nextest
 
@@ -199,6 +207,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
@@ -224,7 +234,11 @@ jobs:
 
       - name: Install cargo-nextest
         if: steps.cache-nextest.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@c295c25a8d3df7288fa86db860a4f8062bf76ad8 # nextest tag
+        # Pinned to the released `v2` SHA, not the moving `nextest` alias tag:
+        # Dependabot resolves a SHA pin's version from the trailing comment, so
+        # "# nextest tag" meant this pin could never receive security updates.
+        # The alias only presets `tool: nextest`, which is set explicitly below.
+        uses: taiki-e/install-action@3d7d7cd5ac7f994c1892ae0c06165095b9139094 # v2
         with:
           tool: nextest
 
@@ -323,7 +337,17 @@ jobs:
   build-backend-release:
     name: "Build Backend Release"
     runs-on: ubuntu-latest
-    needs: [lint-backend]
+    # Deliberately NO `needs: [lint-backend]`. Nothing in this job consumes
+    # clippy/rustfmt output, so the edge was pure fail-fast — and it charged the
+    # deploy critical path lint's entire wall-clock on every GREEN run (measured
+    # 4m29s on run 30143612958, 66s on 30166253220). Starting the release build
+    # at t=0 removes that from every good push.
+    #
+    # It does NOT weaken the gate: lint-backend is still its own required
+    # signal, and everything downstream that can ship — `promote-latest` and
+    # `deploy-staging` — gates on the two test jobs, which keep the lint edge.
+    # So a clippy failure still turns the run red and still blocks the deploy;
+    # the only cost is building an image nobody references on an already-red push.
     timeout-minutes: 25
     container:
       image: rust:1.93-bookworm
@@ -340,6 +364,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup sccache
         uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
@@ -390,6 +416,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -417,7 +445,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/backend
           tags: |
             type=sha,format=long,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
 
       - name: Build and push backend
@@ -442,7 +469,6 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/frontend
           tags: |
             type=sha,format=long,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
 
       - name: Build and push frontend
@@ -472,6 +498,96 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.meta-frontend.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
+  # =============================================================================
+  # PROMOTE `latest` (ONLY after the gate has passed)
+  #
+  # `latest` used to be published by build-and-push, which needs only
+  # build-backend-release — so on every push to main it was re-pointed at a
+  # build whose unit tests, integration tests and API regression suite were
+  # still running (measured: ~1 minute before the gate finished).
+  #
+  # That matters because docker-compose.ghcr.yml defaults to
+  # `image: .../backend:${IMAGE_TAG:-latest}`. An operator running
+  # `docker compose up -d` without IMAGE_TAG — exactly the shape of a hurried
+  # rollback — would pull the newest UNTESTED image instead of the last
+  # known-good one. Both automated deploy paths use the immutable SHA tag and
+  # were never exposed; this closes the human/emergency path.
+  #
+  # Retag-only: imagetools re-points the manifest at the already-built SHA
+  # image, so nothing is rebuilt and `latest` is always byte-identical to a
+  # gated SHA image.
+  # =============================================================================
+
+  promote-latest:
+    name: "Promote latest tag"
+    runs-on: ubuntu-latest
+    # wait-for-frontend-checks included so `latest` means the same thing the
+    # staging deploy means: backend gate AND frontend lint/unit tests green.
+    # Without it, `latest` could advance past a commit whose frontend tests
+    # failed — precisely the "safe to roll back to" claim it is supposed to carry.
+    needs: [build-and-push, test-backend-unit, test-backend-integration, regression-api, wait-for-frontend-checks]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    timeout-minutes: 5
+    # CRITICAL: never let a cosmetic retag fail the workflow run. deploy.yml,
+    # trivy.yml and e2e.yml all gate on this workflow's CONCLUSION, so a
+    # transient GHCR 5xx here would block the production deploy, skip the image
+    # CVE scan and skip Browser E2E — and deploy.yml's tip-of-main staleness
+    # guard means a re-run after main moves cannot recover that deploy. A moving
+    # convenience tag must never sit on the production critical path.
+    continue-on-error: true
+    # Two quick merges both reach this job (main runs are never cancelled), and
+    # without a group they can interleave so the slower one lands `latest` on
+    # the OLDER commit.
+    concurrency:
+      group: promote-latest-${{ github.ref }}
+      cancel-in-progress: false
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Point latest at the gated SHA images
+        env:
+          IMAGE_BASE: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Check BOTH source tags resolve before moving either. Retagging in a
+          # bare loop meant a frontend failure left backend:latest on the new
+          # commit and frontend:latest on the old one — a split `latest` that an
+          # operator pulling both would run as a mismatched pair.
+          for img in backend frontend; do
+            docker buildx imagetools inspect "${IMAGE_BASE}/${img}:${SHA}" >/dev/null
+          done
+
+          failed=0
+          for img in backend frontend; do
+            echo "Promoting ${img}:${SHA} -> ${img}:latest"
+            docker buildx imagetools create \
+              --tag "${IMAGE_BASE}/${img}:latest" \
+              "${IMAGE_BASE}/${img}:${SHA}" || failed=1
+          done
+
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::latest promotion failed; backend/frontend may now disagree."
+            echo "Re-run this job, or promote manually, before relying on :latest."
+            exit 1
+          fi
+
+          {
+            echo "## Promoted \`latest\`"
+            echo ""
+            echo "Both images resolve to gated commit \`${SHA}\`."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # =============================================================================
   # E2E TESTS (using GHCR images)
@@ -525,6 +641,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -654,6 +772,16 @@ jobs:
     needs: [test-backend-unit, test-backend-integration, build-and-push, wait-for-frontend-checks, regression-api]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     timeout-minutes: 10
+    # `GHCR_TOKEN` below is this job's GITHUB_TOKEN; the remote shim on evergreen
+    # uses it to `docker login` + pull ghcr.io/thehfhotel/loyalty-app/*. Without
+    # an explicit grant the job inherits the workflow default (no `packages`
+    # scope) and only works because the packages are public today. deploy.yml
+    # already declares `packages: read` for the identical purpose — keep the two
+    # deploy paths on the same scope so making the packages private breaks
+    # neither.
+    permissions:
+      contents: read
+      packages: read
     environment:
       name: development
       url: http://loyalty-dev.saichon.com
@@ -662,28 +790,20 @@ jobs:
       - name: Checkout config files
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
         with:
+          persist-credentials: false
           sparse-checkout: |
+            .github/actions/evergreen-ssh
             docker-compose.yml
             docker-compose.ghcr.yml
             docker-compose.staging.yml
             nginx/nginx.conf
           sparse-checkout-cone-mode: false
 
-      - name: Install cloudflared
-        run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
-            -o /tmp/cloudflared
-          sudo install -m 755 /tmp/cloudflared /usr/local/bin/cloudflared
-          cloudflared --version
-
-      - name: Install SSH key + known_hosts
-        env:
-          SSH_KEY:  ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
-          HOST_KEY: ${{ secrets.EVERGREEN_HOST_KEY }}
-        run: |
-          mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          printf '%s\n' "$SSH_KEY"  > ~/.ssh/deploy_key  && chmod 600 ~/.ssh/deploy_key
-          printf '%s\n' "$HOST_KEY" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+      - name: Set up SSH access to evergreen
+        uses: ./.github/actions/evergreen-ssh
+        with:
+          ssh-key: ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
+          host-key: ${{ secrets.EVERGREEN_HOST_KEY }}
 
       - name: Deploy via SSH to evergreen
         env:
@@ -763,11 +883,23 @@ jobs:
               deploy@evergreen.thehfhotel.org
 
   # =============================================================================
-  # VERIFY STAGING HEALTH
+  # VERIFY STAGING HEALTH + REVISION
   #
   # Catches deploy-itself-broken cases (image won't start, migration crashes
-  # at runtime, env var missing) that pre-merge tests can't see. Polls the
-  # staging /api/health endpoint until it returns HTTP 200 or 90s elapses.
+  # at runtime, env var missing) that pre-merge tests can't see, AND the
+  # deploy-was-a-no-op case. Two assertions:
+  #
+  #   1. staging /api/health answers 200 — twice in a row, because a container
+  #      that binds the port and then crashes satisfies a single-shot check;
+  #   2. `loyalty_backend_dev` is actually running THIS commit's image.
+  #
+  # (2) matters because /api/health's `version` field is CARGO_PKG_VERSION — a
+  # hard-coded 0.1.0 identical on every commit — so a 200 proves only that
+  # *something* answers. This job's green is what deploy.yml's
+  # check-prerequisites reads to authorise the now-UNATTENDED production
+  # deploy, so "staging silently stayed on the old build" must not read as
+  # verified.
+  #
   # The matching environment URL is set on `deploy-staging` above.
   # =============================================================================
 
@@ -779,43 +911,81 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      # SSH is needed on BOTH paths now — the revision assertion below on the
+      # happy path, log capture on the failure path — so set it up up-front
+      # rather than under an `if: failure()` guard. This job has no checkout
+      # otherwise (it only curls a URL), so fetch just the composite action.
+      - name: Checkout SSH action
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/evergreen-ssh
+          sparse-checkout-cone-mode: false
+
+      - name: Set up SSH access to evergreen
+        uses: ./.github/actions/evergreen-ssh
+        with:
+          ssh-key: ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
+          host-key: ${{ secrets.EVERGREEN_HOST_KEY }}
+
       - name: Poll staging /api/health
         id: poll
         env:
           STAGING_HEALTH_URL: http://loyalty-dev.saichon.com/api/health
         run: |
           set -euo pipefail
+          # Require two CONSECUTIVE successes: the old single-shot exit passed
+          # for a backend that answered once and then crash-looped. Same 90s
+          # total budget, so this costs at most one extra 3s tick.
+          ok=0
           for attempt in $(seq 1 30); do
             if curl -fsS --max-time 5 "$STAGING_HEALTH_URL" >/dev/null; then
-              echo "Staging healthy after ${attempt} attempts"
-              exit 0
+              ok=$((ok + 1))
+              if [ "$ok" -ge 2 ]; then
+                echo "Staging healthy (2 consecutive checks) after ${attempt} attempts"
+                exit 0
+              fi
+            else
+              ok=0
             fi
             sleep 3
           done
           echo "::error::Staging /api/health not responding after 90s"
           exit 1
 
-      # The rest of this job runs only when the poll above fails, to grab
+      - name: Assert staging is running this commit's image
+        env:
+          # deploy-staging hands the shim commit_sha, which it exports as
+          # IMAGE_TAG for docker-compose.ghcr.yml
+          # (`image: .../backend:${IMAGE_TAG:-latest}`), so the running
+          # container's Config.Image is this exact string on a real deploy.
+          EXPECTED_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/backend:${{ github.sha }}
+        run: |
+          # No `-e`: an unreachable host or a missing container must produce the
+          # explanatory error below, not a bare non-zero exit.
+          set -uo pipefail
+
+          ACTUAL_IMAGE=$(ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile=~/.ssh/known_hosts \
+            -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h" \
+            -o ConnectTimeout=15 \
+            deploy@evergreen.thehfhotel.org \
+            'docker inspect -f "{{.Config.Image}}" loyalty_backend_dev' | tr -d '[:space:]') || ACTUAL_IMAGE=""
+
+          echo "expected: $EXPECTED_IMAGE"
+          echo "actual:   ${ACTUAL_IMAGE:-<could not determine>}"
+
+          if [ "$ACTUAL_IMAGE" != "$EXPECTED_IMAGE" ]; then
+            echo "::error::loyalty_backend_dev is running '${ACTUAL_IMAGE:-<could not determine>}', not this commit. Staging answered /api/health but the deploy was a no-op, partial, or overtaken — this run is NOT a verified staging release."
+            exit 1
+          fi
+          echo "Staging is running this commit's backend image"
+
+      # The rest of this job runs only when a check above fails, to grab
       # backend logs + container state from the staging host before the
       # next push overwrites them. Without this, every red verify-staging
       # is a black box.
-
-      - name: Install cloudflared (on failure)
-        if: failure()
-        run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
-            -o /tmp/cloudflared
-          sudo install -m 755 /tmp/cloudflared /usr/local/bin/cloudflared
-
-      - name: Install SSH key + known_hosts (on failure)
-        if: failure()
-        env:
-          SSH_KEY:  ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
-          HOST_KEY: ${{ secrets.EVERGREEN_HOST_KEY }}
-        run: |
-          mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          printf '%s\n' "$SSH_KEY"  > ~/.ssh/deploy_key  && chmod 600 ~/.ssh/deploy_key
-          printf '%s\n' "$HOST_KEY" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
 
       - name: Capture staging logs + container state (on failure)
         if: failure()
@@ -872,7 +1042,16 @@ jobs:
     name: "Notify on Verify Staging failure"
     runs-on: ubuntu-latest
     needs: [verify-staging]
-    if: failure() && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    # A bare `failure()` in a job-level `if` is true when ANY job in the needs
+    # ANCESTRY failed — here that is the whole pipeline (lint-backend, both test
+    # jobs, build-and-push, wait-for-frontend-checks, deploy-staging). So a
+    # clippy failure on main, which skips deploy-staging and verify-staging
+    # entirely, still filed an issue asserting staging had been deployed and was
+    # unhealthy. Nothing had been deployed; and since this job comments on the
+    # same open issue every time, a persistently red lint turned it into noise
+    # that gets muted — hiding the real failures it exists to catch. Check the
+    # one job this notifier is about, explicitly.
+    if: always() && needs.verify-staging.result == 'failure' && github.ref == 'refs/heads/main' && github.event_name == 'push'
     timeout-minutes: 5
     permissions:
       contents: read
@@ -897,10 +1076,18 @@ jobs:
           - Commit: \`${{ github.sha }}\`
           - Author: @${{ github.actor }}
 
-          Staging is now in an undefined state (the new image is up but
-          \`/api/health\` is not responding). Investigate:
-          1. Open the run log linked above for the failing curl attempts.
-          2. SSH to evergreen and check container status / backend logs.
+          The deploy ran, but staging did not verify. \`Verify Staging\` has two
+          checks and the run log says which one failed:
+          - \`/api/health\` never answered 200 twice in a row → the new image is
+            up but not serving (crash loop, bad migration, missing env var).
+          - \`loyalty_backend_dev\` is not running this commit's image → the
+            deploy was a no-op, partial, or overtaken; staging is still on an
+            older build and must NOT be treated as verified.
+
+          Investigate:
+          1. Open the run log linked above to see which check failed.
+          2. Download the \`staging-failure-logs-*\` artifact (container state +
+             backend/postgres/nginx logs captured from evergreen).
           3. Roll back via \`docs/rollback-runbook.md\` if root cause is not
              a quick fix.
           EOF

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -13,7 +13,14 @@ on:
     branches: [main]
 
 concurrency:
-  group: ${{ github.actor == 'dependabot[bot]' && 'dependabot-ci-test' || format('ci-test-{0}', github.ref) }}
+  # Keyed on the ref ONLY — never on the actor. The previous group collapsed to
+  # the literal 'dependabot-ci-test' for every Dependabot run, so with
+  # cancel-in-progress every newly-opened or rebased Dependabot PR evicted the
+  # in-flight CI Tests run of every *other* open Dependabot PR. The victim was
+  # left with a `cancelled` (not `success`) required check and needed a manual
+  # UI re-run. Matches ci-build-e2e.yml's `ci-build-${{ github.ref }}` so both
+  # workflows agree on which run is authoritative for a given PR.
+  group: ci-test-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -26,76 +33,54 @@ env:
 
 jobs:
   # =============================================================================
-  # WORKSPACE PREPARATION (Node.js only)
+  # FRONTEND VALIDATION & TESTING (Node.js only)
   #
   # Backend (Rust) validation, lint, and build have moved to ci-build-e2e.yml so
   # that the single Rust toolchain pass produces the release binary directly,
   # sharing one target/ cache with build & deploy. See PR consolidating CI.
-  # =============================================================================
-
-  prepare:
-    name: "Prepare Workspace"
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      frontend-cache-key: ${{ steps.cache-keys.outputs.frontend }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Generate cache keys
-        id: cache-keys
-        run: |
-          echo "frontend=frontend-deps-${{ hashFiles('frontend/package-lock.json') }}" >> $GITHUB_OUTPUT
-
-      - name: Cache frontend dependencies
-        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
-        with:
-          path: frontend/node_modules
-          key: ${{ steps.cache-keys.outputs.frontend }}
-          restore-keys: |
-            frontend-deps-
-
-      - name: Install frontend dependencies
-        working-directory: ./frontend
-        run: npm ci
-
-  # =============================================================================
-  # FRONTEND VALIDATION & TESTING
+  #
+  # There is deliberately NO "Prepare Workspace" job. Its only product was a
+  # warmed frontend/node_modules cache, but both consumers already fall back to
+  # a full `npm ci` on a cache miss (see the fallback steps below), so it bought
+  # each of them a ~40s install at the price of a serial runner hop (~1-2 min)
+  # sitting on the deploy critical path — ci-build-e2e.yml's
+  # wait-for-frontend-checks blocks staging until this whole workflow finishes.
+  # The two jobs now derive the identical cache key inline and start in parallel
+  # at t=0; whichever finishes first saves the cache, and the loser's save is a
+  # warning inside actions/cache, never a job failure.
   # =============================================================================
 
   lint-frontend:
     name: "Lint Frontend"
     runs-on: ubuntu-latest
-    needs: prepare
     timeout-minutes: 5
 
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      # Same key in both frontend jobs, computed inline from the lockfile so
+      # neither job has to wait on a producer job. No `restore-keys:` on
+      # purpose — a partial-match tree is unconditionally deleted by the `npm
+      # ci` below, so pulling one down is pure download time.
       - name: Restore frontend dependencies
         id: deps-cache
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: frontend/node_modules
-          key: ${{ needs.prepare.outputs.frontend-cache-key }}
+          key: frontend-deps-${{ hashFiles('frontend/package-lock.json') }}
 
-      # The Prepare Workspace cache save can be rejected by the Actions cache
-      # service under load ("rate limit ... unable to reserve cache"), which
-      # used to hard-fail this job via fail-on-cache-miss. Fall back to a
-      # fresh install instead — slower, but never a spurious red.
+      # The cache save can be rejected by the Actions cache service under load
+      # ("rate limit ... unable to reserve cache"), which used to hard-fail this
+      # job via fail-on-cache-miss. Fall back to a fresh install instead —
+      # slower, but never a spurious red.
       - name: Install frontend dependencies (cache-miss fallback)
         if: steps.deps-cache.outputs.cache-hit != 'true'
         working-directory: ./frontend
@@ -131,29 +116,34 @@ jobs:
   test-frontend-unit:
     name: "Frontend Unit Tests"
     runs-on: ubuntu-latest
-    needs: prepare
     timeout-minutes: 10
 
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 
+      # Same key in both frontend jobs, computed inline from the lockfile so
+      # neither job has to wait on a producer job. No `restore-keys:` on
+      # purpose — a partial-match tree is unconditionally deleted by the `npm
+      # ci` below, so pulling one down is pure download time.
       - name: Restore frontend dependencies
         id: deps-cache
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: frontend/node_modules
-          key: ${{ needs.prepare.outputs.frontend-cache-key }}
+          key: frontend-deps-${{ hashFiles('frontend/package-lock.json') }}
 
-      # The Prepare Workspace cache save can be rejected by the Actions cache
-      # service under load ("rate limit ... unable to reserve cache"), which
-      # used to hard-fail this job via fail-on-cache-miss. Fall back to a
-      # fresh install instead — slower, but never a spurious red.
+      # The cache save can be rejected by the Actions cache service under load
+      # ("rate limit ... unable to reserve cache"), which used to hard-fail this
+      # job via fail-on-cache-miss. Fall back to a fresh install instead —
+      # slower, but never a spurious red.
       - name: Install frontend dependencies (cache-miss fallback)
         if: steps.deps-cache.outputs.cache-hit != 'true'
         working-directory: ./frontend

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,8 +36,17 @@ on:
     - cron: '23 4 * * 1'  # weekly, Monday 04:23 UTC
 
 concurrency:
-  group: codeql-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # PR runs are keyed by ref so a rebase/force-push supersedes its own stale
+  # analysis. push and schedule runs are keyed by COMMIT (and by event, so the
+  # Monday cron never shares a slot with a merge): `github.ref` is
+  # `refs/heads/main` for both, and a static group evicts the *pending* run when
+  # a third trigger arrives even with cancel-in-progress: false — which is how
+  # commit 6fc61ddd ended up with no code-scanning analysis at all. Per-commit
+  # groups mean main and cron analyses always complete.
+  group: codeql-${{ github.event_name }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  # Only a superseded PR run is safe to cancel; a cancelled main/cron run leaves
+  # that commit unanalysed with no red signal to say so.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Least-privilege default for the workflow; the analyze job below elevates only
 # to what CodeQL needs (security-events: write). Keeping an explicit top-level
@@ -49,7 +58,11 @@ jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # build-mode: none means no compilation, so the slowest observed leg is ~2m
+    # (rust). 20 min is ~9x that — ample for a cold CodeQL bundle download —
+    # while capping a hung extractor at a fifth of an hour instead of the 2
+    # runner-hours the previous 120 allowed, on a workflow that fires ~25x/day.
+    timeout-minutes: 20
 
     permissions:
       security-events: write   # upload SARIF code-scanning results
@@ -71,14 +84,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,13 +18,14 @@ concurrency:
   group: deploy
   cancel-in-progress: false
 
+# Keep the default token read-only, like ci-build-e2e.yml. `issues: write`
+# lives on notify-on-failure and `packages: read` on deploy-production, at job
+# level: deploy-production pipes GITHUB_TOKEN over SSH to evergreen so the
+# remote shim can pull from GHCR, and a token that leaves the CI boundary must
+# carry no repo-write capability.
 permissions:
   contents: read
   actions: read
-  packages: read
-  # Needed by `notify-on-failure` so a red prod deploy surfaces as a
-  # GitHub issue. The Actions tab is not a paging channel.
-  issues: write
 
 env:
   REGISTRY: ghcr.io
@@ -51,7 +52,9 @@ jobs:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push'
-    timeout-minutes: 5
+    # Generous enough to cover the ci-test.yml poll below (72 x 10s) without
+    # the job being killed mid-wait, which would read as a failed deploy.
+    timeout-minutes: 15
     outputs:
       should-deploy: ${{ steps.check.outputs.ready }}
       commit-sha: ${{ steps.check.outputs.sha }}
@@ -67,18 +70,60 @@ jobs:
           echo "Checking deploy preconditions for commit: $SHA"
           echo "sha=$SHA" >> "$GITHUB_OUTPUT"
 
+          # Assert that THIS build actually put the commit on staging and found
+          # it healthy. The `event == 'push'` job guard above stops a
+          # workflow_dispatch (whose staging jobs are push-only, hence skipped)
+          # from reaching production, but a partial "re-run failed jobs" can
+          # still conclude `success` with the staging jobs missing. A skipped
+          # job does not change a workflow's conclusion, so the trigger's
+          # conclusion alone proves nothing about staging.
+          RUN_ID="${{ github.event.workflow_run.id }}"
+          STAGING=$(gh run view "$RUN_ID" -R "${{ github.repository }}" \
+            --json jobs --jq '.jobs[] | select(.name == "Verify Staging") | .conclusion')
+          echo "CI Build & Deploy run $RUN_ID -> Verify Staging: ${STAGING:-absent}"
+
+          if [ "$STAGING" != "success" ]; then
+            echo "::error::Run $RUN_ID did not deploy and verify staging for $SHA (Verify Staging=${STAGING:-absent})."
+            echo "Refusing to promote an unverified commit to production."
+            exit 1
+          fi
+
           # Defence-in-depth: CI Build & Deploy's wait-for-frontend-checks job
           # already fails closed on ci-test.yml, but verify independently so
           # removing that job can never silently un-gate production.
-          TEST_STATUS=$(gh run list -R "${{ github.repository }}" \
-            --workflow=ci-test.yml --branch=main --commit="$SHA" \
-            --json conclusion --jq '.[0].conclusion // "pending"')
-          echo "CI Tests status: $TEST_STATUS"
+          #
+          # Poll rather than sample once (same loop as ci-build-e2e.yml's
+          # wait-for-frontend-checks): a one-shot read of an in-progress run
+          # yields conclusion "" and would fail a deploy that is merely early.
+          # Selecting `status` too is what makes "not finished yet" (retry)
+          # distinguishable from "finished badly" (abort) — `.conclusion //
+          # "pending"` alone never fires, because in-flight runs return an
+          # empty string, not null.
+          TEST_STATUS=""
+          for attempt in $(seq 1 72); do
+            TEST_STATUS=$(gh run list -R "${{ github.repository }}" \
+              --workflow=ci-test.yml --branch=main --commit="$SHA" \
+              --json conclusion,status --jq '.[0] | "\(.status):\(.conclusion // "pending")"')
+            echo "Attempt $attempt: CI Tests = ${TEST_STATUS:-no-run-yet}"
 
-          if [ "$TEST_STATUS" != "success" ]; then
-            echo "::error::CI Tests did not succeed for $SHA (status=$TEST_STATUS)."
-            echo "Refusing to deploy. Failing loudly rather than skipping, so a"
-            echo "non-deploy can never be reported as a green run."
+            case "$TEST_STATUS" in
+              completed:success)
+                break
+                ;;
+              completed:*)
+                echo "::error::CI Tests did not succeed for $SHA (status=$TEST_STATUS)."
+                echo "Refusing to deploy. Failing loudly rather than skipping, so a"
+                echo "non-deploy can never be reported as a green run."
+                exit 1
+                ;;
+              *)
+                sleep 10
+                ;;
+            esac
+          done
+
+          if [ "$TEST_STATUS" != "completed:success" ]; then
+            echo "::error::Timed out waiting for CI Tests to complete for $SHA (last status=${TEST_STATUS:-no-run-yet})."
             exit 1
           fi
 
@@ -103,7 +148,8 @@ jobs:
           echo "ready=true" >> "$GITHUB_OUTPUT"
 
   # =============================================================================
-  # DEPLOY TO PRODUCTION (requires approval)
+  # DEPLOY TO PRODUCTION (unattended — the `production` environment no longer
+  # has a required reviewer, so check-prerequisites above is the only gate)
   # =============================================================================
 
   deploy-production:
@@ -112,6 +158,21 @@ jobs:
     needs: [check-prerequisites]
     if: needs.check-prerequisites.outputs.should-deploy == 'true'
     timeout-minutes: 10
+    # Shares the `production-mutation` group with backup-production.yml so the
+    # nightly pg_dump and a production deploy can never overlap. Concurrency
+    # groups are repo-wide strings, so BOTH sides must name it — the backup
+    # workflow alone bought nothing. Without this, a deploy that applies a
+    # migration mid-dump yields a backup spanning two schema versions, which is
+    # exactly the backup you would reach for after a bad migration.
+    concurrency:
+      group: production-mutation
+      cancel-in-progress: false
+    # Least privilege: GITHUB_TOKEN is handed to the remote shim on evergreen
+    # (see GHCR_TOKEN below), so it gets exactly what a `docker pull` from GHCR
+    # needs — plus contents:read for the sparse checkout. Nothing writable.
+    permissions:
+      contents: read
+      packages: read
     environment:
       name: production
       url: https://loyalty.saichon.com
@@ -120,31 +181,21 @@ jobs:
       - name: Checkout config files
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
         with:
+          persist-credentials: false
           ref: ${{ needs.check-prerequisites.outputs.commit-sha }}
           sparse-checkout: |
+            .github/actions/evergreen-ssh
             docker-compose.yml
             docker-compose.ghcr.yml
             docker-compose.prod.yml
             nginx/nginx.conf
           sparse-checkout-cone-mode: false
 
-      - name: Install cloudflared
-        # Reaches evergreen via the same `asgard` tunnel the operators use
-        # for daily SSH. No CF Access app gates evergreen, so no service token.
-        run: |
-          curl -fsSL https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64 \
-            -o /tmp/cloudflared
-          sudo install -m 755 /tmp/cloudflared /usr/local/bin/cloudflared
-          cloudflared --version
-
-      - name: Install SSH key + known_hosts
-        env:
-          SSH_KEY:  ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
-          HOST_KEY: ${{ secrets.EVERGREEN_HOST_KEY }}
-        run: |
-          mkdir -p ~/.ssh && chmod 700 ~/.ssh
-          printf '%s\n' "$SSH_KEY"  > ~/.ssh/deploy_key  && chmod 600 ~/.ssh/deploy_key
-          printf '%s\n' "$HOST_KEY" > ~/.ssh/known_hosts && chmod 600 ~/.ssh/known_hosts
+      - name: Set up SSH access to evergreen
+        uses: ./.github/actions/evergreen-ssh
+        with:
+          ssh-key: ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
+          host-key: ${{ secrets.EVERGREEN_HOST_KEY }}
 
       - name: Deploy via SSH to evergreen
         env:
@@ -176,6 +227,23 @@ jobs:
           IMAP_PASS:            ${{ secrets.IMAP_PASS }}
         run: |
           set -euo pipefail
+
+          # A `${{ secrets.X }}` that does not exist renders as an empty string
+          # and the env var is still SET, so `set -u` never trips on it. Without
+          # this guard a deleted/renamed/rotated secret ships a well-formed
+          # payload carrying JWT_SECRET="" and the shim writes an empty signing
+          # key into production — green run, broken auth. Fail before touching
+          # the host. SMTP/IMAP are deliberately absent: they are optional and
+          # use `${VAR:-}` defaults below.
+          for v in JWT_SECRET JWT_REFRESH_SECRET SESSION_SECRET DATABASE_URL \
+                   POSTGRES_USER POSTGRES_PASSWORD POSTGRES_DB \
+                   GHCR_TOKEN; do
+            if [ -z "${!v:-}" ]; then
+              echo "::error::Required secret $v is empty or unset — aborting production deploy."
+              exit 1
+            fi
+          done
+
           tar -czf /tmp/deploy.tar.gz \
             docker-compose.yml docker-compose.ghcr.yml docker-compose.prod.yml \
             nginx/nginx.conf

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,9 @@
 name: Browser E2E
 
-# Full browser end-to-end suite (Playwright `browser` project — *.browser.spec.ts).
+# Browser end-to-end suite: everything that needs a real browser and is
+# therefore excluded from the deploy gate — the `browser` (*.browser.spec.ts)
+# and `browser-mobile` (*.mobile.spec.ts) projects, plus the OAuth *validation*
+# api specs that launch a browser despite living in the `api` project.
 #
 # This pipeline intentionally does NOT gate deployment. The deploy path
 # (ci-build-e2e.yml -> deploy.yml) is gated by the no-browser API
@@ -14,8 +17,8 @@ name: Browser E2E
 # Triggers:
 #   - workflow_run: after "CI Build & Deploy" finishes on main, against the
 #     images that run just pushed to GHCR (tagged with the commit SHA).
-#   - workflow_dispatch / schedule: run against the :latest images on demand
-#     or nightly.
+#   - workflow_dispatch / schedule: run on demand or nightly against the last
+#     commit whose build succeeded (specs and image always the same commit).
 
 on:
   workflow_run:
@@ -29,10 +32,21 @@ on:
         required: false
         default: 'latest'
   schedule:
-    - cron: '17 3 * * *'  # nightly at 03:17 UTC
+    # Nightly at 03:17 UTC. `Resolve target commit` below pins the specs AND
+    # the image to the last successfully-built main commit, so the nightly can
+    # never run new specs against an older image.
+    - cron: '17 3 * * *'
 
+# Keyed per commit. A constant group here was repo-global, and GitHub keeps at
+# most ONE pending run per group: a third trigger (post-merge workflow_run, the
+# nightly cron, a manual dispatch) silently CANCELLED the queued one. A
+# cancelled run is neither pass nor fail, so the browser net quietly developed
+# holes on the busiest days. Nothing is actually shared between runs — each gets
+# its own runner, its own postgres/redis service containers and its own host
+# ports — so different commits can run in parallel. `cancel-in-progress: false`
+# stays so a re-run of the SAME commit queues instead of clobbering.
 concurrency:
-  group: browser-e2e
+  group: browser-e2e-${{ github.event.workflow_run.head_sha || github.sha }}
   cancel-in-progress: false
 
 permissions:
@@ -50,7 +64,19 @@ jobs:
     runs-on: ubuntu-latest
     # Skip when the upstream build did not succeed (cron / manual runs have no
     # workflow_run context and always proceed).
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    #
+    # The `event == 'push'` + same-repository checks are the real trust boundary
+    # for the checkout below, NOT the `branches: [main]` filter: that filter
+    # matches `workflow_run.head_branch`, which for a fork pull request is the
+    # branch name *inside the fork* — a fork whose default branch is `main`
+    # passes it. ci-build-e2e.yml does run on `pull_request`, so such a
+    # workflow_run exists. These two conditions are what guarantee `head_sha` is
+    # a commit already merged into this repo's `main`.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
     timeout-minutes: 30
 
     services:
@@ -79,13 +105,62 @@ jobs:
           --health-retries 5
 
     steps:
-      # The workflow_run trigger is filtered to branches: [main], so head_sha
-      # is always an already-merged main commit — never untrusted PR code.
+      # Safe because the job `if:` above requires the upstream run to be a
+      # `push` event from THIS repository (see the comment there) — head_sha is
+      # therefore an already-merged main commit, never untrusted fork PR code.
+      # The `branches: [main]` trigger filter alone does NOT establish that.
+      #
+      # Resolve ONE commit used for BOTH the specs and the image. Previously a
+      # scheduled run checked out main's tip but pulled `:latest`. That was
+      # harmless while `latest` moved at build time, but `latest` is now
+      # promoted only after the gate passes, so it lags main whenever the gate
+      # fails — and the nightly would then run NEW specs against an OLD image,
+      # failing for reasons that are not regressions and filing an issue every
+      # night. Pinning both to the last successfully-built commit removes the
+      # skew entirely.
+      - name: Resolve target commit
+        id: target
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WR_SHA: ${{ github.event.workflow_run.head_sha }}
+          INPUT_TAG: ${{ github.event.inputs.image_tag }}
+        run: |
+          set -euo pipefail
+          if [ -n "${WR_SHA:-}" ]; then
+            # Triggered by a build: test exactly what it produced.
+            echo "sha=$WR_SHA" >> "$GITHUB_OUTPUT"
+            echo "tag=$WR_SHA" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "${INPUT_TAG:-}" ] && [ "${INPUT_TAG}" != "latest" ]; then
+            # Explicit manual override wins; check out main tip for the specs.
+            echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            echo "tag=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Nightly / manual-with-latest: use the newest main commit whose
+          # build actually succeeded, so specs and image are the same commit.
+          SHA=$(gh run list -R "${{ github.repository }}" \
+                  --workflow=ci-build-e2e.yml --branch=main --event=push \
+                  --status=success --limit 1 --json headSha --jq '.[0].headSha // empty')
+          if [ -z "$SHA" ]; then
+            echo "::warning::No successful CI Build & Deploy run found; falling back to :latest"
+            echo "sha=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "Using last successfully-built commit: $SHA"
+            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+            echo "tag=$SHA" >> "$GITHUB_OUTPUT"
+          fi
+
       # nosemgrep: yaml.github-actions.security.workflow-run-target-code-checkout.workflow-run-target-code-checkout
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          persist-credentials: false
+          ref: ${{ steps.target.outputs.sha }}
 
       - name: Resolve Playwright image from lockfile
         # Pin the Playwright container to the EXACT @playwright/test version in
@@ -124,20 +199,6 @@ jobs:
           echo "::error::No usable Playwright container image found"
           exit 1
 
-      - name: Resolve image tag
-        id: tag
-        env:
-          WR_SHA: ${{ github.event.workflow_run.head_sha }}
-          INPUT_TAG: ${{ github.event.inputs.image_tag }}
-        run: |
-          if [ -n "${WR_SHA:-}" ]; then
-            echo "tag=$WR_SHA" >> "$GITHUB_OUTPUT"
-          elif [ -n "${INPUT_TAG:-}" ]; then
-            echo "tag=$INPUT_TAG" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=latest" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -145,33 +206,61 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Shared with ci-build-e2e.yml's regression-api job. Unlike that job,
-      # this one can run against `latest` (nightly/manual), so the tag is
-      # whatever `Resolve image tag` produced.
+      # Shared with ci-build-e2e.yml's regression-api job. The tag always
+      # matches the checked-out commit (see `Resolve target commit`).
       - name: Start app stack
         uses: ./.github/actions/start-app-stack
         with:
-          image-tag: ${{ steps.tag.outputs.tag }}
+          image-tag: ${{ steps.target.outputs.tag }}
 
-      - name: Run full E2E suite (Playwright container, pre-baked browsers)
-        # Run the COMPLETE suite (api + browser projects, including the
-        # browser-launching oauth-validation specs) inside the official
-        # Playwright image (browsers already installed) on the host network so
-        # the tests reach the app on localhost. No cdn.playwright.dev download
-        # happens on the exact-match path. When pwimage fell back to an older
-        # image (MCR publish lag), the pre-baked browser revisions don't match
-        # the @playwright/test runner, so install matching browsers first —
-        # a CDN download, but only in the degraded window, and better than 25
-        # guaranteed "Executable doesn't exist" failures.
+      - name: Run browser E2E suite (Playwright container, pre-baked browsers)
+        # Runs inside the official Playwright image (browsers already installed)
+        # on the host network so the tests reach the app on localhost. No
+        # cdn.playwright.dev download happens on the exact-match path. When
+        # pwimage fell back to an older image (MCR publish lag), the pre-baked
+        # browser revisions don't match the @playwright/test runner, so install
+        # matching browsers first — a CDN download, but only in the degraded
+        # window, and better than 25 guaranteed "Executable doesn't exist"
+        # failures.
+        #
+        # --ipc=host is a Playwright-documented requirement for Chromium in
+        # Docker: renderer shared memory lives in /dev/shm, which defaults to
+        # 64 MB in a container, and with 2 workers it runs out mid-test. That
+        # surfaces as "Target crashed" / "Target page ... has been closed" and
+        # reads like a product bug — the most likely mechanical cause of the
+        # flakiness that got this suite demoted to non-gating. --init reaps
+        # orphaned browser processes.
+        #
+        # Project selection is the exact COMPLEMENT of the deploy gate:
+        # ci-build-e2e.yml's regression-api already ran
+        # `--project=api --grep-invert "OAuth (Flow|Security) Validation"`
+        # against the same-SHA images minutes earlier. Re-running the whole api
+        # project here would execute ~12 spec files twice per commit (inside a
+        # container that also pays an uncached `npm ci`) and would let a
+        # non-browser flake paint "Browser E2E" red — training people to ignore
+        # the reds. What's left for this workflow is the browser projects plus
+        # the OAuth *validation* api specs, which the gate greps out precisely
+        # because they launch a real browser.
         run: |
-          docker run --rm --network host \
+          docker run --rm --init --ipc=host --network host \
             -v "${{ github.workspace }}:/work" -w /work \
             -e CI=true \
             -e PW_EXACT_IMAGE='${{ steps.pwimage.outputs.exact }}' \
             -e BACKEND_URL=http://localhost:4202 \
             -e FRONTEND_URL=http://localhost:3201 \
             ${{ steps.pwimage.outputs.image }} \
-            bash -lc "npm ci && if [ \"\$PW_EXACT_IMAGE\" != true ]; then npx playwright install --with-deps; fi && npx playwright test"
+            bash -lc '
+              set -euo pipefail
+              npm ci
+              if [ "$PW_EXACT_IMAGE" != true ]; then npx playwright install --with-deps; fi
+              # Run BOTH selections unconditionally (no && short-circuit) so a
+              # red browser project never hides the OAuth results; the step
+              # still fails if either did, since the worst exit code wins.
+              rc=0
+              npx playwright test --project=browser --project=browser-mobile || rc=$?
+              npx playwright test --project=api --grep "OAuth (Flow|Security) Validation" || rc=$?
+              exit $rc
+            '
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -235,3 +324,57 @@ jobs:
           else
             gh issue create -R "${{ github.repository }}" --title "$TITLE" --body "$BODY"
           fi
+
+  # =============================================================================
+  # RUN SUMMARY
+  #
+  # browser-e2e is this workflow's only test job, and its `if:` guard skips it
+  # whenever the upstream CI Build & Deploy did not conclude `success` — which
+  # includes `cancelled`, a routine outcome since ci-build-e2e cancels
+  # superseded non-main runs. A run whose only job SKIPPED still concludes
+  # SUCCESS, so "Browser E2E" shows a green check for a commit where zero
+  # browser tests executed, and the missing-run gap is invisible.
+  #
+  # Failing closed is wrong here (this suite must never block shipping), so
+  # instead make the green auditable: every run states in its summary which of
+  # the two it was.
+  # =============================================================================
+
+  run-summary:
+    name: "Run summary"
+    runs-on: ubuntu-latest
+    needs: [browser-e2e]
+    if: always()
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Record whether the browser suite actually ran
+        env:
+          RESULT: ${{ needs.browser-e2e.result }}
+          TRIGGER: ${{ github.event_name }}
+          UPSTREAM_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          UPSTREAM_EVENT: ${{ github.event.workflow_run.event }}
+          UPSTREAM_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Browser E2E"
+            echo ""
+            echo "- Trigger: \`${TRIGGER}\`"
+            echo "- Commit: \`${COMMIT_SHA}\`"
+            if [ "$RESULT" = "skipped" ]; then
+              echo ""
+              echo "**SKIPPED — no browser test executed in this run.**"
+              echo ""
+              echo "- Upstream CI Build & Deploy conclusion: \`${UPSTREAM_CONCLUSION:-n/a}\` (must be \`success\`)"
+              echo "- Upstream event: \`${UPSTREAM_EVENT:-n/a}\` (must be \`push\`)"
+              echo "- Upstream head repository: \`${UPSTREAM_REPO:-n/a}\` (must be \`${GITHUB_REPOSITORY}\`)"
+              echo ""
+              echo "This run is green because nothing ran, not because browsers passed."
+            else
+              echo ""
+              echo "Browser suite executed — result: \`${RESULT}\`."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,8 +17,16 @@ on:
     # Weekly, Monday 09:30 UTC (16:30 ICT) — same quiet window as the
     # other scheduled scans.
     - cron: '30 9 * * 1'
-  push:
-    branches: [main]
+  # Deliberately NOT on `push: main`: Scorecard grades repository
+  # *configuration* (branch protection, token permissions, dependency
+  # pinning, maintenance signals), which an ordinary code merge cannot
+  # change — so a run per merge only re-published the same score the weekly
+  # cron already publishes. The one thing a merge *can* change that
+  # Scorecard grades is a workflow file (unpinned action, over-broad token),
+  # and that is caught on the same commit by CodeQL's `actions` pack, which
+  # does run on every push and PR. Both remaining automatic triggers
+  # (branch_protection_rule, schedule) are publish_results-supported
+  # default-branch events, so the public OpenSSF badge keeps updating.
   workflow_dispatch: {}
 
 permissions: read-all
@@ -28,11 +36,23 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # A job-level block REPLACES the workflow-level `read-all` above (it is
+    # not additive), so every scope scorecard-action documents has to be
+    # re-stated here — same reason codeql.yml re-declares contents/actions.
+    # Without them the job token is contents=none/actions=none: checkout
+    # cannot fetch, and the checks that read workflow-run metadata
+    # (Dangerous-Workflow, Token-Permissions, Pinned-Dependencies, CI-Tests)
+    # degrade to inconclusive — which publish_results would then push to the
+    # public API as an apparently clean score.
     permissions:
       # Upload SARIF to code scanning.
       security-events: write
       # OIDC token so scorecard can publish verified results.
       id-token: write
+      # Clone the repo (actions/checkout) and read repo metadata.
+      contents: read
+      # Read workflow run/definition metadata for the CI-oriented checks.
+      actions: read
 
     steps:
       - name: Checkout code
@@ -48,6 +68,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: results.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -19,7 +19,23 @@ on:
     - cron: '0 10 * * 1'
   push:
     branches: [main]
+    # A docs-only merge can't change what p/default finds in code, so don't
+    # spend a full repo scan on it. Unlike ci-test.yml / ci-build-e2e.yml this
+    # list deliberately does NOT ignore '.github/workflows/**': p/default
+    # includes the yaml.github-actions.security rules, so a workflow-only
+    # change is exactly the kind of push this scanner must still see.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch: {}
+
+# Back-to-back merges otherwise stack full 15-minute scans that compete for the
+# same Actions queue. Keyed on the event as well as the ref so a Monday-morning
+# push can't cancel the weekly cron run — that run is the only one that
+# re-evaluates unchanged code against a refreshed ruleset.
+concurrency:
+  group: semgrep-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -30,7 +46,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     container:
-      image: semgrep/semgrep:1.171.0
+      # Digest-pinned, not tag-pinned: this container IS the execution
+      # environment for a job holding security-events: write, so a re-pushed
+      # tag would run attacker code with a token that can forge or suppress
+      # code-scanning results. Same convention as the SHA-pinned actions below
+      # and the pinned Dockerfile.ci images (e833a8b7). Bump digest + comment
+      # together.
+      image: semgrep/semgrep@sha256:bdf7013b2c3634a487671158da77c554f531742326b543a9464d2adf6c433ac8 # 1.171.0
     permissions:
       contents: read
       security-events: write
@@ -45,7 +67,7 @@ jobs:
         run: semgrep scan --config p/default --sarif --output semgrep.sarif --metrics=off
 
       - name: Upload SARIF to code scanning
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: semgrep.sarif
           category: semgrep

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,9 +1,15 @@
 # Trivy Container Security Scanner
 # Scans Docker images for vulnerabilities in OS packages and dependencies.
 #
-# Image scans run AFTER "CI Build & E2E" succeeds, reusing the GHCR images it
+# Image scans run AFTER "CI Build & Deploy" succeeds, reusing the GHCR images it
 # pushed (~30s pull) instead of rebuilding from Dockerfiles (~6 minutes).
-# Filesystem scan still runs on PRs/pushes/cron for source-level CVE coverage.
+#
+# The filesystem scan runs in two modes:
+#   * on pull_request  — BLOCKING table scan (exit-code 1) so a dependency with
+#     a fixable CRITICAL/HIGH CVE cannot merge. `main` has no branch protection
+#     and production deploys unattended, so post-merge is too late for the
+#     first signal.
+#   * after CI Build & Deploy / weekly cron — SARIF upload to code scanning.
 
 name: Trivy Container Scan
 
@@ -12,8 +18,18 @@ on:
     workflows: ["CI Build & Deploy"]
     types: [completed]
     branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: '28 5 * * 6'  # Weekly on Saturday
+
+concurrency:
+  # Key on the commit under scan so runs for different commits never evict each
+  # other: a static group keeps only ONE pending run and cancels the older one,
+  # which is where this repo's unexplained "cancelled" runs come from. PR runs
+  # key on the ref instead, so a new push supersedes its own in-flight scan.
+  group: trivy-${{ github.event_name == 'pull_request' && github.ref || github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -25,9 +41,11 @@ env:
 
 jobs:
   scan-backend:
-    # Skip if the upstream "CI Build & E2E" run did not succeed; cron runs
-    # always proceed (workflow_run context is absent there).
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Run only where a published GHCR image exists: after a SUCCESSFUL
+    # "CI Build & Deploy", or on the weekly cron (which scans :latest).
+    # Never on pull_request — no image is pushed for a PR SHA, so the job
+    # would only fail on `docker pull`.
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'schedule'
     permissions:
       contents: read
       security-events: write
@@ -35,10 +53,14 @@ jobs:
       packages: read
     name: Scan Backend Image
     runs-on: ubuntu-latest
+    # A hung `docker pull` or a stalled Trivy DB fetch would otherwise run to
+    # GitHub's 6h default before failing.
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
         with:
+          persist-credentials: false
           # workflow_run checks out the DEFAULT BRANCH TIP, not the commit that
           # triggered it, so scans and their SARIF were attributed to the wrong
           # commit whenever main moved on during the build.
@@ -75,13 +97,14 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: 'trivy-backend-results.sarif'
           category: 'trivy-backend'
 
   scan-frontend:
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    # Same gate as scan-backend: image-bearing events only.
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || github.event_name == 'schedule'
     permissions:
       contents: read
       security-events: write
@@ -89,10 +112,12 @@ jobs:
       packages: read
     name: Scan Frontend Image
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
         with:
+          persist-credentials: false
           # workflow_run checks out the DEFAULT BRANCH TIP, not the commit that
           # triggered it, so scans and their SARIF were attributed to the wrong
           # commit whenever main moved on during the build.
@@ -129,28 +154,60 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: 'trivy-frontend-results.sarif'
           category: 'trivy-frontend'
 
   scan-filesystem:
+    # Same upstream-success guard as the image jobs. Without it a failed or
+    # concurrency-cancelled "CI Build & Deploy" still uploaded a
+    # `trivy-filesystem` SARIF, overwriting the last good analysis for that
+    # category with results from a build that produced nothing. Pre-merge
+    # coverage no longer depends on this path — the pull_request run below does
+    # that job.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     permissions:
       contents: read
       security-events: write
       actions: read
     name: Scan Filesystem (Dependencies)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
         with:
+          persist-credentials: false
           # workflow_run checks out the DEFAULT BRANCH TIP, not the commit that
           # triggered it, so scans and their SARIF were attributed to the wrong
           # commit whenever main moved on during the build.
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      # PR path — a real blocking check, not a report. No SARIF upload here:
+      # Dependabot-actored runs get a read-only GITHUB_TOKEN, which would fail
+      # the upload and paint every Dependabot PR red for an unrelated reason
+      # (the same trap semgrep.yml documents).
+      - name: Run Trivy filesystem scanner (blocking)
+        if: github.event_name == 'pull_request'
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
+        with:
+          scan-type: 'fs'
+          scan-ref: '.'
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          # Only block on CVEs that have a fix available; an unfixable upstream
+          # advisory must not wedge every PR in the repo.
+          ignore-unfixed: true
+          # Vulnerabilities only. The default `vuln,secret` set would match the
+          # RSA PEM test fixtures in backend-rust (cf_access.rs /
+          # cf_access_test.rs) as HIGH secrets and fail every PR on day one.
+          # Secret findings still reach code scanning via the SARIF path below.
+          scanners: 'vuln'
+          exit-code: '1'
+
       - name: Run Trivy filesystem scanner
+        if: github.event_name != 'pull_request'
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
         with:
           scan-type: 'fs'
@@ -160,7 +217,8 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        if: github.event_name != 'pull_request'
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           sarif_file: 'trivy-fs-results.sarif'
           category: 'trivy-filesystem'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,12 @@ Before wiring a new frontend call:
 ## CI/CD
 
 Workflows fire on push to `main`:
-- `ci-test.yml` — frontend lint + frontend unit tests (Prepare Workspace
-  + Lint Frontend + Frontend Unit Tests).
+- `ci-test.yml` — Lint Frontend (typecheck + ESLint at a
+  `--max-warnings` ratchet + the test-integrity guard) and Frontend Unit
+  Tests, running in parallel. There is deliberately no "Prepare
+  Workspace" job: both jobs derive the same cache key inline and fall
+  back to `npm ci` on a miss, so the serial hop it added to the deploy
+  critical path bought nothing.
 - `ci-build-e2e.yml` (named **CI Build & Deploy**) — Lint Backend (Rust) →
   parallel (Test Backend Unit, Test Backend Integration, Build Backend
   Release) → Build & Push to GHCR → **Regression & Smoke (API)** +
@@ -159,9 +163,21 @@ Workflows fire on push to `main`:
   (and nightly / on demand) and **does NOT gate deployment** — a flaky
   browser/CDN issue must never block shipping. Treat a red Browser E2E
   as a signal to investigate, not a deploy blocker.
-- `trivy.yml` — Filesystem scan on push; backend/frontend image scans
-  triggered by `workflow_run` from `ci-build-e2e.yml` (`CI Build &
-  Deploy`; pulls images from GHCR instead of rebuilding).
+- `trivy.yml` — filesystem dependency scan (blocking on PRs, so a
+  fixable CRITICAL/HIGH shows red before merge); backend/frontend image
+  scans triggered by `workflow_run` from `ci-build-e2e.yml` (`CI Build &
+  Deploy`; pulls images from GHCR instead of rebuilding) and are
+  informational, since the image has already shipped by then.
+- `scorecard.yml` / `semgrep.yml` / `codeql.yml` / `cargo-audit.yml` —
+  non-gating security scanners. `cargo-audit` also runs on
+  `backend-rust/Cargo.{lock,toml}` changes so a vulnerable crate cannot
+  merge and auto-deploy inside the daily cron window.
+- `backup-production.yml` — nightly production `pg_dump`. It shares the
+  `production-mutation` concurrency group with `deploy.yml`, so a deploy
+  can never apply a migration mid-dump. Set the repo variable
+  `BACKUP_ENABLED=true` once the `BACKUP_*` secrets are wired: until
+  then missing secrets only *skip* the job, and after it they *fail* it
+  (a nightly backup that silently no-ops is worse than none).
 
 Production deploys live in `deploy.yml` and are **unattended** — the
 `production` environment no longer has a required reviewer, so a green

--- a/scripts/validate-workflow.sh
+++ b/scripts/validate-workflow.sh
@@ -88,15 +88,43 @@ for workflow in $WORKFLOW_FILES; do
         echo "$OUTPUT" | while IFS= read -r line; do
             if [[ $line == *"error"* ]]; then
                 echo -e "  ${RED}ERROR: $line${NC}"
-                ((ERRORS++))
+                ERRORS=$((ERRORS + 1))
             else
                 echo -e "  ${YELLOW}WARNING: $line${NC}"
-                ((WARNINGS++))
+                WARNINGS=$((WARNINGS + 1))
             fi
         done
     fi
     echo ""
 done
+
+# ----------------------------------------------------------------------------
+# Local composite actions must exist AND be tracked by git.
+#
+# `uses: ./.github/actions/x` is resolved from the checked-out tree at RUNTIME.
+# actionlint validates the path on disk, so an action that exists locally but
+# was never `git add`ed passes every local check and then fails on the runner
+# with "Can't find 'action.yml'" — simultaneously, in every job that uses it
+# (production deploy, staging deploy, nightly DB backup). Catch it here.
+# ----------------------------------------------------------------------------
+echo "🔗 Checking local composite action references..."
+for ref in $(grep -rhoE "uses:\s*\./[A-Za-z0-9_./-]+" .github/workflows/*.yml | sed -E 's|uses:[[:space:]]*\./||' | sort -u); do
+    found=""
+    for candidate in "$ref/action.yml" "$ref/action.yaml" "$ref"; do
+        [ -f "$candidate" ] && { found="$candidate"; break; }
+    done
+
+    if [ -z "$found" ]; then
+        echo -e "  ${RED}ERROR: local action './$ref' referenced but no action.yml on disk${NC}"
+        ERRORS=$((ERRORS + 1))
+    elif ! git ls-files --error-unmatch "$found" >/dev/null 2>&1; then
+        echo -e "  ${RED}ERROR: '$found' exists but is UNTRACKED — commit it or the runner cannot resolve it${NC}"
+        ERRORS=$((ERRORS + 1))
+    else
+        echo -e "  ${GREEN}ok${NC} ./$ref"
+    fi
+done
+echo ""
 
 # Summary
 echo "===================================="


### PR DESCRIPTION
Closes out [`docs/workflow-review-2026-07.md`](docs/workflow-review-2026-07.md): **32 of the 34 remaining findings** implemented (2 skipped with reasons below), plus the two items flagged as highest-value next.

Implemented by 10 agents on disjoint files, then adversarially reviewed — **the review found 3 blockers in my own earlier work**, all fixed here.

## Supply chain

- **`.github/actions/evergreen-ssh`** — version-pinned (`2026.7.3`) and **sha256-verified** cloudflared + SSH bootstrap, replacing four inlined copies that fetched from the *mutable* `releases/latest` URL with no integrity check. That binary is the `ProxyCommand` carrying every production secret and the entire production DB dump — the one unpinned input on the most sensitive path, while every Action in the repo is SHA-pinned.
- **All 20 `actions/checkout` steps now set `persist-credentials: false`.** Two jobs gained a checkout to reach the composite, and the default leaves a repo token in `.git/config` for the rest of the job — in `backup-production` that meant a token on disk *while the production database streamed through the runner*.
- `codeql-action` unified on one v4 commit (`init`/`analyze` were **7 months behind** `upload-sarif`); `taiki-e/install-action@nextest` alias pins collapsed onto the v2 SHA — Dependabot can't resolve a version from a non-semver comment, so those never received updates.

## `latest` no longer moves before the gate

- Removed `type=raw,value=latest` from `build-and-push`; added **`promote-latest`** gated on backend tests + `regression-api` + `wait-for-frontend-checks`. `docker-compose.ghcr.yml` defaults to `:latest`, so an operator redeploy — the shape of a hurried rollback — used to pull the newest **untested** image.
- **`continue-on-error` + its own concurrency group.** `deploy.yml`, `trivy.yml` and `e2e.yml` all gate on this workflow's *conclusion*, so a transient GHCR blip during a cosmetic retag would have blocked the production deploy, skipped the image CVE scan and skipped Browser E2E — unrecoverable once the tip-of-main guard rejects a re-run.
- Both source tags verified before either moves, so a mid-loop failure can't split `latest` across two commits.
- **`e2e.yml` resolves one commit for both specs and image.** It checked out main's tip while pulling `:latest` — harmless when `latest` moved at build time, but it now lags whenever the gate fails, so the nightly would run new specs against an old image and file a failure issue *every night*.

## Mutual exclusion

`deploy-production` joins `backup-production`'s `production-mutation` group. Concurrency groups are repo-wide strings, so the backup side alone bought nothing: a deploy applying a migration mid-`pg_dump` yields a backup spanning two schema versions — exactly the backup you'd reach for after a bad migration.

## Tooling

`scripts/validate-workflow.sh` had `((ERRORS++))` under `set -e`, so on bash ≥4.1 it **aborted at its first finding and never printed its summary** — silently useless on Linux (same defect class as `validate-test-integrity.sh` in b478fe3a; that's now two scripts). Also added a guard asserting every `uses: ./...` local action **exists and is git-tracked** — an untracked composite passes actionlint and then fails at runtime in *every* job at once, including production deploy. It caught exactly that during this work.

## Skipped
- **#40** — superseded by the `promote-latest` + single-commit-resolution work above.
- **#43** — the real defect was in `start-app-stack`'s `seed()` helper, fixed here instead: it returned success for *any* curl failure, so a 500 or refused connection produced an unseeded stack and confusing auth failures much later.

## Verification
- `actionlint` — **0 structural findings**
- All workflow + action YAML parses; every embedded `run` block passes `bash -n`
- `scripts/validate-workflow.sh` exits 0 under bash 5.3
- Gate wiring re-checked programmatically: `deploy-staging` still needs `regression-api`; `deploy.yml` still **fails** rather than skips

## Needs a human action after merge
Set repo variable **`BACKUP_ENABLED=true`** once the `BACKUP_*` secrets are wired. Until then a missing secret only *skips* the nightly backup; after it, it *fails* — a backup that silently no-ops is worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015btC9bN9T6aWu46k1oBTb1