### PR TITLE
fix(ci): remove the untrusted-code checkout from trivy instead of guarding it

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -14,9 +14,18 @@
 name: Trivy Container Scan
 
 on:
+  # Image scans need a published GHCR image, so they hang off the build.
   workflow_run:
     workflows: ["CI Build & Deploy"]
     types: [completed]
+    branches: [main]
+  # The FILESYSTEM scan reads source, not images, so it runs directly on the
+  # commit. That keeps its checkout on the default ref for the event — no
+  # `ref: workflow_run.head_sha`, which is what made this an untrusted-code
+  # checkout in a job holding `security-events: write` (Scorecard flagged it
+  # Critical, and correctly: the guards made it safe in practice but the
+  # pattern remained).
+  push:
     branches: [main]
   pull_request:
     branches: [main]
@@ -70,19 +79,6 @@ jobs:
     # GitHub's 6h default before failing.
     timeout-minutes: 20
     steps:
-      # Safe because the job `if:` above requires the upstream run to be a
-      # `push` from THIS repository, so head_sha is an already-merged main
-      # commit — never untrusted fork PR code.
-      # nosemgrep: yaml.github-actions.security.workflow-run-target-code-checkout.workflow-run-target-code-checkout
-      - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
-        with:
-          persist-credentials: false
-          # workflow_run checks out the DEFAULT BRANCH TIP, not the commit that
-          # triggered it, so scans and their SARIF were attributed to the wrong
-          # commit whenever main moved on during the build.
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -144,19 +140,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      # Safe because the job `if:` above requires the upstream run to be a
-      # `push` from THIS repository, so head_sha is an already-merged main
-      # commit — never untrusted fork PR code.
-      # nosemgrep: yaml.github-actions.security.workflow-run-target-code-checkout.workflow-run-target-code-checkout
-      - name: Checkout code
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
-        with:
-          persist-credentials: false
-          # workflow_run checks out the DEFAULT BRANCH TIP, not the commit that
-          # triggered it, so scans and their SARIF were attributed to the wrong
-          # commit whenever main moved on during the build.
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -194,45 +177,18 @@ jobs:
           category: 'trivy-frontend'
 
   scan-filesystem:
-    # Same upstream-success guard as the image jobs. Without it a failed or
-    # concurrency-cancelled "CI Build & Deploy" still uploaded a
-    # `trivy-filesystem` SARIF, overwriting the last good analysis for that
-    # category with results from a build that produced nothing. Pre-merge
-    # coverage no longer depends on this path — the pull_request run below does
-    # that job.
-    # The `event == 'push'` + same-repository checks are the real trust
-    # boundary for the `ref:` checkout below, NOT the `branches: [main]`
-    # trigger filter: that filter matches `workflow_run.head_branch`, which
-    # for a fork pull request is the branch name *inside the fork* — a fork
-    # whose default branch is `main` passes it. ci-build-e2e.yml does run on
-    # `pull_request`, so such a workflow_run exists. Without these two
-    # conditions this job would check out untrusted fork code while holding
-    # `security-events: write` (Scorecard: Dangerous-Workflow).
-    if: >-
-      github.event_name != 'workflow_run' ||
-      (github.event.workflow_run.conclusion == 'success' &&
-       github.event.workflow_run.event == 'push' &&
-       github.event.workflow_run.head_repository.full_name == github.repository)
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
-    name: Scan Filesystem (Dependencies)
+    # Runs on push/pull_request/schedule — never on workflow_run. It scans the
+    # source tree, so it does not need to wait for an image build, and driving
+    # it directly off the commit means the SARIF is attributed to the commit
+    # actually scanned instead of whatever main happened to be at.
+    if: github.event_name != 'workflow_run'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      # Safe because the job `if:` above requires the upstream run to be a
-      # `push` from THIS repository, so head_sha is an already-merged main
-      # commit — never untrusted fork PR code.
-      # nosemgrep: yaml.github-actions.security.workflow-run-target-code-checkout.workflow-run-target-code-checkout
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
         with:
           persist-credentials: false
-          # workflow_run checks out the DEFAULT BRANCH TIP, not the commit that
-          # triggered it, so scans and their SARIF were attributed to the wrong
-          # commit whenever main moved on during the build.
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       # PR path — a real blocking check, not a report. No SARIF upload here:
       # Dependabot-actored runs get a read-only GITHUB_TOKEN, which would fail


### PR DESCRIPTION
Scorecard re-opened three Critical Dangerous-Workflow alerts (#1480–#1482) right after the guards added in #341 — it closed the old ones as "fixed" and immediately filed new ones for the same pattern.

**It's right to.** Those guards do make the pattern safe in practice, but Scorecard's check is static: it sees `ref: ${{ github.event.workflow_run.head_sha }}` in a `workflow_run` job holding `security-events: write` and scores 0 without evaluating `if:` conditions. Annotating around a finding that keeps re-firing is the wrong answer when **the checkout wasn't needed in the first place**.

## Changes

- **`scan-backend` / `scan-frontend`: checkout deleted.** These jobs log in, resolve an image reference from the event context, pull from GHCR, and scan it — they never read a repo file. The checkout was pure liability: untrusted code on disk in a privileged job, for nothing.
- **`scan-filesystem`** genuinely needs source, so it now runs on `push` / `pull_request` / `schedule` and **never on `workflow_run`**. Driving it off the commit directly means its checkout uses the event's default ref, and the SARIF is attributed to the commit actually scanned — which is the same wrong-commit bug #339 set out to fix, now solved without touching `head_sha` at all.

## Result

Zero `head_sha` checkouts in this workflow and **zero `nosemgrep` suppressions** — the pattern is gone, not annotated. Main-branch filesystem coverage is preserved by the new `push` trigger; image coverage is unchanged.

## A correction worth recording

My earlier "0 semgrep findings" verification used local semgrep **1.136.0**, while CI runs the pinned **1.171.0** container with additional rules — which is why CI reported 13 results when local reported 0. (Those 13 are ~10 `nosemgrep`-suppressed findings, which SARIF reports as suppressions, plus the 3 open trivy ones this PR removes.) A clean local scan is weaker evidence than a clean CI run; the commit message records that for next time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015btC9bN9T6aWu46k1oBTb1