### PR TITLE
fix(ops): backup unit could never start on evergreen (snap docker)

### DIFF
--- a/docs/restore-runbook.md
+++ b/docs/restore-runbook.md
@@ -66,6 +66,28 @@ The age **private** key stays on the operator's machine at
 **If it is lost, every backup is unreadable** — store a copy in a password
 manager, not only on one laptop.
 
+### Host requirements
+
+Verified on evergreen (Ubuntu 24.04, snap-packaged Docker 29.x, systemd). Two
+things about that host shaped the unit and are worth knowing if it is ever
+rebuilt or the backup is moved elsewhere:
+
+- Docker is **snap**-packaged, so its unit is `snap.docker.dockerd.service`,
+  not `docker.service`, and its binary lives in `/snap/bin` which is absent
+  from systemd's default `PATH`. The unit therefore sets `PATH` explicitly and
+  uses soft `After=` ordering against both possible unit names — a `Requires=`
+  on a non-existent unit makes systemd refuse to start the backup at all.
+- `NoNewPrivileges=` must **not** be set: snap confinement needs privilege
+  transitions, and with it enabled every run fails with
+  `container 'loyalty_postgres_production' not found`. `PrivateTmp`,
+  `ProtectSystem=strict` and `ProtectHome` were each tested individually and
+  are fine.
+
+A harmless warning appears in the journal on every run:
+`cannot create user data directory: cannot create snap home dir: mkdir
+/root/snap: read-only file system`. That is snap wanting a home dir under the
+`ProtectSystem=strict` read-only tree; the dump succeeds regardless.
+
 ### Verify it works
 
 ```bash

--- a/scripts/evergreen/install.sh
+++ b/scripts/evergreen/install.sh
@@ -40,8 +40,9 @@ fi
 command -v docker >/dev/null || { echo "docker is required but not installed" >&2; exit 1; }
 
 echo "==> Scripts"
-fetch backup-loyalty-db.sh    /usr/local/bin/backup-loyalty-db.sh    755
-fetch loyalty-backup-alert.sh /usr/local/bin/loyalty-backup-alert.sh 755
+fetch backup-loyalty-db.sh          /usr/local/bin/backup-loyalty-db.sh          755
+fetch loyalty-backup-alert.sh       /usr/local/bin/loyalty-backup-alert.sh       755
+fetch loyalty-backup-notify-email.sh /usr/local/bin/loyalty-backup-notify-email.sh 755
 
 echo "==> systemd units"
 fetch loyalty-backup.service          /etc/systemd/system/loyalty-backup.service          644

--- a/scripts/evergreen/loyalty-backup-notify-email.sh
+++ b/scripts/evergreen/loyalty-backup-notify-email.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Email transport for backup failure alerts. Set as ALERT_COMMAND in
+# /etc/loyalty-backup.conf; the alert text arrives on stdin.
+#
+#   ALERT_COMMAND=/usr/local/bin/loyalty-backup-notify-email.sh
+#
+# Credentials come from /etc/loyalty-backup.conf (root-only, mode 600) rather
+# than from the running backend container. That is deliberate: the alert must
+# still work when the app is down — which is exactly the situation where a
+# backup is most likely to have failed.
+#
+# Uses curl's SMTP support; no MTA is installed on evergreen.
+
+set -euo pipefail
+
+CONFIG_FILE="${LOYALTY_BACKUP_CONFIG:-/etc/loyalty-backup.conf}"
+# shellcheck source=/dev/null
+[ -r "$CONFIG_FILE" ] && . "$CONFIG_FILE"
+
+: "${SMTP_HOST:?SMTP_HOST not set in $CONFIG_FILE}"
+: "${SMTP_PORT:=465}"
+: "${SMTP_USER:?SMTP_USER not set in $CONFIG_FILE}"
+: "${SMTP_PASS:?SMTP_PASS not set in $CONFIG_FILE}"
+: "${ALERT_EMAIL_TO:?ALERT_EMAIL_TO not set in $CONFIG_FILE}"
+: "${ALERT_EMAIL_FROM:=$SMTP_USER}"
+
+BODY="$(cat)"
+[ -n "$BODY" ] || BODY="(no alert body received on stdin)"
+
+# 465 is implicit TLS (smtps://); 587 is STARTTLS on a plain smtp:// URL.
+if [ "$SMTP_PORT" = "465" ]; then
+  URL="smtps://${SMTP_HOST}:${SMTP_PORT}"
+else
+  URL="smtp://${SMTP_HOST}:${SMTP_PORT}"
+fi
+
+MAIL_FILE="$(mktemp)"
+trap 'rm -f "$MAIL_FILE"' EXIT
+chmod 600 "$MAIL_FILE"
+
+{
+  printf 'From: %s\r\n' "$ALERT_EMAIL_FROM"
+  printf 'To: %s\r\n' "$ALERT_EMAIL_TO"
+  printf 'Subject: [loyalty] PRODUCTION BACKUP FAILED on %s\r\n' "$(hostname)"
+  printf 'Date: %s\r\n' "$(date -R)"
+  printf 'Content-Type: text/plain; charset=UTF-8\r\n'
+  printf '\r\n'
+  printf '%s\r\n' "$BODY"
+} > "$MAIL_FILE"
+
+# --silent --show-error: quiet on success, loud on failure. The exit status is
+# what loyalty-backup-alert.sh checks to decide whether the alert got out.
+curl --silent --show-error --ssl-reqd \
+     --url "$URL" \
+     --user "${SMTP_USER}:${SMTP_PASS}" \
+     --mail-from "$ALERT_EMAIL_FROM" \
+     --mail-rcpt "$ALERT_EMAIL_TO" \
+     --upload-file "$MAIL_FILE" \
+     --max-time 60
+
+echo "Alert emailed to ${ALERT_EMAIL_TO}"

--- a/scripts/evergreen/loyalty-backup.conf.example
+++ b/scripts/evergreen/loyalty-backup.conf.example
@@ -26,7 +26,30 @@ AGE_RECIPIENT="age18sdlft5g3rnwlyhshykht3s9gmydylallnvmkmrr4ms3g08pfvmss5qm0k"
 # text arrives on stdin. Without this, failures are only visible in the journal
 # and in $BACKUP_DIR/LAST-FAILURE.
 #
-#   ALERT_COMMAND='mail -s "loyalty backup FAILED" ops@thehfhotel.org'
+# The bundled email transport needs no MTA (evergreen has none) — it sends via
+# curl over SMTPS. Fill in the SMTP block below and point ALERT_COMMAND at it:
+#
+#   ALERT_COMMAND=/usr/local/bin/loyalty-backup-notify-email.sh
+#
+# Any other command works too; the alert text arrives on stdin:
+#
 #   ALERT_COMMAND='curl -sS -X POST --data-binary @- https://hooks.example/backup'
 #
 #ALERT_COMMAND=''
+
+# --- SMTP, used only by loyalty-backup-notify-email.sh ---
+#
+# Credentials are duplicated here rather than read from the running backend
+# container on purpose: the alert must still send when the app is DOWN, which
+# is exactly when a backup is most likely to have failed.
+#
+# Port 465 = implicit TLS (smtps://); 587 = STARTTLS. Note the sending address
+# must be one the mailbox actually owns — an alias will be refused with
+# `553 ... Sender address rejected: not owned by user`.
+#
+#SMTP_HOST=""
+#SMTP_PORT="465"
+#SMTP_USER=""
+#SMTP_PASS=""
+#ALERT_EMAIL_TO=""
+#ALERT_EMAIL_FROM=""     # defaults to SMTP_USER

--- a/scripts/evergreen/loyalty-backup.service
+++ b/scripts/evergreen/loyalty-backup.service
@@ -1,14 +1,21 @@
 [Unit]
 Description=Encrypted nightly backup of the loyalty production database
 Documentation=https://github.com/thehfhotel/loyalty-app/blob/main/docs/restore-runbook.md
-# Do not start if docker is not up — a failure here should mean "the backup
-# broke", not "the host was still booting".
-After=docker.service
-Requires=docker.service
+# Soft ordering only — NO Requires=. Docker may be packaged as docker.service
+# (apt) or snap.docker.dockerd.service (snap); a Requires= naming a unit that
+# does not exist on the host makes systemd refuse to start this one at all
+# ("Unit docker.service not found"), which is exactly what happened on
+# evergreen. The script itself hard-fails if docker is unreachable, and that is
+# the check that actually matters.
+After=network-online.target docker.service snap.docker.dockerd.service
+Wants=network-online.target
 OnFailure=loyalty-backup-failure@%n.service
 
 [Service]
 Type=oneshot
+# /snap/bin is NOT in systemd's default PATH, so a snap-packaged docker is
+# invisible to this unit without it.
+Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin
 ExecStart=/usr/local/bin/backup-loyalty-db.sh
 # The dump is IO-heavy; keep it from starving the app it is backing up.
 Nice=10
@@ -18,7 +25,12 @@ TimeoutStartSec=3600
 
 # Hardening: this unit needs docker's socket and its own backup directory,
 # nothing else.
-NoNewPrivileges=true
+#
+# NoNewPrivileges is deliberately absent. Snap-packaged docker needs privilege
+# transitions for its confinement, and with NoNewPrivileges=true the wrapper
+# cannot reach the daemon — every backup fails with "container not found".
+# Verified per-option on evergreen: PrivateTmp / ProtectSystem=strict /
+# ProtectHome are all fine with snap docker; only NoNewPrivileges breaks it.
 PrivateTmp=true
 ProtectSystem=strict
 ProtectHome=true


### PR DESCRIPTION
Installing the backup on evergreen surfaced **two defects that no local validation would have caught** — both only appear where Docker is snap-packaged, which evergreen is.

## The bugs

1. **`Requires=docker.service`** — that unit doesn't exist there (snap uses `snap.docker.dockerd.service`). systemd refused to start the backup at all: *"Unit docker.service not found"*, exit 5, before the script ran a single line. Now soft `After=` listing both names, no `Requires=`; the script already hard-fails if docker is unreachable.

2. **`NoNewPrivileges=true`** — snap confinement needs privilege transitions, so the docker wrapper couldn't reach the daemon and every run died with *"container 'loyalty_postgres_production' not found"* while the container was up and healthy. Each sandbox option was then tested individually with `systemd-run`:

   | Option | Result |
   |---|---|
   | `NoNewPrivileges=yes` | **BREAKS** |
   | `PrivateTmp=yes` | OK |
   | `ProtectSystem=strict` | OK |
   | `ProtectHome=yes` | OK |

   Dropped, with the reasoning in the unit so nobody hardens it back.

Also sets an explicit `PATH` including `/snap/bin`, absent from systemd's default.

The committed unit is now byte-identical (comments aside) to the one running on evergreen.

## Verified end to end against production — not a stub

- **41,276-byte encrypted dump** written to `/srv/backups/loyalty`
- Decrypted with the private key, gunzipped to **215,599 bytes: 44 `CREATE TABLE` + 44 `COPY` blocks** with real rows
- **Completeness proven** by the matching `\restrict` / `\unrestrict` token pair — pg_dump 15.15 emits the closing token only after a full dump. (That format replaced the older `-- dump complete` comment, so the sentinel I'd have looked for is absent; worth knowing before someone greps for it.)
- Plaintext copy **shredded** from the operator machine afterwards
- The **OnFailure path proved itself too** — the first failure wrote `LAST-FAILURE` exactly as designed

## Runbook

Documents the host requirements and the benign snap warning (`/root/snap: read-only file system`) so a future rebuild doesn't rediscover this the hard way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015btC9bN9T6aWu46k1oBTb1