### PR TITLE
fix(ci): provision the E2E admin via ADMIN_BOOTSTRAP_EMAILS and drop the skip-on-403 masks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,18 @@ PROMPTPAY_HFVILLE_ID=
 LOYALTY_USERNAME=admin@localhost
 LOYALTY_PASSWORD=your_admin_password
 
+# Admin bootstrap allowlist (issue #348). Comma-separated, case-insensitive
+# emails promoted to the 'admin' role automatically: at registration (the
+# first JWT already carries role=admin) and by a startup sweep covering
+# pre-existing 'customer' accounts with a matching email (incl.
+# Google-OAuth-created; LINE-only accounts have email = NULL and can never
+# match). Existing admin/super_admin rows are never touched; nothing is
+# ever demoted. Empty/unset = off.
+# Intended for E2E stacks and one-time first-admin bootstrap. REMOVE after
+# use in production: registration does NOT verify email ownership, so
+# anyone who registers a listed email becomes admin.
+ADMIN_BOOTSTRAP_EMAILS=
+
 # ===========================================
 # DEVELOPMENT SETTINGS
 # ===========================================

--- a/.env.production.example
+++ b/.env.production.example
@@ -52,6 +52,39 @@ LINE_CALLBACK_URL=https://your-domain.com/api/oauth/line/callback
 LOYALTY_USERNAME=CHANGE_ME_admin@your-domain.com
 LOYALTY_PASSWORD=CHANGE_ME_ADMIN_PASSWORD
 
+# Admin bootstrap allowlist (issue #348). Comma-separated, case-insensitive
+# emails promoted to the 'admin' role automatically: at registration (the
+# first JWT already carries role=admin) and by a startup sweep covering
+# pre-existing 'customer' accounts with a matching email. Google-OAuth
+# accounts are covered; LINE-only accounts are created with email = NULL,
+# so the allowlist can NEVER match them. Existing admin/super_admin rows
+# are never touched; nothing is ever demoted. Empty/unset = off.
+#
+# ONE-TIME FIRST-ADMIN BOOTSTRAP — the procedure the code supports
+# (full write-up: backend-rust/README.md, "First-admin bootstrap"):
+#   1. Add ADMIN_BOOTSTRAP_EMAILS=you@example.com to the server-side .env
+#      in the deploy directory on the host (the file docker compose reads).
+#   2. Recreate the backend so it picks the value up:
+#        docker compose -f docker-compose.yml -f docker-compose.ghcr.yml \
+#          -f docker-compose.prod.yml up -d backend
+#      (staging: use docker-compose.staging.yml; a plain `docker compose
+#      restart` does NOT re-read .env).
+#   3. Register — or log in via Google OAuth — with the listed address and
+#      verify an admin-only endpoint answers 200 for that account.
+#   4. REMOVE the variable from .env and recreate the backend again.
+#
+# Operational caveats:
+# - The deploy workflows REGENERATE the server-side .env from GitHub
+#   secrets on every deploy, and ADMIN_BOOTSTRAP_EMAILS is not part of
+#   that payload — a hand-added value will not survive the next deploy.
+#   Complete the bootstrap in one sitting, and still remove the value
+#   yourself (step 4) rather than counting on a deploy to wipe it.
+# - Registration does NOT verify email ownership: while this is set,
+#   ANYONE who registers a listed address becomes admin. Keep the window
+#   short. The backend logs a warning at startup while it is set in
+#   production.
+ADMIN_BOOTSTRAP_EMAILS=
+
 # ===========================================
 # PRODUCTION SETTINGS
 # ===========================================

--- a/.github/actions/start-app-stack/action.yml
+++ b/.github/actions/start-app-stack/action.yml
@@ -82,6 +82,7 @@ runs:
           -e LINE_CLIENT_SECRET=e2e-line-channel-secret \
           -e LINE_CALLBACK_URL="http://localhost:${BACKEND_PORT}/api/oauth/line/callback" \
           -e FRONTEND_URL="http://localhost:${FRONTEND_PORT}" \
+          -e ADMIN_BOOTSTRAP_EMAILS=e2e-admin@test.local \
           -e RUST_LOG=info \
           "${IMAGE_BASE}/backend:${TAG}"
 
@@ -168,6 +169,9 @@ runs:
         # and the specs authenticate with these exact values.
         seed "e2e-browser@test.com"   "E2ETestPassword123!" "E2E" "Browser"
         seed "e2e-browser-2@test.com" "E2ETestPassword123!" "E2E" "Browser2"
-        # Admin email must stay in sync with admins.e2e.json.
+        # Admin email must stay in sync with ADMIN_BOOTSTRAP_EMAILS on the
+        # backend container above: registering it triggers the backend's
+        # promote-on-register path, so this account is a real admin from
+        # its very first JWT (issue #348).
         seed "e2e-admin@test.local"   "AdminPassword123!"   "E2E" "Admin"
         echo "E2E test users seeded"

--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -1872,7 +1872,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loyalty-backend"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "anyhow",
  "argon2",

--- a/backend-rust/README.md
+++ b/backend-rust/README.md
@@ -288,7 +288,9 @@ backend-rust/
 ├── rust-toolchain.toml     # Rust version specification
 ├── .env.example            # Environment template
 ├── config/
-│   └── admins.json         # Admin users configuration
+│   └── admins.json         # Legacy admin email lists (does NOT grant roles;
+│                           # provision admins via ADMIN_BOOTSTRAP_EMAILS —
+│                           # see .env.example — or the role-change endpoint)
 ├── migrations/
 │   └── 20240101000000_init.sql  # Database schema
 ├── scripts/
@@ -435,6 +437,54 @@ backend-rust/
 | `MAX_FILE_SIZE` | Maximum upload size (bytes) | `5242880` (5MB) |
 | `RATE_LIMIT_WINDOW_MS` | Rate limit window | `900000` (15 min) |
 | `RATE_LIMIT_MAX_REQUESTS` | Max requests per window | `10000` |
+
+### Admin Bootstrap (Optional)
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ADMIN_BOOTSTRAP_EMAILS` | Comma-separated, case-insensitive emails auto-promoted to `admin` (issue #348) | unset (feature off) |
+
+Listed emails are promoted to the `admin` role at registration (the first
+JWT already carries `role=admin`) and by a startup sweep over pre-existing
+`customer` rows with a matching email. Existing `admin`/`super_admin` rows
+are never modified and nothing is ever demoted, so the sweep is idempotent.
+LINE-only accounts are created with `email = NULL`, so the allowlist can
+never match them — those accounts can only be promoted by an existing admin
+via the role-change endpoint.
+
+#### First-admin bootstrap (staging/production)
+
+This is the procedure the code supports for provisioning the first admin on
+a deployed stack. Registration does **not** verify email ownership — while
+the variable is set, anyone who registers a listed address becomes admin —
+so keep the window as short as possible.
+
+1. Add `ADMIN_BOOTSTRAP_EMAILS=you@example.com` to the server-side `.env`
+   in the deploy directory on the host (the file `docker compose` reads).
+2. Recreate the backend container so it picks up the value — a plain
+   `docker compose restart` does **not** re-read `.env`:
+
+   ```bash
+   # production (staging: swap in docker-compose.staging.yml)
+   docker compose -f docker-compose.yml -f docker-compose.ghcr.yml \
+     -f docker-compose.prod.yml up -d backend
+   ```
+
+3. Register — or log in via Google OAuth — with the listed address, then
+   verify an admin-only endpoint answers 200 for that account.
+4. Remove the variable from `.env` (or set it empty) and recreate the
+   backend again.
+
+Operational caveats:
+
+- The deploy workflows (`deploy.yml` for production, `ci-build-e2e.yml`
+  for staging) regenerate the server-side `.env` from GitHub secrets on
+  every deploy, and `ADMIN_BOOTSTRAP_EMAILS` is not part of that payload.
+  A hand-added value therefore does not survive the next deploy: complete
+  the bootstrap in one sitting, and still remove the value yourself
+  (step 4) rather than counting on a deploy to wipe it.
+- The backend logs a warning at startup while the variable is set in
+  production.
 
 ## Testing
 

--- a/backend-rust/src/config/mod.rs
+++ b/backend-rust/src/config/mod.rs
@@ -430,6 +430,56 @@ pub struct LoyaltyServiceConfig {
     pub token: Option<String>,
 }
 
+/// Admin bootstrap allowlist (issue #348).
+///
+/// `ADMIN_BOOTSTRAP_EMAILS` is a comma-separated, case-insensitive list of
+/// email addresses whose accounts are promoted to the `admin` role
+/// automatically: in-transaction during `/api/auth/register` (so the very
+/// first JWT already carries `role=admin`) and via a startup sweep that
+/// covers pre-existing rows (including OAuth-created accounts).
+///
+/// Promotion is ONE-SHOT and UNAMBIGUOUS. Because `users.email`
+/// uniqueness is byte-exact while this allowlist matches
+/// case-insensitively, several distinct rows can match one entry; a
+/// promotion happens only when (a) exactly one user row matches the
+/// entry case-insensitively, (b) no matching row already holds
+/// admin/super_admin, and (c) no prior promotion for the entry is
+/// recorded in `user_audit_log` (action `admin_bootstrap_promotion`, the
+/// one-shot marker). Only `customer` rows are ever touched, nothing is
+/// ever demoted, and a deliberate demotion through the admin API is
+/// never undone by a later restart.
+///
+/// Intended for E2E stacks and one-time first-admin bootstrap. Remove the
+/// variable once the first admin exists: registration does not verify
+/// email ownership, so the FIRST registration of a listed address still
+/// becomes admin. Empty/unset disables the feature entirely.
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct AdminBootstrapConfig {
+    /// Comma-separated allowlist; `None` or blank = feature off.
+    #[serde(default)]
+    pub emails: Option<String>,
+}
+
+impl AdminBootstrapConfig {
+    /// Parsed allowlist: split on `,`, trimmed, lowercased, empties dropped.
+    pub fn email_list(&self) -> Vec<String> {
+        self.emails
+            .as_deref()
+            .unwrap_or("")
+            .split(',')
+            .map(|e| e.trim().to_lowercase())
+            .filter(|e| !e.is_empty())
+            .collect()
+    }
+
+    /// Case-insensitive membership test. Always `false` when the list is
+    /// empty/unset (feature off).
+    pub fn contains(&self, email: &str) -> bool {
+        let needle = email.trim().to_lowercase();
+        !needle.is_empty() && self.email_list().iter().any(|e| e == &needle)
+    }
+}
+
 /// Server configuration
 #[derive(Debug, Clone, Deserialize)]
 pub struct ServerConfig {
@@ -637,6 +687,10 @@ pub struct Settings {
     /// Inbound service token (PMS → loyalty accrual calls)
     #[serde(default)]
     pub loyalty_service: LoyaltyServiceConfig,
+
+    /// Admin bootstrap allowlist (`ADMIN_BOOTSTRAP_EMAILS`, issue #348)
+    #[serde(default)]
+    pub admin_bootstrap: AdminBootstrapConfig,
 }
 
 impl Settings {
@@ -751,6 +805,10 @@ impl Settings {
             .set_override_option(
                 "loyalty_service.token",
                 env::var("LOYALTY_SERVICE_TOKEN").ok(),
+            )?
+            .set_override_option(
+                "admin_bootstrap.emails",
+                env::var("ADMIN_BOOTSTRAP_EMAILS").ok(),
             )?
             .set_override_option("security.max_file_size", env::var("MAX_FILE_SIZE").ok())?
             .set_override_option(
@@ -931,6 +989,35 @@ impl Settings {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_admin_bootstrap_email_list_parsing() {
+        // Unset = off
+        let cfg = AdminBootstrapConfig::default();
+        assert!(cfg.email_list().is_empty());
+        assert!(!cfg.contains("anyone@example.com"));
+
+        // Blank / separators-only = off
+        let cfg = AdminBootstrapConfig {
+            emails: Some("  , ,".to_string()),
+        };
+        assert!(cfg.email_list().is_empty());
+        assert!(!cfg.contains("anyone@example.com"));
+
+        // Comma-separated, trimmed, lowercased, case-insensitive matching
+        let cfg = AdminBootstrapConfig {
+            emails: Some(" Admin@Example.COM , e2e-admin@test.local ".to_string()),
+        };
+        assert_eq!(
+            cfg.email_list(),
+            vec!["admin@example.com", "e2e-admin@test.local"]
+        );
+        assert!(cfg.contains("admin@example.com"));
+        assert!(cfg.contains("ADMIN@example.com"));
+        assert!(cfg.contains("e2e-admin@test.local"));
+        assert!(!cfg.contains("other@example.com"));
+        assert!(!cfg.contains(""));
+    }
 
     #[test]
     fn test_environment_from_string() {

--- a/backend-rust/src/db/seed.rs
+++ b/backend-rust/src/db/seed.rs
@@ -231,6 +231,164 @@ pub async fn seed_sample_data(db: &PgPool) -> Result<()> {
     Ok(())
 }
 
+/// Promote pre-existing users on the admin bootstrap allowlist to 'admin'
+/// (issue #348).
+///
+/// Startup counterpart of the in-transaction promotion in
+/// `/api/auth/register`: covers rows that already existed before
+/// `ADMIN_BOOTSTRAP_EMAILS` was set — including OAuth-created accounts.
+/// Matching is case-insensitive, but `users.email` uniqueness is
+/// byte-exact, so several distinct rows can match one allowlist entry.
+/// A promotion for an entry therefore happens only when ALL of these
+/// hold, evaluated inside one transaction per entry:
+///
+/// (a) exactly ONE user row matches the entry case-insensitively —
+///     multiple matches mean a case-variant row exists (possible
+///     squatting) and the sweep refuses to promote, logging a WARN;
+/// (b) that row still holds role `customer` — existing
+///     admins/super_admins are never modified and nothing is ever
+///     demoted, which also keeps the sweep idempotent;
+/// (c) no prior bootstrap promotion is recorded for the entry — the
+///     `admin_bootstrap_promotion` row in `user_audit_log` is the
+///     one-shot marker, so a deliberate demotion via
+///     `PATCH /api/admin/users/:id/role` is never silently undone by
+///     the next restart.
+///
+/// The role UPDATE and the audit-marker INSERT share the transaction,
+/// so a promotion cannot half-apply. Returns the number of rows
+/// promoted.
+pub async fn promote_bootstrap_admins(db: &PgPool, emails: &[String]) -> Result<u64> {
+    let mut allowlist: Vec<String> = emails
+        .iter()
+        .map(|e| e.trim().to_lowercase())
+        .filter(|e| !e.is_empty())
+        .collect();
+    allowlist.sort();
+    allowlist.dedup();
+
+    if allowlist.is_empty() {
+        return Ok(0);
+    }
+
+    let mut promoted: u64 = 0;
+
+    for entry in &allowlist {
+        // Log the stable non-reversible hash, never the raw address
+        // (emails are PII; see src/utils/email_hash.rs).
+        let entry_hash = crate::utils::hash_email(entry);
+
+        let mut tx = db
+            .begin()
+            .await
+            .context("Failed to begin bootstrap promotion transaction")?;
+
+        // Serialize with the register-path promotion for the same entry:
+        // without this, a registration committing between our checks and
+        // our UPDATE could produce a second matching row unseen under
+        // READ COMMITTED. Transaction-scoped, released on commit/rollback.
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1)::bigint)")
+            .bind(format!("admin_bootstrap:{entry}"))
+            .execute(&mut *tx)
+            .await
+            .context("Failed to acquire bootstrap promotion advisory lock")?;
+
+        // (a) exactly one candidate row for the entry.
+        let candidates: Vec<(Uuid, String)> =
+            sqlx::query_as("SELECT id, role::text FROM users WHERE lower(email) = $1")
+                .bind(entry)
+                .fetch_all(&mut *tx)
+                .await
+                .context("Failed to list bootstrap promotion candidates")?;
+
+        let (user_id, role) = match candidates.as_slice() {
+            [] => continue, // no matching row yet — nothing to sweep
+            [only] => only.clone(),
+            many => {
+                warn!(
+                    email_hash = %entry_hash,
+                    candidate_count = many.len(),
+                    "Admin bootstrap sweep: refusing to promote — {} user rows match the \
+                     allowlist entry case-insensitively (ambiguous; possible case-variant \
+                     squatting). Resolve the duplicate rows before re-enabling bootstrap.",
+                    many.len()
+                );
+                continue;
+            },
+        };
+
+        // (b) only `customer` rows are ever promoted; admin/super_admin
+        // rows are left untouched (idempotent no-op).
+        if role != "customer" {
+            continue;
+        }
+
+        // (c) one-shot marker: a recorded promotion for this entry means
+        // it was already used — possibly followed by a deliberate
+        // demotion through the admin API, which must stick.
+        let prior_promotions: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM user_audit_log \
+             WHERE action = 'admin_bootstrap_promotion' AND details->>'email_hash' = $1",
+        )
+        .bind(&entry_hash)
+        .fetch_one(&mut *tx)
+        .await
+        .context("Failed to check bootstrap promotion marker")?;
+
+        if prior_promotions > 0 {
+            info!(
+                email_hash = %entry_hash,
+                user_id = %user_id,
+                "Admin bootstrap sweep: skipping — a promotion for this entry is already \
+                 recorded (one-shot); a deliberate demotion is not undone"
+            );
+            continue;
+        }
+
+        let updated = sqlx::query(
+            r#"
+            UPDATE users
+            SET role = 'admin'::user_role, updated_at = NOW()
+            WHERE id = $1
+              AND role = 'customer'::user_role
+            "#,
+        )
+        .bind(user_id)
+        .execute(&mut *tx)
+        .await
+        .context("Failed to promote bootstrap admin")?
+        .rows_affected();
+
+        if updated != 1 {
+            continue; // row changed under us; tx rolls back on drop
+        }
+
+        // One-shot marker + audit trail, same transaction as the UPDATE.
+        sqlx::query(
+            "INSERT INTO user_audit_log (user_id, action, details) \
+             VALUES ($1, 'admin_bootstrap_promotion', $2)",
+        )
+        .bind(user_id)
+        .bind(json!({ "email_hash": entry_hash, "source": "startup_sweep" }))
+        .execute(&mut *tx)
+        .await
+        .context("Failed to record bootstrap promotion audit marker")?;
+
+        tx.commit()
+            .await
+            .context("Failed to commit bootstrap promotion")?;
+
+        // WARN, not INFO: granting admin is a privileged event.
+        warn!(
+            user_id = %user_id,
+            email_hash = %entry_hash,
+            "Admin bootstrap sweep: promoted user to admin (ADMIN_BOOTSTRAP_EMAILS)"
+        );
+        promoted += 1;
+    }
+
+    Ok(promoted)
+}
+
 /// Initialize the membership ID sequence
 ///
 /// The membership_id_sequence table is required for generating unique

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -127,6 +127,41 @@ async fn main() -> anyhow::Result<()> {
         // Continue startup even if seeding fails - data may already exist
     }
 
+    // Admin bootstrap sweep (issue #348): promote pre-existing 'customer'
+    // rows whose email is on the ADMIN_BOOTSTRAP_EMAILS allowlist. The
+    // in-transaction promotion in /api/auth/register covers new
+    // registrations; this sweep covers rows created before the variable
+    // was set (including OAuth-created accounts). Non-fatal, like seeding.
+    let bootstrap_emails = config.admin_bootstrap.email_list();
+    if !bootstrap_emails.is_empty() {
+        // Staging deploys real user data too — warn anywhere that isn't
+        // local development, not just production.
+        if config.is_production() || config.is_staging() {
+            warn!(
+                "ADMIN_BOOTSTRAP_EMAILS is set in {} ({} entries) — remove it once the \
+                 first admin exists: the first registration of a listed email becomes admin \
+                 without proving ownership of the address",
+                config.environment,
+                bootstrap_emails.len()
+            );
+        }
+        match db::seed::promote_bootstrap_admins(db.pool(), &bootstrap_emails).await {
+            // A promotion is a privileged event: surface a non-zero sweep
+            // at WARN (per-user WARN lines with ids come from
+            // promote_bootstrap_admins itself).
+            Ok(promoted) if promoted > 0 => warn!(
+                "Admin bootstrap sweep: promoted {} user(s) to admin ({} allowlisted email(s))",
+                promoted,
+                bootstrap_emails.len()
+            ),
+            Ok(_) => info!(
+                "Admin bootstrap sweep: nothing to promote ({} allowlisted email(s))",
+                bootstrap_emails.len()
+            ),
+            Err(e) => error!("Admin bootstrap sweep failed: {:#}", e),
+        }
+    }
+
     // Seed sample data (development only)
     if config.environment == Environment::Development {
         info!("Seeding sample data (development mode)...");

--- a/backend-rust/src/routes/auth.rs
+++ b/backend-rust/src/routes/auth.rs
@@ -446,10 +446,118 @@ async fn register(
     .await
     .map_err(|e| AppError::DatabaseQuery(e.to_string()))?;
 
-    let user_row = match user_row {
+    let mut user_row = match user_row {
         Some(row) => row,
         None => return Err(AppError::Conflict("Email already registered".to_string())),
     };
+
+    // Admin bootstrap (issue #348): when the registering email is on the
+    // ADMIN_BOOTSTRAP_EMAILS allowlist, promote the freshly inserted row
+    // to 'admin' inside the same transaction, so the very first JWT (and
+    // the response body below) already carry role=admin.
+    //
+    // SECURITY: `payload.email` is USER INPUT, not operator config — the
+    // allowlist match only proves the submitted address collides
+    // case-insensitively with a configured entry. `users.email`
+    // uniqueness is byte-exact, so a case variant of a listed address is
+    // a DISTINCT row that still satisfies `contains()`. Promotion is
+    // therefore one-shot and unambiguous; it happens only when:
+    //
+    // (a) no OTHER user row matches the entry case-insensitively (the
+    //     only candidate is the row just inserted) — ambiguity means a
+    //     case-variant row exists and we refuse;
+    // (b) no matching row already holds admin/super_admin — implied by
+    //     (a) here, because the sole matching row is the one this
+    //     transaction just inserted with role 'customer';
+    // (c) no prior bootstrap promotion is recorded for the entry — the
+    //     `admin_bootstrap_promotion` row in `user_audit_log` is the
+    //     one-shot marker shared with the startup sweep.
+    //
+    // Checks, role UPDATE, and marker INSERT all run in this
+    // transaction, so the promotion cannot half-apply. The raw email is
+    // never logged (user input, PII) — only its stable hash.
+    if state.config().admin_bootstrap.contains(&payload.email) {
+        let entry = payload.email.trim().to_lowercase();
+        let entry_hash = crate::utils::hash_email(&entry);
+
+        // Serialize concurrent promotions for the same entry (two case
+        // variants registering at once would otherwise each see zero
+        // "other" rows under READ COMMITTED). Transaction-scoped lock,
+        // shared with the startup sweep; released on commit/rollback.
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1)::bigint)")
+            .bind(format!("admin_bootstrap:{entry}"))
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::DatabaseQuery(e.to_string()))?;
+
+        // (a) rows OTHER than the one just inserted.
+        let other_matches: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM users WHERE lower(email) = $1 AND id <> $2")
+                .bind(&entry)
+                .bind(user_row.id)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(|e| AppError::DatabaseQuery(e.to_string()))?;
+
+        // (c) one-shot marker.
+        let prior_promotions: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM user_audit_log \
+             WHERE action = 'admin_bootstrap_promotion' AND details->>'email_hash' = $1",
+        )
+        .bind(&entry_hash)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| AppError::DatabaseQuery(e.to_string()))?;
+
+        if other_matches > 0 {
+            tracing::warn!(
+                email_hash = %entry_hash,
+                user_id = %user_row.id,
+                other_matching_rows = other_matches,
+                "Admin bootstrap: refusing register-path promotion — {} other user row(s) \
+                 match the allowlist entry case-insensitively (ambiguous; possible \
+                 case-variant escalation attempt). Registering as customer.",
+                other_matches
+            );
+        } else if prior_promotions > 0 {
+            tracing::warn!(
+                email_hash = %entry_hash,
+                user_id = %user_row.id,
+                "Admin bootstrap: refusing register-path promotion — a promotion for this \
+                 entry is already recorded (one-shot). Registering as customer."
+            );
+        } else {
+            sqlx::query(
+                r#"
+                UPDATE users
+                SET role = 'admin'::user_role, updated_at = NOW()
+                WHERE id = $1 AND role = 'customer'::user_role
+                "#,
+            )
+            .bind(user_row.id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::DatabaseQuery(e.to_string()))?;
+
+            // One-shot marker + audit trail, same transaction as the UPDATE.
+            sqlx::query(
+                "INSERT INTO user_audit_log (user_id, action, details) \
+                 VALUES ($1, 'admin_bootstrap_promotion', $2)",
+            )
+            .bind(user_row.id)
+            .bind(serde_json::json!({ "email_hash": entry_hash, "source": "register" }))
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| AppError::DatabaseQuery(e.to_string()))?;
+
+            user_row.role = Some(UserRole::Admin);
+            tracing::info!(
+                email_hash = %entry_hash,
+                user_id = %user_row.id,
+                "Admin bootstrap: promoted registering user to admin (ADMIN_BOOTSTRAP_EMAILS)"
+            );
+        }
+    }
 
     // Create user profile
     sqlx::query(

--- a/backend-rust/src/routes/oauth.rs
+++ b/backend-rust/src/routes/oauth.rs
@@ -859,17 +859,95 @@ async fn process_google_auth(
             .unwrap_or_default();
         let avatar_url = user_info.picture.as_deref();
 
+        // Admin bootstrap (issue #348): a new OAuth account whose email
+        // is on the ADMIN_BOOTSTRAP_EMAILS allowlist may be created as
+        // 'admin' directly, mirroring /api/auth/register.
+        //
+        // SECURITY: `email` here is PROVIDER-SUPPLIED USER DATA (Google
+        // has verified ownership, but it is not operator configuration),
+        // so only its non-reversible hash is ever logged. Promotion
+        // follows the same one-shot rules as the register path and the
+        // startup sweep: it is refused when another user row matches the
+        // entry case-insensitively (the byte-exact lookup above found
+        // nothing, so any match is a case-variant row — ambiguous), or
+        // when a prior `admin_bootstrap_promotion` marker exists for the
+        // entry in `user_audit_log` (one-shot: a deliberate demotion or
+        // an already-consumed entry must never silently mint a new
+        // admin).
+        let mut bootstrap_admin = false;
+        let entry = email.trim().to_lowercase();
+        let entry_hash = crate::utils::hash_email(&entry);
+        if state.config().admin_bootstrap.contains(email) {
+            let variant_rows: i64 =
+                sqlx::query_scalar("SELECT COUNT(*) FROM users WHERE lower(email) = $1")
+                    .bind(&entry)
+                    .fetch_one(db)
+                    .await
+                    .map_err(AppError::Database)?;
+
+            let prior_promotions: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM user_audit_log \
+                 WHERE action = 'admin_bootstrap_promotion' AND details->>'email_hash' = $1",
+            )
+            .bind(&entry_hash)
+            .fetch_one(db)
+            .await
+            .map_err(AppError::Database)?;
+
+            if variant_rows > 0 {
+                tracing::warn!(
+                    email_hash = %entry_hash,
+                    matching_rows = variant_rows,
+                    "Admin bootstrap: refusing OAuth-path promotion — {} user row(s) match \
+                     the allowlist entry case-insensitively (ambiguous; possible \
+                     case-variant squatting). Creating as customer.",
+                    variant_rows
+                );
+            } else if prior_promotions > 0 {
+                tracing::warn!(
+                    email_hash = %entry_hash,
+                    "Admin bootstrap: refusing OAuth-path promotion — a promotion for this \
+                     entry is already recorded (one-shot). Creating as customer."
+                );
+            } else {
+                bootstrap_admin = true;
+                tracing::info!(
+                    email_hash = %entry_hash,
+                    user_id = %user_id,
+                    "Admin bootstrap: creating new Google OAuth user as admin \
+                     (ADMIN_BOOTSTRAP_EMAILS)"
+                );
+            }
+        }
+        let role = if bootstrap_admin { "admin" } else { "customer" };
+
         // Create user
         sqlx::query(
             r#"INSERT INTO users (id, email, password_hash, email_verified, oauth_provider, oauth_provider_id, role, is_active)
-               VALUES ($1, $2, '', true, 'google', $3, 'customer', true)"#,
+               VALUES ($1, $2, '', true, 'google', $3, $4::user_role, true)"#,
         )
         .bind(user_id)
         .bind(email)
         .bind(&user_info.id)
+        .bind(role)
         .execute(db)
         .await
         .map_err(AppError::Database)?;
+
+        // One-shot marker + audit trail for the bootstrap promotion,
+        // same shape as the register path and the startup sweep so
+        // future sweeps honour it (a later demotion must stick).
+        if bootstrap_admin {
+            sqlx::query(
+                "INSERT INTO user_audit_log (user_id, action, details) \
+                 VALUES ($1, 'admin_bootstrap_promotion', $2)",
+            )
+            .bind(user_id)
+            .bind(serde_json::json!({ "email_hash": entry_hash, "source": "oauth_google" }))
+            .execute(db)
+            .await
+            .map_err(AppError::Database)?;
+        }
 
         // Generate membership ID
         let membership_id = generate_membership_id(state).await?;
@@ -901,7 +979,7 @@ async fn process_google_auth(
         let user = UserResponse {
             id: user_id.to_string(),
             email: Some(email.to_string()),
-            role: "customer".to_string(),
+            role: role.to_string(),
             is_active: true,
             email_verified: true,
             oauth_provider: Some("google".to_string()),

--- a/backend-rust/tests/common/mod.rs
+++ b/backend-rust/tests/common/mod.rs
@@ -711,6 +711,8 @@ fn create_test_config() -> loyalty_backend::Settings {
         loyalty_service: LoyaltyServiceConfig {
             token: Some(TEST_LOYALTY_SERVICE_TOKEN.to_string()),
         },
+        // Feature off by default; tests opt in via TestApp::new_with_config.
+        admin_bootstrap: AdminBootstrapConfig::default(),
     }
 }
 

--- a/backend-rust/tests/integration/admin_bootstrap_test.rs
+++ b/backend-rust/tests/integration/admin_bootstrap_test.rs
@@ -1,0 +1,471 @@
+//! Admin bootstrap allowlist tests (issue #348)
+//!
+//! `ADMIN_BOOTSTRAP_EMAILS` (config key `admin_bootstrap.emails`) is a
+//! comma-separated, case-insensitive allowlist of emails promoted to the
+//! `admin` role automatically:
+//!
+//! - in-transaction during `/api/auth/register`, so the very first JWT
+//!   already carries `role=admin`;
+//! - via the startup sweep (`promote_bootstrap_admins`) for rows that
+//!   existed before the variable was set.
+//!
+//! Empty/unset = feature fully off. Existing admin/super_admin rows are
+//! never touched and nothing is ever demoted.
+//!
+//! Promotion is ONE-SHOT and UNAMBIGUOUS (see `AdminBootstrapConfig`):
+//! `users.email` uniqueness is byte-exact while the allowlist matches
+//! case-insensitively, so case variants of a listed address are distinct
+//! rows that all satisfy the allowlist. Both promotion paths refuse when
+//! more than one row matches an entry, and record a one-shot
+//! `admin_bootstrap_promotion` marker in `user_audit_log` so a
+//! deliberate demotion is never silently undone by a later restart.
+
+use crate::common::*;
+use loyalty_backend::db::seed::promote_bootstrap_admins;
+use loyalty_backend::utils::hash_email;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+/// Generate a unique email for test isolation.
+fn unique_email(prefix: &str) -> String {
+    format!("{}-{}@test.local", prefix, Uuid::new_v4().simple())
+}
+
+fn register_payload(email: &str) -> Value {
+    json!({
+        "email": email,
+        "password": "SecurePass123!",
+        "firstName": "Bootstrap",
+        "lastName": "Test",
+    })
+}
+
+async fn db_role(app: &TestApp, email: &str) -> String {
+    sqlx::query_scalar::<_, String>("SELECT role::text FROM users WHERE lower(email) = lower($1)")
+        .bind(email)
+        .fetch_one(app.db())
+        .await
+        .expect("user row should exist")
+}
+
+/// Byte-exact role lookup — required when a test deliberately creates
+/// case-variant rows of the same address (`db_role`'s case-insensitive
+/// match would find more than one row and fail).
+async fn db_role_exact(app: &TestApp, email: &str) -> String {
+    sqlx::query_scalar::<_, String>("SELECT role::text FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(app.db())
+        .await
+        .expect("user row should exist")
+}
+
+/// Byte-exact user id lookup.
+async fn db_user_id(app: &TestApp, email: &str) -> Uuid {
+    sqlx::query_scalar::<_, Uuid>("SELECT id FROM users WHERE email = $1")
+        .bind(email)
+        .fetch_one(app.db())
+        .await
+        .expect("user row should exist")
+}
+
+// ============================================================================
+// Registration-time promotion
+// ============================================================================
+
+#[tokio::test]
+async fn test_register_bootstrap_email_gets_admin_role_and_token() {
+    // Mixed case in the CONFIG vs lowercase in the REQUEST pins the
+    // case-insensitivity contract.
+    let mutate = |cfg: &mut loyalty_backend::Settings| {
+        cfg.admin_bootstrap.emails =
+            Some("Other@Example.com, Bootstrap-Admin@Test.LOCAL".to_string());
+    };
+    let app = TestApp::new_with_config(&mutate)
+        .await
+        .expect("Failed to create test app");
+
+    let email = "bootstrap-admin@test.local";
+    let response = app
+        .client()
+        .post("/api/auth/register", &register_payload(email))
+        .await;
+    response.assert_status(200);
+
+    let body: Value = response.json().expect("Response should be valid JSON");
+    assert_eq!(
+        body["user"]["role"], "admin",
+        "bootstrap-listed email must register as admin. Body: {body}"
+    );
+
+    // The FIRST issued access token must already pass an admin-only
+    // endpoint — no re-login required (issue #348's whole point).
+    let token = body["tokens"]["accessToken"]
+        .as_str()
+        .expect("access token")
+        .to_string();
+    let admin_response = app
+        .client()
+        .with_auth(&token)
+        .get("/api/loyalty/admin/tiers")
+        .await;
+    admin_response.assert_status(200);
+
+    // And the DB row really carries the role (not just the JWT claim).
+    assert_eq!(db_role(&app, email).await, "admin");
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_register_unlisted_email_stays_customer() {
+    let mutate = |cfg: &mut loyalty_backend::Settings| {
+        cfg.admin_bootstrap.emails = Some("only-this-one@test.local".to_string());
+    };
+    let app = TestApp::new_with_config(&mutate)
+        .await
+        .expect("Failed to create test app");
+
+    let email = unique_email("unlisted");
+    let response = app
+        .client()
+        .post("/api/auth/register", &register_payload(&email))
+        .await;
+    response.assert_status(200);
+
+    let body: Value = response.json().expect("Response should be valid JSON");
+    assert_eq!(
+        body["user"]["role"], "customer",
+        "unlisted email must stay customer. Body: {body}"
+    );
+
+    let token = body["tokens"]["accessToken"]
+        .as_str()
+        .expect("access token")
+        .to_string();
+    let admin_response = app
+        .client()
+        .with_auth(&token)
+        .get("/api/loyalty/admin/tiers")
+        .await;
+    admin_response.assert_status(403);
+
+    assert_eq!(db_role(&app, &email).await, "customer");
+
+    app.cleanup().await.ok();
+}
+
+#[tokio::test]
+async fn test_empty_allowlist_disables_feature() {
+    // Blank / separators-only value = feature fully off: even an email
+    // that LOOKS like a bootstrap entry registers as a plain customer.
+    let mutate = |cfg: &mut loyalty_backend::Settings| {
+        cfg.admin_bootstrap.emails = Some("  , ,".to_string());
+    };
+    let app = TestApp::new_with_config(&mutate)
+        .await
+        .expect("Failed to create test app");
+
+    let email = unique_email("e2e-admin-lookalike");
+    let response = app
+        .client()
+        .post("/api/auth/register", &register_payload(&email))
+        .await;
+    response.assert_status(200);
+
+    let body: Value = response.json().expect("Response should be valid JSON");
+    assert_eq!(
+        body["user"]["role"], "customer",
+        "empty allowlist must leave registration untouched. Body: {body}"
+    );
+
+    app.cleanup().await.ok();
+}
+
+// ============================================================================
+// Startup sweep (promote_bootstrap_admins)
+// ============================================================================
+
+#[tokio::test]
+async fn test_sweep_promotes_customers_only_and_is_idempotent() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let pool = app.db();
+
+    // Pre-existing customer on the allowlist (listed in UPPERCASE to pin
+    // case-insensitive matching against the lowercase DB row).
+    let customer = create_test_user(pool, &unique_email("sweep-customer"))
+        .await
+        .expect("insert customer");
+
+    // Pre-existing super_admin on the allowlist — must NOT be touched.
+    let mut super_admin = TestUser::new(&unique_email("sweep-super"));
+    super_admin.role = "super_admin".to_string();
+    super_admin.insert(pool).await.expect("insert super_admin");
+
+    // Customer NOT on the allowlist — must NOT be promoted.
+    let bystander = create_test_user(pool, &unique_email("sweep-bystander"))
+        .await
+        .expect("insert bystander");
+
+    let allowlist = vec![customer.email.to_uppercase(), super_admin.email.clone()];
+
+    let promoted = promote_bootstrap_admins(pool, &allowlist)
+        .await
+        .expect("sweep should succeed");
+    assert_eq!(promoted, 1, "only the listed customer row is promoted");
+
+    assert_eq!(db_role(&app, &customer.email).await, "admin");
+    assert_eq!(
+        db_role(&app, &super_admin.email).await,
+        "super_admin",
+        "sweep must never modify super_admin rows"
+    );
+    assert_eq!(
+        db_role(&app, &bystander.email).await,
+        "customer",
+        "sweep must not touch unlisted users"
+    );
+
+    // Idempotent: a second run finds nothing left to promote.
+    let promoted_again = promote_bootstrap_admins(pool, &allowlist)
+        .await
+        .expect("second sweep should succeed");
+    assert_eq!(promoted_again, 0, "sweep must be idempotent");
+
+    // Empty allowlist is a no-op by contract.
+    let promoted_empty = promote_bootstrap_admins(pool, &[])
+        .await
+        .expect("empty sweep should succeed");
+    assert_eq!(promoted_empty, 0);
+
+    app.cleanup().await.ok();
+}
+
+// ============================================================================
+// One-shot / ambiguity hardening
+// ============================================================================
+
+/// Case-variant escalation attack (the HIGH from the adversarial review):
+/// `users.email` uniqueness is byte-exact, so registering an upper-case
+/// variant of a listed address creates a NEW row that still matches the
+/// case-insensitive allowlist. The variant must register as a plain
+/// customer, its token must fail admin endpoints, and exactly one admin
+/// may exist for the address.
+#[tokio::test]
+async fn test_register_case_variant_of_listed_email_cannot_escalate() {
+    let mutate = |cfg: &mut loyalty_backend::Settings| {
+        cfg.admin_bootstrap.emails = Some("ops-target@test.local".to_string());
+    };
+    let app = TestApp::new_with_config(&mutate)
+        .await
+        .expect("Failed to create test app");
+
+    // 1. The listed address registers first and becomes admin (legit).
+    let listed = "ops-target@test.local";
+    let response = app
+        .client()
+        .post("/api/auth/register", &register_payload(listed))
+        .await;
+    response.assert_status(200);
+    let body: Value = response.json().expect("valid JSON");
+    assert_eq!(body["user"]["role"], "admin", "Body: {body}");
+
+    // 2. An attacker registers a case variant. ON CONFLICT(email) does
+    //    not fire (different bytes), so a second row is created — but it
+    //    must stay customer.
+    let variant = "Ops-Target@test.local";
+    let response = app
+        .client()
+        .post("/api/auth/register", &register_payload(variant))
+        .await;
+    response.assert_status(200);
+    let body: Value = response.json().expect("valid JSON");
+    assert_eq!(
+        body["user"]["role"], "customer",
+        "case variant of a listed email must NOT be promoted. Body: {body}"
+    );
+
+    // 3. The variant's very first token must fail admin endpoints.
+    let token = body["tokens"]["accessToken"]
+        .as_str()
+        .expect("access token")
+        .to_string();
+    let admin_response = app
+        .client()
+        .with_auth(&token)
+        .get("/api/loyalty/admin/tiers")
+        .await;
+    admin_response.assert_status(403);
+
+    // 4. DB ground truth: roles per row, and exactly ONE admin for the
+    //    address across all case variants.
+    assert_eq!(db_role_exact(&app, listed).await, "admin");
+    assert_eq!(db_role_exact(&app, variant).await, "customer");
+    let admin_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM users \
+         WHERE lower(email) = $1 AND role IN ('admin'::user_role, 'super_admin'::user_role)",
+    )
+    .bind(listed)
+    .fetch_one(app.db())
+    .await
+    .expect("count admins");
+    assert_eq!(
+        admin_count, 1,
+        "exactly one admin may exist for a bootstrap address"
+    );
+
+    app.cleanup().await.ok();
+}
+
+/// One-shot marker: after a sweep promotion, a deliberate demotion via
+/// the admin API (PATCH /api/admin/users/:id/role) must survive a
+/// restart-equivalent second sweep. Without the marker, `role =
+/// 'customer'` is exactly the state a revocation leaves, and every
+/// restart would silently restore the revoked admin.
+#[tokio::test]
+async fn test_sweep_does_not_restore_deliberately_demoted_admin() {
+    // Bootstrap is off in the app config: the sweep is exercised
+    // directly, as main.rs does at startup.
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let pool = app.db();
+
+    // Row created through the real registration endpoint (customer).
+    let email = unique_email("oneshot");
+    app.client()
+        .post("/api/auth/register", &register_payload(&email))
+        .await
+        .assert_status(200);
+
+    // First sweep: single candidate, customer, no marker -> promoted.
+    let allowlist = vec![email.clone()];
+    let promoted = promote_bootstrap_admins(pool, &allowlist)
+        .await
+        .expect("sweep should succeed");
+    assert_eq!(promoted, 1);
+    assert_eq!(db_role(&app, &email).await, "admin");
+
+    // The promotion recorded its audit/one-shot marker.
+    let target_id = db_user_id(&app, &email).await;
+    let marker_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM user_audit_log \
+         WHERE action = 'admin_bootstrap_promotion' AND user_id = $1",
+    )
+    .bind(target_id)
+    .fetch_one(pool)
+    .await
+    .expect("count markers");
+    assert_eq!(marker_count, 1, "promotion must record an audit marker");
+
+    // Deliberate revocation THROUGH THE ADMIN API (not a direct DB
+    // write): another admin demotes the bootstrap admin to customer.
+    let actor = TestUser::admin(&unique_email("oneshot-actor"));
+    actor.insert(pool).await.expect("insert acting admin");
+    let response = app
+        .authenticated_client_with_role(&actor.id, &actor.email, "admin")
+        .patch(
+            &format!("/api/admin/users/{}/role", target_id),
+            &json!({ "role": "customer" }),
+        )
+        .await;
+    response.assert_status(200);
+    assert_eq!(db_role(&app, &email).await, "customer");
+
+    // Restart-equivalent: the sweep runs again. The one-shot marker must
+    // keep the demotion in force.
+    let promoted_again = promote_bootstrap_admins(pool, &allowlist)
+        .await
+        .expect("second sweep should succeed");
+    assert_eq!(
+        promoted_again, 0,
+        "a revoked bootstrap admin must never be re-promoted by a restart"
+    );
+    assert_eq!(db_role(&app, &email).await, "customer");
+
+    app.cleanup().await.ok();
+}
+
+/// Ambiguity: when TWO case-variant customer rows exist for one
+/// allowlist entry, the sweep can't know which one the operator meant —
+/// it must promote NEITHER (and WARN with the candidate count).
+#[tokio::test]
+async fn test_sweep_refuses_ambiguous_case_variant_rows() {
+    // Bootstrap explicitly disabled while the rows are created, so both
+    // registrations go through the normal customer path.
+    let mutate = |cfg: &mut loyalty_backend::Settings| {
+        cfg.admin_bootstrap.emails = None;
+    };
+    let app = TestApp::new_with_config(&mutate)
+        .await
+        .expect("Failed to create test app");
+    let pool = app.db();
+
+    let lower = "dup-squat@test.local";
+    let variant = "Dup-Squat@test.local";
+    for email in [lower, variant] {
+        app.client()
+            .post("/api/auth/register", &register_payload(email))
+            .await
+            .assert_status(200);
+    }
+
+    // Enabling bootstrap later (sweep with the entry allowlisted) must
+    // refuse: two candidates match the entry case-insensitively.
+    let promoted = promote_bootstrap_admins(pool, &[lower.to_string()])
+        .await
+        .expect("sweep should succeed");
+    assert_eq!(
+        promoted, 0,
+        "ambiguous case-variant rows must promote NEITHER"
+    );
+    assert_eq!(db_role_exact(&app, lower).await, "customer");
+    assert_eq!(db_role_exact(&app, variant).await, "customer");
+
+    app.cleanup().await.ok();
+}
+
+/// Audit row shape for a successful promotion: action, user_id, and the
+/// JSONB details ({"email_hash": ..., "source": ...}) that the one-shot
+/// check keys on.
+#[tokio::test]
+async fn test_bootstrap_promotion_writes_audit_row_shape() {
+    let listed = "audit-shape@test.local";
+    let mutate = |cfg: &mut loyalty_backend::Settings| {
+        cfg.admin_bootstrap.emails = Some(listed.to_string());
+    };
+    let app = TestApp::new_with_config(&mutate)
+        .await
+        .expect("Failed to create test app");
+
+    app.client()
+        .post("/api/auth/register", &register_payload(listed))
+        .await
+        .assert_status(200);
+    assert_eq!(db_role_exact(&app, listed).await, "admin");
+
+    let rows: Vec<(Option<Uuid>, Value, bool)> = sqlx::query_as(
+        "SELECT user_id, details, created_at IS NOT NULL \
+         FROM user_audit_log WHERE action = 'admin_bootstrap_promotion'",
+    )
+    .fetch_all(app.db())
+    .await
+    .expect("fetch audit rows");
+    assert_eq!(rows.len(), 1, "exactly one promotion audit row");
+
+    let (user_id, details, has_created_at) = &rows[0];
+    assert_eq!(
+        user_id.expect("audit row must carry the promoted user id"),
+        db_user_id(&app, listed).await
+    );
+    assert_eq!(
+        details["email_hash"].as_str(),
+        Some(hash_email(listed).as_str()),
+        "details.email_hash must be the stable hash the one-shot check keys on. Details: {details}"
+    );
+    assert_eq!(
+        details["source"].as_str(),
+        Some("register"),
+        "register-path promotions must be attributed to source=register. Details: {details}"
+    );
+    assert!(has_created_at, "audit row must be timestamped");
+
+    app.cleanup().await.ok();
+}

--- a/backend-rust/tests/integration/mod.rs
+++ b/backend-rust/tests/integration/mod.rs
@@ -30,6 +30,7 @@
 //! TEST_DATABASE_URL=postgresql://... TEST_REDIS_URL=redis://... cargo test --test integration
 //! ```
 
+pub mod admin_bootstrap_test;
 pub mod admin_test;
 pub mod auth_test;
 pub mod booking_test;

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -59,6 +59,8 @@ services:
       LINE_CLIENT_SECRET: ${LINE_CHANNEL_SECRET}
       LINE_CALLBACK_URL: ${LINE_CALLBACK_URL}
       FRONTEND_URL: ${FRONTEND_URL}
+      # Admin bootstrap allowlist (issue #348) — empty/unset = feature off.
+      ADMIN_BOOTSTRAP_EMAILS: ${ADMIN_BOOTSTRAP_EMAILS:-}
       # Rust-specific logging
       RUST_LOG: ${RUST_LOG:-debug}
       LOG_LEVEL: ${LOG_LEVEL:-debug}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -91,6 +91,13 @@ services:
       LINE_CLIENT_SECRET: ${LINE_CHANNEL_SECRET}
       LINE_CALLBACK_URL: ${LINE_CALLBACK_URL}
 
+      # Admin bootstrap allowlist (issue #348): one-time first-admin
+      # provisioning. NOT in the GitHub-Actions .env payload — added by hand
+      # to the server-side .env for the bootstrap window, then removed (the
+      # next deploy rewrites .env without it anyway). Empty/unset = feature
+      # off; the backend logs a startup warning while it is set in production.
+      ADMIN_BOOTSTRAP_EMAILS: ${ADMIN_BOOTSTRAP_EMAILS:-}
+
       # Email Service (SMTP/IMAP)
       SMTP_HOST: ${SMTP_HOST:-}
       SMTP_PORT: ${SMTP_PORT:-587}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -51,6 +51,11 @@ services:
       LINE_CLIENT_SECRET: ${LINE_CHANNEL_SECRET}
       LINE_CALLBACK_URL: ${LINE_CALLBACK_URL}
       FRONTEND_URL: ${FRONTEND_URL}
+      # Admin bootstrap allowlist (issue #348): one-time first-admin
+      # provisioning. NOT part of the CI deploy payload — set it by hand in
+      # the server-side .env for the bootstrap window, then remove it.
+      # Empty/unset = feature off.
+      ADMIN_BOOTSTRAP_EMAILS: ${ADMIN_BOOTSTRAP_EMAILS:-}
       # Rust-specific logging
       RUST_LOG: ${RUST_LOG:-info}
       LOG_LEVEL: ${LOG_LEVEL:-info}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,9 @@ services:
       LINE_CLIENT_SECRET: ${LINE_CHANNEL_SECRET:?LINE_CHANNEL_SECRET is required}
       LINE_CALLBACK_URL: ${LINE_CALLBACK_URL:?LINE_CALLBACK_URL is required}
       FRONTEND_URL: ${FRONTEND_URL:?FRONTEND_URL is required}
+      # Admin bootstrap allowlist (issue #348) — empty/unset = feature off.
+      # See .env.example for semantics and the remove-after-use warning.
+      ADMIN_BOOTSTRAP_EMAILS: ${ADMIN_BOOTSTRAP_EMAILS:-}
       # Email configuration (optional)
       SMTP_HOST: ${SMTP_HOST:-}
       SMTP_PORT: ${SMTP_PORT:-587}

--- a/docs/GOOGLE_OAUTH_SETUP.md
+++ b/docs/GOOGLE_OAUTH_SETUP.md
@@ -96,7 +96,7 @@ The `docker compose.yml` is configured to read these environment variables from 
 ### New User Flow:
 - Automatic account creation using Google profile data
 - Email is marked as verified (Google emails are trusted)
-- Gets appropriate role based on admin configuration
+- Created with the `customer` role (unless listed in `ADMIN_BOOTSTRAP_EMAILS`, see below)
 - Redirected to dashboard with welcome message
 
 ### Existing User Flow:
@@ -106,16 +106,31 @@ The `docker compose.yml` is configured to read these environment variables from 
 
 ## Admin Role Assignment
 
-Google OAuth users follow the same admin role assignment rules:
-- If email is in `adminEmails` → gets `admin` role
-- If email is in `superAdminEmails` → gets `super_admin` role  
-- Super admin takes precedence over admin if email is in both lists
+Roles live in the **database** (`users.role`), not in `config/admins.json` —
+the `adminEmails` / `superAdminEmails` lists there do **not** grant roles at
+OAuth login. A Google OAuth user becomes an admin through one of:
+
+- **`ADMIN_BOOTSTRAP_EMAILS`** (env var, issue #348): a comma-separated,
+  case-insensitive allowlist. New OAuth accounts with a listed email are
+  created as `admin`, and a startup sweep promotes pre-existing `customer`
+  rows with a listed email. Intended for E2E stacks and one-time
+  first-admin bootstrap — remove it afterwards. On staging/production the
+  variable must be added to the server-side `.env` and the backend
+  recreated; the step-by-step procedure (including why a hand-added value
+  does not survive the next deploy) is in `backend-rust/README.md`
+  ("First-admin bootstrap") and `.env.production.example`.
+- **An existing admin** changing the user's role via the admin role-change
+  endpoint.
+
+The `/api/auth/cf-exchange` admin auto-login reads the DB role, so a user
+must already be `admin`/`super_admin` in the database for it to work — the
+bootstrap is what creates that first row.
 
 ## Security Features
 
 - ✅ **Email verification**: Google users have verified emails by default
 - ✅ **No password required**: OAuth users don't need passwords
-- ✅ **Admin config integration**: Role assignment based on email configuration
+- ✅ **Admin bootstrap integration**: Optional first-admin provisioning via `ADMIN_BOOTSTRAP_EMAILS`
 - ✅ **Audit logging**: All OAuth actions are logged with provider information
 - ✅ **Session management**: Secure session handling with configurable secrets
 - ✅ **Error handling**: Graceful fallback when Google OAuth is not configured

--- a/docs/LINE_OAUTH_SETUP.md
+++ b/docs/LINE_OAUTH_SETUP.md
@@ -76,9 +76,12 @@ The `docker compose.yml` is configured to read these environment variables autom
 
 ### New User Flow:
 - Automatic account creation using LINE profile data
-- Uses LINE ID as unique identifier (email format: `line_{id}@line.oauth`)
-- Email is marked as unverified (LINE doesn't provide email)
-- Gets appropriate role based on admin configuration
+- Uses the LINE user ID as the unique identifier (`oauth_provider_id`)
+- The account is created with **no email** (`email = NULL`) — LINE Login
+  does not provide one, and the backend does not synthesize one
+- Always created with the `customer` role: the `ADMIN_BOOTSTRAP_EMAILS`
+  allowlist is email-based and is never consulted on the LINE signup
+  path, so it cannot apply here (see below)
 - Redirected to dashboard with welcome message
 
 ### Existing User Flow:
@@ -88,18 +91,26 @@ The `docker compose.yml` is configured to read these environment variables autom
 
 ## Admin Role Assignment
 
-LINE OAuth users follow the same admin role assignment rules:
-- If email is in `adminEmails` → gets `admin` role
-- If email is in `superAdminEmails` → gets `super_admin` role  
-- Super admin takes precedence over admin if email is in both lists
-- Note: Since LINE doesn't provide email, role assignment typically won't apply
+Roles live in the **database** (`users.role`), not in `config/admins.json` —
+the `adminEmails` / `superAdminEmails` lists there do **not** grant roles at
+OAuth login. A user becomes an admin through one of:
+
+- **`ADMIN_BOOTSTRAP_EMAILS`** (env var, issue #348): a comma-separated,
+  case-insensitive allowlist applied at registration and by a startup
+  sweep over pre-existing `customer` rows. It can **never** apply to
+  LINE-only accounts: they are created with `email = NULL` (not a
+  synthetic address), the LINE signup path never consults the allowlist,
+  and the startup sweep matches on email — which a NULL email never
+  satisfies.
+- **An existing admin** changing the user's role via the admin role-change
+  endpoint (the only path for LINE-only users).
 
 ## Security Features
 
 - ✅ **Profile verification**: LINE users have verified profiles by default
 - ✅ **No password required**: OAuth users don't need passwords
 - ✅ **Unique LINE ID**: Each LINE account has a unique ID for identification
-- ✅ **Admin config integration**: Role assignment based on email configuration
+- ✅ **Admin bootstrap integration**: `ADMIN_BOOTSTRAP_EMAILS` never applies to LINE-only accounts, which are created with `email = NULL` (see above)
 - ✅ **Audit logging**: All OAuth actions are logged with provider information
 - ✅ **Session management**: Secure session handling with configurable secrets
 - ✅ **Error handling**: Graceful fallback when LINE OAuth is not configured

--- a/tests/admin-tiers.api.spec.ts
+++ b/tests/admin-tiers.api.spec.ts
@@ -5,20 +5,20 @@ import { retryRequest } from './helpers/retry';
  * E2E tests for admin tier management (/api/loyalty/admin/tiers)
  *
  * Runs against a SHARED stack, so it never mutates the four real tiers:
- * when it can act as admin it works on ONE fixed-name INACTIVE probe tier
- * with create-if-missing-else-reuse semantics (repeated runs converge to a
+ * it works on ONE fixed-name INACTIVE probe tier with
+ * create-if-missing-else-reuse semantics (repeated runs converge to a
  * single row instead of accumulating uniquely-named tiers), updates only
  * that tier, and verifies it is visible in the admin list but hidden from
  * the public /api/loyalty/tiers endpoint.
  *
- * Admin capability is probed once in beforeAll: the CI stack seeds
- * e2e-admin@test.local through the public register endpoint, which may or
- * may not be elevated to the admin role depending on the stack's admin
- * provisioning. Instead of skipping when it is not elevated (this suite is
- * a deploy gate — silent skips would hide regressions), every mutation
- * test asserts the OTHER contract in that case: the endpoint must enforce
- * 403 for the non-elevated account. Both branches are real assertions
- * about the deployed backend.
+ * The CI backend container sets ADMIN_BOOTSTRAP_EMAILS=e2e-admin@test.local
+ * (.github/actions/start-app-stack/action.yml), so registering that email
+ * yields a REAL admin account from its very first JWT (issue #348).
+ * beforeAll hard-asserts that guarantee once, and every admin test then
+ * asserts the full admin contract unconditionally — no dual-branch 403
+ * arms, no skips (this suite is a deploy gate; silent skips would hide
+ * regressions). RBAC enforcement is still covered explicitly by the
+ * unauthenticated (401) and plain-customer (403) tests.
  */
 test.describe('Admin Tier Management', () => {
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:4202';
@@ -36,7 +36,6 @@ test.describe('Admin Tier Management', () => {
   const tierName = 'E2E Perks Probe (inactive)';
 
   let adminToken: string | null = null;
-  let adminIsPrivileged = false;
   let customerToken: string | null = null;
   let csrfToken: string | null = null;
   let createdTierId: string | null = null;
@@ -98,17 +97,38 @@ test.describe('Admin Tier Management', () => {
       if (registerResponse.ok()) {
         const registerData = await registerResponse.json();
         adminToken = registerData.tokens?.accessToken || registerData.accessToken;
+      } else {
+        // A parallel or earlier run may have registered the account between
+        // our login attempt and this register (409 Conflict). Retry the
+        // login ONCE and take that token; the hard assertions below still
+        // apply unconditionally.
+        const retryLoginResponse = await request.post(`${backendUrl}/api/auth/login`, {
+          data: { email: adminEmail, password: adminPassword },
+          headers: {
+            'Content-Type': 'application/json',
+            ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
+          },
+        });
+        if (retryLoginResponse.ok()) {
+          const retryLoginData = await retryLoginResponse.json();
+          adminToken = retryLoginData.tokens?.accessToken || retryLoginData.accessToken;
+        }
       }
     }
 
-    // Probe whether the account actually carries the admin role on this
-    // stack (depends on the stack's admin provisioning).
-    if (adminToken) {
-      const probe = await request.get(`${backendUrl}/api/loyalty/admin/tiers`, {
-        headers: authHeaders(adminToken),
-      });
-      adminIsPrivileged = probe.status() === 200;
-    }
+    // Hard-assert the account actually carries the admin role. The CI
+    // backend sets ADMIN_BOOTSTRAP_EMAILS=e2e-admin@test.local, which
+    // promotes this account to admin at registration — fail loudly here
+    // instead of silently degrading the deploy gate.
+    expect(adminToken, 'admin account login/registration must succeed').toBeTruthy();
+    const probe = await request.get(`${backendUrl}/api/loyalty/admin/tiers`, {
+      headers: authHeaders(adminToken as string),
+    });
+    expect(
+      probe.status(),
+      `GET /api/loyalty/admin/tiers must answer 200 for ${adminEmail} — ` +
+        'check ADMIN_BOOTSTRAP_EMAILS on the backend container',
+    ).toBe(200);
 
     // Register a regular customer for the 403 checks
     const customerRegisterResponse = await request.post(`${backendUrl}/api/auth/register`, {
@@ -176,24 +196,8 @@ test.describe('Admin Tier Management', () => {
   });
 
   test.describe('2. Create Inactive Tier', () => {
-    test('create or reuse the probe tier: full contract as admin, 403 otherwise', async ({ request }) => {
+    test('should create or reuse the inactive probe tier', async ({ request }) => {
       expect(adminToken, 'admin account login/registration must succeed').toBeTruthy();
-
-      if (!adminIsPrivileged) {
-        // Stack without admin provisioning: RBAC must still hold.
-        const response = await request.post(`${backendUrl}/api/loyalty/admin/tiers`, {
-          data: {
-            name: tierName,
-            min_nights: 9999,
-            color: '#123456',
-            is_active: false,
-            benefits: initialBenefits,
-          },
-          headers: authHeaders(adminToken as string),
-        });
-        expect(response.status()).toBe(403);
-        return;
-      }
 
       // Create-if-missing-else-reuse: look the fixed name up first so
       // repeated runs on a shared stack converge to one probe row.
@@ -258,23 +262,22 @@ test.describe('Admin Tier Management', () => {
       expect(createdTierId).toBeTruthy();
     });
 
-    test('invalid tier payloads: 400 as admin, 403 otherwise', async ({ request }) => {
+    test('invalid tier payloads are rejected with 400', async ({ request }) => {
       expect(adminToken, 'admin account login/registration must succeed').toBeTruthy();
-      const rejectedStatus = adminIsPrivileged ? 400 : 403;
 
       // Invalid color
       const badColor = await request.post(`${backendUrl}/api/loyalty/admin/tiers`, {
         data: { name: `E2E Bad Color ${Date.now()}`, min_nights: 1, color: 'red', is_active: false },
         headers: authHeaders(adminToken as string),
       });
-      expect(badColor.status()).toBe(rejectedStatus);
+      expect(badColor.status()).toBe(400);
 
       // Negative min_nights
       const badNights = await request.post(`${backendUrl}/api/loyalty/admin/tiers`, {
         data: { name: `E2E Bad Nights ${Date.now()}`, min_nights: -1, color: '#123456', is_active: false },
         headers: authHeaders(adminToken as string),
       });
-      expect(badNights.status()).toBe(rejectedStatus);
+      expect(badNights.status()).toBe(400);
 
       // Legacy flat benefits shape must be rejected
       const badBenefits = await request.post(`${backendUrl}/api/loyalty/admin/tiers`, {
@@ -287,43 +290,25 @@ test.describe('Admin Tier Management', () => {
         },
         headers: authHeaders(adminToken as string),
       });
-      expect(badBenefits.status()).toBe(rejectedStatus);
+      expect(badBenefits.status()).toBe(400);
     });
 
-    test('duplicate tier name: 409 as admin, 403 otherwise', async ({ request }) => {
+    test('duplicate tier name is rejected with 409', async ({ request }) => {
       expect(adminToken, 'admin account login/registration must succeed').toBeTruthy();
+      expect(createdTierId, 'tier must have been created').toBeTruthy();
 
       const response = await request.post(`${backendUrl}/api/loyalty/admin/tiers`, {
         data: { name: tierName, min_nights: 9999, color: '#123456', is_active: false },
         headers: authHeaders(adminToken as string),
       });
 
-      if (!adminIsPrivileged) {
-        expect(response.status()).toBe(403);
-        return;
-      }
-
-      expect(createdTierId, 'tier must have been created').toBeTruthy();
       expect(response.status()).toBe(409);
     });
   });
 
   test.describe('3. Update the Created Tier', () => {
-    test('update benefits and color: full contract as admin, 403 otherwise', async ({ request }) => {
+    test('should update benefits and color on the probe tier', async ({ request }) => {
       expect(adminToken, 'admin account login/registration must succeed').toBeTruthy();
-
-      if (!adminIsPrivileged) {
-        const response = await request.put(
-          `${backendUrl}/api/loyalty/admin/tiers/00000000-0000-0000-0000-000000000000`,
-          {
-            data: { benefits: updatedBenefits, color: '#654321' },
-            headers: authHeaders(adminToken as string),
-          },
-        );
-        expect(response.status()).toBe(403);
-        return;
-      }
-
       expect(createdTierId, 'tier must have been created').toBeTruthy();
       const response = await request.put(
         `${backendUrl}/api/loyalty/admin/tiers/${createdTierId}`,
@@ -344,7 +329,7 @@ test.describe('Admin Tier Management', () => {
       expect(body.data.recalculation).toBeNull();
     });
 
-    test('unknown tier id: 404 as admin, 403 otherwise', async ({ request }) => {
+    test('unknown tier id returns 404', async ({ request }) => {
       expect(adminToken, 'admin account login/registration must succeed').toBeTruthy();
 
       const response = await request.put(
@@ -354,22 +339,17 @@ test.describe('Admin Tier Management', () => {
           headers: authHeaders(adminToken as string),
         },
       );
-      expect(response.status()).toBe(adminIsPrivileged ? 404 : 403);
+      expect(response.status()).toBe(404);
     });
   });
 
   test.describe('4. Visibility', () => {
-    test('admin tier list: includes the inactive tier as admin, 403 otherwise', async ({ request }) => {
+    test('admin tier list includes the inactive probe tier', async ({ request }) => {
       expect(adminToken, 'admin account login/registration must succeed').toBeTruthy();
 
       const response = await request.get(`${backendUrl}/api/loyalty/admin/tiers`, {
         headers: authHeaders(adminToken as string),
       });
-
-      if (!adminIsPrivileged) {
-        expect(response.status()).toBe(403);
-        return;
-      }
 
       expect(response.status()).toBe(200);
       const body = await response.json();

--- a/tests/coupon-lifecycle.api.spec.ts
+++ b/tests/coupon-lifecycle.api.spec.ts
@@ -4,11 +4,25 @@ import { retryRequest } from './helpers/retry';
 /**
  * E2E tests for complete coupon lifecycle
  * Tests coupon creation, activation, assignment, revocation, deletion, and expiration
+ *
+ * The CI backend container sets ADMIN_BOOTSTRAP_EMAILS=e2e-admin@test.local
+ * (.github/actions/start-app-stack/action.yml), so the seeded admin account
+ * is promoted to a real admin at registration (issue #348). beforeAll
+ * hard-asserts that privilege once; every admin test then asserts the full
+ * admin contract unconditionally — no "skip on 403" escapes.
+ *
+ * Request/response shapes follow the Rust backend
+ * (backend-rust/src/routes/coupons.rs): request DTOs are snake_case
+ * (coupon_type, usage_limit, valid_until), responses are wrapped in
+ * { success, data } and paginated lists in { items, total, page, limit,
+ * totalPages }. The camelCase shapes this spec used to send date from the
+ * old Node backend and never executed — they were hidden behind the skips.
  */
 test.describe('Coupon Lifecycle Management', () => {
   const backendUrl = process.env.BACKEND_URL || 'http://localhost:4202';
 
-  // Admin credentials - use fixed email that matches admins.e2e.json (mounted in E2E Docker)
+  // Admin credentials - fixed email listed in ADMIN_BOOTSTRAP_EMAILS on the
+  // CI backend container, so this account carries role=admin.
   const adminEmail = process.env.E2E_ADMIN_EMAIL || 'e2e-admin@test.local';
   const adminPassword = process.env.E2E_ADMIN_PASSWORD || 'AdminPassword123!';
 
@@ -40,7 +54,7 @@ test.describe('Coupon Lifecycle Management', () => {
     }
 
     // Try to login as admin first (might already exist)
-    let adminLoginResponse = await request.post(`${backendUrl}/api/auth/login`, {
+    const adminLoginResponse = await request.post(`${backendUrl}/api/auth/login`, {
       data: {
         email: adminEmail,
         password: adminPassword,
@@ -69,11 +83,46 @@ test.describe('Coupon Lifecycle Management', () => {
       if (registerResponse.ok()) {
         const registerData = await registerResponse.json();
         adminToken = registerData.tokens?.accessToken || registerData.accessToken;
+      } else {
+        // A parallel or earlier run may have registered the account between
+        // our login attempt and this register (409 Conflict). Retry the
+        // login ONCE and take that token; the hard assertions below still
+        // apply unconditionally.
+        const retryLoginResponse = await request.post(`${backendUrl}/api/auth/login`, {
+          data: {
+            email: adminEmail,
+            password: adminPassword,
+          },
+          headers: {
+            'Content-Type': 'application/json',
+            ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
+          },
+        });
+        if (retryLoginResponse.ok()) {
+          const retryLoginData = await retryLoginResponse.json();
+          adminToken = retryLoginData.tokens?.accessToken || retryLoginData.accessToken;
+        }
       }
     } else {
       const loginData = await adminLoginResponse.json();
       adminToken = loginData.tokens?.accessToken || loginData.accessToken;
     }
+
+    // The suite is a deploy gate: fail loudly here instead of letting every
+    // admin test silently skip when the account is not what we expect.
+    expect(adminToken, 'admin login/registration must yield a token').toBeTruthy();
+
+    // Hard-assert the account actually carries the admin role: an
+    // admin-only endpoint must answer 200, not 403.
+    const privilegeProbe = await request.get(`${backendUrl}/api/coupons/analytics/stats`, {
+      headers: {
+        'Authorization': `Bearer ${adminToken}`,
+      },
+    });
+    expect(
+      privilegeProbe.status(),
+      `${adminEmail} must be a real admin — check ADMIN_BOOTSTRAP_EMAILS on the backend container`,
+    ).toBe(200);
 
     // Register customer user
     const customerRegisterResponse = await request.post(`${backendUrl}/api/auth/register`, {
@@ -89,39 +138,28 @@ test.describe('Coupon Lifecycle Management', () => {
       },
     });
 
-    if (customerRegisterResponse.ok()) {
-      const customerData = await customerRegisterResponse.json();
-      customerToken = customerData.tokens?.accessToken || customerData.accessToken;
-      customerId = customerData.user?.id;
-    }
-
-    // If we didn't get customerId from registration, try to get it from profile
-    if (!customerId && customerToken) {
-      const profileResponse = await request.get(`${backendUrl}/api/users/profile`, {
-        headers: {
-          'Authorization': `Bearer ${customerToken}`,
-        },
-      });
-      if (profileResponse.ok()) {
-        const profile = await profileResponse.json();
-        customerId = profile.userId;
-      }
-    }
+    expect(
+      customerRegisterResponse.ok(),
+      'customer registration must succeed (unique email per run)',
+    ).toBeTruthy();
+    const customerData = await customerRegisterResponse.json();
+    customerToken = customerData.tokens?.accessToken || customerData.accessToken;
+    customerId = customerData.user?.id;
+    expect(customerToken, 'customer registration must yield a token').toBeTruthy();
+    expect(customerId, 'customer registration must yield the user id').toBeTruthy();
   });
 
   test.describe('1. Create New Coupon', () => {
     test('should create a new draft coupon', async ({ request }) => {
-      test.skip(!adminToken, 'No admin token available');
-
       const couponData = {
         code: testCouponCode,
         name: 'E2E Test Coupon',
         description: 'Created by E2E test for lifecycle testing',
-        type: 'percentage',
+        coupon_type: 'percentage',
         value: 15,
         currency: 'THB',
-        usageLimitPerUser: 1,
-        usageLimit: 100,
+        usage_limit_per_user: 1,
+        usage_limit: 100,
       };
 
       const response = await request.post(`${backendUrl}/api/coupons`, {
@@ -133,31 +171,28 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      // May fail with 403 if test user is not admin - that's expected
-      if (response.status() === 403) {
-        test.skip(true, 'Test user does not have admin privileges');
-        return;
-      }
-
       expect(response.status()).toBe(201);
-      const coupon = await response.json();
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      const coupon = body.data;
 
       expect(coupon.code).toBe(couponData.code);
       expect(coupon.name).toBe(couponData.name);
-      expect(coupon.type).toBe(couponData.type);
+      expect(coupon.coupon_type).toBe(couponData.coupon_type);
       expect(coupon.status).toBe('draft'); // New coupons start as draft
 
       createdCouponId = coupon.id;
+      expect(createdCouponId).toBeTruthy();
     });
 
     test('should reject duplicate coupon code', async ({ request }) => {
-      test.skip(!adminToken || !createdCouponId, 'No admin token or coupon not created');
+      expect(createdCouponId, 'coupon must have been created').toBeTruthy();
 
       const response = await request.post(`${backendUrl}/api/coupons`, {
         data: {
           code: testCouponCode, // Same code as before
           name: 'Duplicate Code Test',
-          type: 'percentage',
+          coupon_type: 'percentage',
           value: 10,
         },
         headers: {
@@ -167,18 +202,16 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      // Should fail due to duplicate code
-      expect([400, 409, 403]).toContain(response.status());
+      // Duplicate key maps to AppError::AlreadyExists -> 409 Conflict
+      expect(response.status()).toBe(409);
     });
 
     test('should validate coupon type', async ({ request }) => {
-      test.skip(!adminToken, 'No admin token available');
-
       const response = await request.post(`${backendUrl}/api/coupons`, {
         data: {
           code: `INVALID${Date.now()}`.slice(0, 20).toUpperCase(),
           name: 'Invalid Type Test',
-          type: 'invalid_type', // Invalid type
+          coupon_type: 'invalid_type', // Not a CouponType variant
           value: 10,
         },
         headers: {
@@ -188,14 +221,15 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      // Should fail validation
-      expect([400, 403]).toContain(response.status());
+      // An unknown enum variant fails serde deserialization, which axum's
+      // Json extractor rejects with 422 before the handler runs.
+      expect(response.status()).toBe(422);
     });
   });
 
   test.describe('2. Activate Coupon', () => {
     test('should activate a draft coupon', async ({ request }) => {
-      test.skip(!adminToken || !createdCouponId, 'No admin token or coupon not created');
+      expect(createdCouponId, 'coupon must have been created').toBeTruthy();
 
       const response = await request.put(`${backendUrl}/api/coupons/${createdCouponId}`, {
         data: {
@@ -208,19 +242,14 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      if (response.status() === 403) {
-        test.skip(true, 'Test user does not have admin privileges');
-        return;
-      }
-
       expect(response.status()).toBe(200);
-      const coupon = await response.json();
-
-      expect(coupon.status).toBe('active');
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('active');
     });
 
     test('should be able to pause an active coupon', async ({ request }) => {
-      test.skip(!adminToken || !createdCouponId, 'No admin token or coupon not created');
+      expect(createdCouponId, 'coupon must have been created').toBeTruthy();
 
       const response = await request.put(`${backendUrl}/api/coupons/${createdCouponId}`, {
         data: {
@@ -233,18 +262,13 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      if (response.status() === 403) {
-        test.skip(true, 'Test user does not have admin privileges');
-        return;
-      }
-
       expect(response.status()).toBe(200);
-      const coupon = await response.json();
-
-      expect(coupon.status).toBe('paused');
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.data.status).toBe('paused');
 
       // Re-activate for next tests
-      await request.put(`${backendUrl}/api/coupons/${createdCouponId}`, {
+      const reactivate = await request.put(`${backendUrl}/api/coupons/${createdCouponId}`, {
         data: { status: 'active' },
         headers: {
           'Authorization': `Bearer ${adminToken}`,
@@ -252,12 +276,14 @@ test.describe('Coupon Lifecycle Management', () => {
           ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
         },
       });
+      expect(reactivate.status()).toBe(200);
     });
   });
 
   test.describe('3. Assign Coupon to User', () => {
     test('should assign coupon to a customer', async ({ request }) => {
-      test.skip(!adminToken || !createdCouponId || !customerId, 'Missing required data');
+      expect(createdCouponId, 'coupon must have been created').toBeTruthy();
+      expect(customerId, 'customer must have been registered').toBeTruthy();
 
       const response = await request.post(`${backendUrl}/api/coupons/assign`, {
         data: {
@@ -272,21 +298,17 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      if (response.status() === 403) {
-        test.skip(true, 'Test user does not have admin privileges');
-        return;
-      }
-
       expect(response.status()).toBe(200);
-      const result = await response.json();
+      const body = await response.json();
 
-      expect(result.success).toBe(true);
-      expect(result.assignedCount).toBeGreaterThan(0);
+      // Response is { success, data: [UserCouponResponse, ...], message }
+      expect(body.success).toBe(true);
+      expect(Array.isArray(body.data)).toBe(true);
+      expect(body.data.length).toBe(1);
+      expect(body.data[0].status).toBe('available');
     });
 
     test('customer should see assigned coupon in my-coupons', async ({ request }) => {
-      test.skip(!customerToken, 'No customer token available');
-
       const response = await request.get(`${backendUrl}/api/coupons/my-coupons`, {
         headers: {
           'Authorization': `Bearer ${customerToken}`,
@@ -296,26 +318,22 @@ test.describe('Coupon Lifecycle Management', () => {
       expect(response.status()).toBe(200);
       const result = await response.json();
 
-      // API returns { success: true, data: { coupons: [...], total, page, limit, totalPages } }
+      // API returns { success: true, data: { items: [...], total, page, limit, totalPages } }
       expect(result.success).toBe(true);
-      const coupons = result.data?.coupons || result.coupons || [];
+      const coupons = result.data?.items ?? [];
       expect(Array.isArray(coupons)).toBe(true);
 
-      // Find our test coupon
-      const testCoupon = coupons.find((c: { coupon?: { code: string }, code?: string }) =>
-        (c.coupon?.code === testCouponCode) || (c.code === testCouponCode)
-      );
+      // Items are flat user-coupon rows joined with the coupon's code
+      const testCoupon = coupons.find((c: { code: string }) => c.code === testCouponCode);
+      expect(testCoupon, 'assigned coupon must appear in my-coupons').toBeTruthy();
+      expect(testCoupon.status).toBe('available');
 
-      if (testCoupon) {
-        // Store the userCouponId for revocation test
-        assignedUserCouponId = testCoupon.id;
-        expect(testCoupon.status).toBe('available');
-      }
+      // Store the userCouponId for the revocation tests
+      assignedUserCouponId = testCoupon.id;
+      expect(assignedUserCouponId).toBeTruthy();
     });
 
     test('should validate couponId format', async ({ request }) => {
-      test.skip(!adminToken, 'No admin token available');
-
       const response = await request.post(`${backendUrl}/api/coupons/assign`, {
         data: {
           couponId: 'not-a-valid-uuid',
@@ -328,12 +346,13 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      // Should fail validation
-      expect([400, 403]).toContain(response.status());
+      // couponId deserializes into a Uuid; a malformed value fails serde and
+      // axum's Json extractor rejects it with 422 before the handler runs.
+      expect(response.status()).toBe(422);
     });
 
     test('should limit users per assignment request', async ({ request }) => {
-      test.skip(!adminToken || !createdCouponId, 'Missing required data');
+      expect(createdCouponId, 'coupon must have been created').toBeTruthy();
 
       // Create array of 101 fake UUIDs
       const tooManyUsers = Array(101).fill(null).map((_, i) =>
@@ -352,14 +371,14 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      // Should fail validation (max 100 users)
-      expect([400, 403]).toContain(response.status());
+      // Handler-level validation (max 100 users) -> 400
+      expect(response.status()).toBe(400);
     });
   });
 
   test.describe('4. Revoke Coupon from User', () => {
     test('should revoke assigned coupon from user', async ({ request }) => {
-      test.skip(!adminToken || !assignedUserCouponId, 'Missing required data');
+      expect(assignedUserCouponId, 'user coupon must have been assigned').toBeTruthy();
 
       const response = await request.post(`${backendUrl}/api/coupons/user-coupons/${assignedUserCouponId}/revoke`, {
         data: {
@@ -372,16 +391,11 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      if (response.status() === 403) {
-        test.skip(true, 'Test user does not have admin privileges');
-        return;
-      }
-
-      expect([200, 204]).toContain(response.status());
+      expect(response.status()).toBe(200);
     });
 
     test('customer should not see revoked coupon as available', async ({ request }) => {
-      test.skip(!customerToken || !assignedUserCouponId, 'Missing required data');
+      expect(assignedUserCouponId, 'user coupon must have been assigned').toBeTruthy();
 
       const response = await request.get(`${backendUrl}/api/coupons/my-coupons`, {
         headers: {
@@ -391,21 +405,20 @@ test.describe('Coupon Lifecycle Management', () => {
 
       expect(response.status()).toBe(200);
       const result = await response.json();
+      expect(result.success).toBe(true);
+      const coupons = result.data?.items ?? [];
 
-      const coupons = result.coupons || result;
+      // Revocation UPDATEs the row to status 'revoked' (it does not delete),
+      // and my-coupons applies no default status filter, so the row must
+      // still be listed — as revoked, never as available.
       const testCoupon = coupons.find((c: { id: string, status: string }) =>
         c.id === assignedUserCouponId
       );
-
-      // Coupon should either be revoked status or not in list at all
-      if (testCoupon) {
-        expect(testCoupon.status).toBe('revoked');
-      }
+      expect(testCoupon, 'revoked user-coupon row must still be listed').toBeTruthy();
+      expect(testCoupon.status).toBe('revoked');
     });
 
     test('should handle non-existent userCouponId', async ({ request }) => {
-      test.skip(!adminToken, 'No admin token available');
-
       const response = await request.post(`${backendUrl}/api/coupons/user-coupons/00000000-0000-0000-0000-000000000000/revoke`, {
         data: {
           reason: 'Testing non-existent',
@@ -417,14 +430,13 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      // Should return 404 or 403
-      expect([403, 404]).toContain(response.status());
+      expect(response.status()).toBe(404);
     });
   });
 
   test.describe('5. Delete Coupon', () => {
     test('should delete a coupon', async ({ request }) => {
-      test.skip(!adminToken || !createdCouponId, 'Missing required data');
+      expect(createdCouponId, 'coupon must have been created').toBeTruthy();
 
       const response = await request.delete(`${backendUrl}/api/coupons/${createdCouponId}`, {
         headers: {
@@ -433,16 +445,11 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      if (response.status() === 403) {
-        test.skip(true, 'Test user does not have admin privileges');
-        return;
-      }
-
-      expect([200, 204]).toContain(response.status());
+      expect(response.status()).toBe(200);
     });
 
     test('deleted coupon should not be accessible', async ({ request }) => {
-      test.skip(!adminToken || !createdCouponId, 'Missing required data');
+      expect(createdCouponId, 'coupon must have been created').toBeTruthy();
 
       const response = await request.get(`${backendUrl}/api/coupons/${createdCouponId}`, {
         headers: {
@@ -455,8 +462,6 @@ test.describe('Coupon Lifecycle Management', () => {
     });
 
     test('should handle non-existent couponId for deletion', async ({ request }) => {
-      test.skip(!adminToken, 'No admin token available');
-
       const response = await request.delete(`${backendUrl}/api/coupons/00000000-0000-0000-0000-000000000000`, {
         headers: {
           'Authorization': `Bearer ${adminToken}`,
@@ -464,8 +469,7 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      // Should return 404 or 403
-      expect([403, 404]).toContain(response.status());
+      expect(response.status()).toBe(404);
     });
   });
 
@@ -473,8 +477,6 @@ test.describe('Coupon Lifecycle Management', () => {
     let expiredCouponId: string | null = null;
 
     test('should create a coupon with past expiration date', async ({ request }) => {
-      test.skip(!adminToken, 'No admin token available');
-
       const pastDate = new Date();
       pastDate.setDate(pastDate.getDate() - 1); // Yesterday
 
@@ -482,10 +484,10 @@ test.describe('Coupon Lifecycle Management', () => {
         data: {
           code: `EXP${Date.now()}`.slice(0, 20).toUpperCase(),
           name: 'Expired Test Coupon',
-          type: 'percentage',
+          coupon_type: 'percentage',
           value: 10,
-          validUntil: pastDate.toISOString(),
-          status: 'active', // Try to create as active
+          valid_until: pastDate.toISOString(),
+          status: 'active', // Create as active; the past valid_until governs usability
         },
         headers: {
           'Authorization': `Bearer ${adminToken}`,
@@ -494,21 +496,14 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      if (response.status() === 403) {
-        test.skip(true, 'Test user does not have admin privileges');
-        return;
-      }
-
-      // May succeed but coupon should be expired
-      if (response.status() === 201) {
-        const coupon = await response.json();
-        expiredCouponId = coupon.id;
-      }
+      expect(response.status()).toBe(201);
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expiredCouponId = body.data.id;
+      expect(expiredCouponId).toBeTruthy();
     });
 
     test('should handle coupon with expiration date set', async ({ request }) => {
-      test.skip(!adminToken, 'No admin token available');
-
       // Create a coupon that will expire soon
       const futureDate = new Date();
       futureDate.setDate(futureDate.getDate() + 1); // Tomorrow
@@ -517,10 +512,10 @@ test.describe('Coupon Lifecycle Management', () => {
         data: {
           code: `FUT${Date.now()}`.slice(0, 20).toUpperCase(),
           name: 'Future Expiration Test',
-          type: 'fixed_amount',
+          coupon_type: 'fixed_amount',
           value: 100,
-          validFrom: new Date().toISOString(),
-          validUntil: futureDate.toISOString(),
+          valid_from: new Date().toISOString(),
+          valid_until: futureDate.toISOString(),
         },
         headers: {
           'Authorization': `Bearer ${adminToken}`,
@@ -529,23 +524,19 @@ test.describe('Coupon Lifecycle Management', () => {
         },
       });
 
-      if (response.status() === 403) {
-        test.skip(true, 'Test user does not have admin privileges');
-        return;
-      }
-
       expect(response.status()).toBe(201);
-      const coupon = await response.json();
-
-      expect(coupon.validUntil).toBeTruthy();
+      const body = await response.json();
+      expect(body.success).toBe(true);
+      expect(body.data.valid_until).toBeTruthy();
 
       // Clean up
-      await request.delete(`${backendUrl}/api/coupons/${coupon.id}`, {
+      const cleanup = await request.delete(`${backendUrl}/api/coupons/${body.data.id}`, {
         headers: {
           'Authorization': `Bearer ${adminToken}`,
           ...(csrfToken && { 'X-CSRF-Token': csrfToken }),
         },
       });
+      expect(cleanup.status()).toBe(200);
     });
 
     test.afterAll(async ({ request }) => {

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -24,7 +24,9 @@ export function getTestUserForWorker(workerIndex: number) {
   return TEST_USERS[workerIndex % TEST_USERS.length];
 }
 
-// Admin user for testing admin pages (configured in admins.e2e.json mounted in CI)
+// Admin user for testing admin pages. In CI the backend container sets
+// ADMIN_BOOTSTRAP_EMAILS=e2e-admin@test.local (.github/actions/start-app-stack),
+// so this account is promoted to a real admin when it registers.
 export const ADMIN_USER = {
   email: process.env.E2E_ADMIN_EMAIL || 'e2e-admin@test.local',
   password: process.env.E2E_ADMIN_PASSWORD || 'AdminPassword123!',


### PR DESCRIPTION
Closes #348.

## The problem

CI registered `e2e-admin@test.local` through `/api/auth/register`, which yields a `customer`. Nothing ever elevated it — `admins.e2e.json` was deleted along with the old Node backend, the E2E backend container mounts no admin config, and the `admins.json` email fallback is dormant anyway (the committed file uses key `admins`, the parser wants `adminEmails`). So every admin endpoint 403'd in CI and `coupon-lifecycle.api.spec.ts` masked it with ~23 `test.skip` calls — the admin half of the deploy gate had never run.

## The fix

**`ADMIN_BOOTSTRAP_EMAILS`** — a comma-separated allowlist. Matching accounts are promoted to `admin` at registration (in-transaction, so the first JWT already carries the role), on Google-OAuth signup, and by an idempotent startup sweep for pre-existing rows. Unset or empty means the feature is off. Beyond CI, this is the first-admin bootstrap path the app never had (cf-exchange only *reads* the DB role; it can't create one).

**Promotion is one-shot and fails closed.** This matters more than it first appears: `users.email` uniqueness is byte-exact (no citext, no lowercase index) and login is case-sensitive, so `Ops@…` and `ops@…` are different rows. A naive case-insensitive allowlist would let any anonymous visitor register a case variant of a listed address and receive an admin token, repeatedly. Promotion now requires all of:

1. exactly one case-insensitive candidate row (ambiguity → refuse + WARN naming a possible escalation attempt),
2. no row for that address already holding admin/super_admin,
3. no prior promotion recorded — a `user_audit_log` row (`admin_bootstrap_promotion`, hashed email) written in the same transaction as the role change, under a per-address advisory lock.

Consequence worth noting: a deliberate demotion (offboarding, compromise) is no longer silently undone by the next restart, which the earlier draft would have done.

**Specs tell the truth now.** With a real admin in CI, `coupon-lifecycle` and `admin-tiers` assert admin behaviour unconditionally — every `test.skip`, runtime 403 escape, and `adminIsPrivileged` branch removed. Since those admin paths had literally never executed, their payloads were still written for the old Node backend; they're realigned to the Rust contract (snake_case bodies, `{success,data}` envelopes, `data.items` pagination, 422 for serde rejections vs 400 for handler validation, exact 409/404). Unauthenticated-401 and customer-403 tests are unchanged — those are the legitimate 403 assertions.

**Plumbing/docs honesty.** `ADMIN_BOOTSTRAP_EMAILS` is wired into all four compose files (`${ADMIN_BOOTSTRAP_EMAILS:-}`, inert when unset) — previously it was documented for production but could never reach a deployed backend, so the documented procedure would have silently no-opped. The OAuth docs no longer claim `admins.json` `adminEmails` grants roles at login (no code path did), and now state that LINE accounts are created with `email = NULL` and can never be bootstrapped.

## Verification

- **End-to-end against a fresh DB, the way CI runs it**: 36/36 deploy-gate tests pass, **0 skipped**.
- **Escalation probe**: with the admin already promoted, registering `E2E-Admin@test.local` returns a *customer* token, 403s on `/api/loyalty/admin/tiers`, and leaves exactly one admin row; backend logs the refusal.
- **One-shot probe**: restart against the same DB re-runs the sweep and promotes nothing; exactly one audit row exists across both runs.
- Backend: 125/125 integration tests (incl. 8 new bootstrap tests), clippy/fmt clean, `sqlx prepare --check` passes with **zero** `.sqlx` diffs (all new queries are unchecked).

## Reviewer notes

- ⚠️ Security-sensitive by nature: anyone who can register a listed address becomes admin. Docs say to keep the window short and remove the variable after bootstrapping, and warn that the deploy regenerates the server-side `.env` from GitHub secrets (which does not include this var).
- `email-delivery.api.spec.ts` stays `describe.skip` — it's blocked on a backend endpoint that doesn't exist, unrelated to this issue.
- One-line `backend-rust/Cargo.lock` change: version sync 4.3.0 → 4.4.0 that `cargo` applied mechanically; `--locked` CI builds need it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU