### PR TITLE
fix(ci): restore security-events permission on trivy scan-filesystem

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -182,6 +182,16 @@ jobs:
     # it directly off the commit means the SARIF is attributed to the commit
     # actually scanned instead of whatever main happened to be at.
     if: github.event_name != 'workflow_run'
+    # The workflow default (`contents: read`) is not enough for the SARIF
+    # upload below: github/codeql-action needs `security-events: write` for the
+    # code-scanning API, and `actions: read` to read the run it is attributing
+    # results to. Without this block the upload fails "Resource not accessible
+    # by integration" on every push to main. No `packages: read` — unlike the
+    # image jobs, this one never touches GHCR.
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:


### PR DESCRIPTION
## The regression

`Trivy Container Scan` has failed on **every push to `main`** since b52922ce (#346).

Failing run: https://github.com/thehfhotel/loyalty-app/actions/runs/30232708916 (commit `71e6437`)
Job `scan-filesystem`, step **Upload Trivy scan results** (`github/codeql-action/upload-sarif`):

```
Warning: This run of the CodeQL Action does not have permission to access the CodeQL
Action API endpoints... at least security-events
Error: Resource not accessible by integration
```

It has kept failing since — `4efb5b79`, `f23714d3`, `d89c29d1`, `96c9ab74` all red on the
`push` trigger, while the `workflow_run` runs for the same commits are green. That split is
the diagnosis: only the job on the push path is broken.

## Root cause

#346 rewrote `scan-filesystem` to run on `push`/`pull_request`/`schedule` instead of
`workflow_run`, deleting the untrusted-code checkout Scorecard flagged Critical. That rewrite
replaced the job's entire header hunk, and the job-level `permissions:` block was inside it:

```yaml
-    permissions:
-      contents: read
-      security-events: write
-      actions: read
```

Nothing put it back, so the job fell through to the workflow-level default (`permissions:
contents: read`) — no `security-events: write`, so the SARIF upload is denied. `scan-backend`
and `scan-frontend` kept their blocks, which is exactly why the image scans still pass.

## The fix

Restores the three scopes the job actually uses, and nothing else:

| scope | used by |
|---|---|
| `contents: read` | `actions/checkout` |
| `security-events: write` | `github/codeql-action/upload-sarif` (code-scanning API) |
| `actions: read` | run metadata the upload attributes results to |

Deliberately **not** `packages: read`: unlike the two image jobs, this one never logs into or
pulls from GHCR. That is the one scope where it stays narrower than its siblings.

## What stays closed

#346 closed a real security hole and this PR does not reopen any part of it:

- No `ref: ${{ github.event.workflow_run.head_sha }}` — the checkout still uses the event's
  default ref.
- No `nosemgrep` suppression re-added.
- `if: github.event_name != 'workflow_run'` is unchanged, so the job still never runs on the
  `workflow_run` trigger. `security-events: write` is only ever held on `push` /
  `pull_request` / `schedule`, where the checked-out code is already trusted — which is
  precisely the shape Scorecard's Dangerous-Workflow check wants.

## Scope check

- `git show --stat b52922ce` touched **only** `.github/workflows/trivy.yml` — no other
  workflow lost permissions in that commit.
- The other two SARIF uploaders were verified independently and are fine:
  `semgrep.yml` (job-level `security-events: write`) and `scorecard.yml` (job-level
  `security-events: write` + `id-token: write`).
- So `scan-filesystem` is the only job needing a fix.

Not fixed here (cosmetic, separate concern): #346 also dropped this job's
`name: Scan Filesystem (Dependencies)`, so it now displays as `scan-filesystem`. Renaming it
back would change the check name, which is unrelated to the failure — left alone deliberately.

## Validation

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/trivy.yml'))"   # OK
actionlint .github/workflows/trivy.yml                                          # clean
```

Real confirmation is this PR's own `scan-filesystem` run going green on merge to `main`
(the PR path doesn't upload SARIF by design, so the push run after merge is the proof).
