### PR TITLE
fix(ci): ship one verified healthcheck binary and prove deploys land (#360, #345)

### DIFF
--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -377,15 +377,31 @@ jobs:
           cache-on-failure: true
           prefix-key: "v0-rust-container"
 
-      - name: Build release binary
+      # `healthcheck` is built HERE, alongside the backend, so the binary that
+      # ships is the one compiled from src/bin/healthcheck.rs — the source CI
+      # lints and unit-tests. Dockerfile.ci used to vendor a second copy inline
+      # and compile it in rust:1.97-slim (trixie, glibc 2.41) for a bookworm
+      # (glibc 2.36) runtime; this container is bookworm, so the shipped binary
+      # is now built against exactly the libc it runs on. See issue #360.
+      # It is ~1MB with one transitive dep (ureq, no TLS) and shares this job's
+      # dependency graph, so it adds no measurable build time.
+      - name: Build release binaries
         working-directory: ./backend-rust
-        run: cargo build --release --bin loyalty-backend
+        run: cargo build --release --bin loyalty-backend --bin healthcheck
 
+      # upload-artifact roots the archive at the LEAST COMMON ANCESTOR of the
+      # given paths — `backend-rust/target/release/` — so both binaries land
+      # FLAT in the artifact and therefore flat in ./backend-binary, which is
+      # the Dockerfile.ci build context. Do not add a path outside
+      # target/release/ here without re-checking the COPY lines in
+      # Dockerfile.ci: a higher ancestor would nest them under directories.
       - name: Upload binary artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: loyalty-backend-binary
-          path: backend-rust/target/release/loyalty-backend
+          path: |
+            backend-rust/target/release/loyalty-backend
+            backend-rust/target/release/healthcheck
           retention-days: 1
 
       - name: Show sccache stats
@@ -432,11 +448,26 @@ jobs:
       # -------------------------------------------------------------------------
       # Backend Image (Rust) - uses pre-built binary from build-backend-release
       # -------------------------------------------------------------------------
-      - name: Download backend binary
+      # Unpacks BOTH release binaries (loyalty-backend + healthcheck) flat into
+      # ./backend-binary, which is the Dockerfile.ci build context below.
+      - name: Download backend binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: loyalty-backend-binary
           path: ./backend-binary
+
+      # Fail here, with a readable message, rather than 40 lines later inside
+      # a BuildKit "COPY failed" trace.
+      - name: Assert both binaries are in the build context
+        run: |
+          set -euo pipefail
+          ls -l ./backend-binary
+          for bin in loyalty-backend healthcheck; do
+            if [ ! -f "./backend-binary/$bin" ]; then
+              echo "::error::./backend-binary/$bin is missing — the upload/download artifact layout changed."
+              exit 1
+            fi
+          done
 
       - name: Extract backend metadata
         id: meta-backend
@@ -448,6 +479,7 @@ jobs:
             type=ref,event=branch
 
       - name: Build and push backend
+        id: build-backend
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./backend-binary
@@ -455,9 +487,94 @@ jobs:
           push: true
           tags: ${{ steps.meta-backend.outputs.tags }}
           labels: ${{ steps.meta-backend.outputs.labels }}
+          # Baked into the image as ENV GIT_SHA and surfaced by /api/health as
+          # `revision` (issue #345). The image carrying its own SHA is what lets
+          # the staging/production verifiers prove a deploy was not a no-op
+          # without any SSH access to the host.
+          build-args: |
+            GIT_SHA=${{ github.sha }}
           cache-from: type=gha,scope=backend-ci
           cache-to: type=gha,mode=max,scope=backend-ci
           platforms: linux/amd64
+
+      # -------------------------------------------------------------------------
+      # ASSERT THE SHIPPED healthcheck BINARY ACTUALLY EXECUTES (issue #360)
+      #
+      # docker-compose.prod.yml runs /app/healthcheck as the container's Docker
+      # HEALTHCHECK, but nothing gated on it — so a binary that could not even
+      # be loaded (glibc skew, lost exec bit, wrong architecture) would leave
+      # the container sitting `unhealthy` forever while serving traffic
+      # normally, with no CI, deploy step or alert saying so.
+      #
+      # Run it in the JUST-PUSHED image, which is the artifact that ships.
+      # Nothing listens on port 4001 in a bare container, so the CORRECT
+      # outcome is the binary's own connection-refused message on stderr and
+      # exit 1. The check is written so a loader failure can never be mistaken
+      # for that refusal: it requires the binary's own output text, which only
+      # executing code can produce, in addition to rejecting loader signatures.
+      #
+      # Addressed by DIGEST, not by tag. The digest is what this step just
+      # pushed, on every event type — whereas the SHA tag is computed by
+      # docker/metadata-action, which does not necessarily use `github.sha`
+      # on `pull_request` events. Pulling the digest can never test a
+      # different image than the one built here.
+      # -------------------------------------------------------------------------
+      - name: Assert shipped healthcheck binary executes
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/backend@${{ steps.build-backend.outputs.digest }}
+        run: |
+          # Deliberately no `-e` anywhere in this step: the EXPECTED outcome is
+          # a non-zero exit from `docker run`, and errexit would abort before
+          # the exit code could be inspected. Every failure path below exits
+          # explicitly instead.
+          set -uo pipefail
+
+          if ! docker pull "$IMAGE"; then
+            echo "::error::Could not pull the image just pushed ($IMAGE)."
+            exit 1
+          fi
+
+          OUTPUT=$(docker run --rm "$IMAGE" /app/healthcheck 2>&1)
+          CODE=$?
+
+          echo "exit code: ${CODE}"
+          echo "--- output ---"
+          printf '%s\n' "$OUTPUT"
+          echo "--------------"
+
+          # 1. Loader / exec signatures, checked FIRST and unconditionally.
+          #    These are what a build/runtime glibc mismatch, a dropped
+          #    executable bit, or a wrong-arch binary actually look like.
+          if printf '%s' "$OUTPUT" | grep -Eqi 'exec format error|error while loading shared libraries|cannot open shared object|GLIBC_|no such file or directory|permission denied|exec: .*not found'; then
+            echo "::error::/app/healthcheck could not be LOADED in the shipped image ($IMAGE). This is a loader failure (glibc skew / exec bit / architecture), not a health result. Output above."
+            exit 1
+          fi
+
+          # 2. Docker's own "could not start the process" exit codes. 125 =
+          #    daemon error, 126 = not executable, 127 = command not found.
+          case "$CODE" in
+            125|126|127)
+              echo "::error::docker run exited $CODE — the container could not execute /app/healthcheck at all (126 = not executable, 127 = not found, 125 = daemon error)."
+              exit 1
+              ;;
+          esac
+
+          # 3. Positive proof the compiled code RAN. Only the binary itself can
+          #    emit this line, so no loader/exec failure can satisfy it. Keep in
+          #    sync with the eprintln! in backend-rust/src/bin/healthcheck.rs.
+          if ! printf '%s' "$OUTPUT" | grep -Eq '^healthcheck: request to http://127\.0\.0\.1:4001/api/health failed:'; then
+            echo "::error::/app/healthcheck did not produce its own connection-refused message. Expected 'healthcheck: request to http://127.0.0.1:4001/api/health failed: ...' on stderr from a bare container where nothing listens on 4001."
+            exit 1
+          fi
+
+          # 4. And it must report failure the way the compose HEALTHCHECK
+          #    contract requires: exit 1, not 0 and not something else.
+          if [ "$CODE" -ne 1 ]; then
+            echo "::error::/app/healthcheck ran but exited $CODE; the contract is exit 1 on an unreachable backend."
+            exit 1
+          fi
+
+          echo "OK: shipped /app/healthcheck loaded, ran, and refused cleanly (exit 1)."
 
       # -------------------------------------------------------------------------
       # Frontend Image
@@ -681,6 +798,14 @@ jobs:
         env:
           BACKEND_URL: http://localhost:4202
           FRONTEND_URL: http://localhost:3201
+          # Proves the SHA bake works BEFORE anything is deployed (issue #345).
+          # This job runs the image that was just built and pushed for THIS
+          # commit, so health.api.spec.ts asserting revision == this SHA is a
+          # direct test that the image carries its own identity. The SHA is
+          # NOT injected into the container by start-app-stack — doing that
+          # would make the test assert its own input instead of the image's
+          # baked-in value.
+          EXPECTED_REVISION: ${{ github.sha }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
@@ -891,14 +1016,21 @@ jobs:
   #
   #   1. staging /api/health answers 200 — twice in a row, because a container
   #      that binds the port and then crashes satisfies a single-shot check;
-  #   2. `loyalty_backend_dev` is actually running THIS commit's image.
+  #   2. the app reports THIS commit as its `revision`.
   #
   # (2) matters because /api/health's `version` field is CARGO_PKG_VERSION — a
-  # hard-coded 0.1.0 identical on every commit — so a 200 proves only that
+  # hard-coded value identical on every commit — so a 200 proves only that
   # *something* answers. This job's green is what deploy.yml's
   # check-prerequisites reads to authorise the now-UNATTENDED production
   # deploy, so "staging silently stayed on the old build" must not read as
   # verified.
+  #
+  # `revision` is baked into the image at build time (ARG/ENV GIT_SHA in
+  # Dockerfile.ci, build-arg set in build-and-push) — NOT injected by the
+  # deploy host. That is deliberate: the remote shim on evergreen cannot be
+  # edited from this repo, and the deploy key carries a forced command, so
+  # neither `ssh ... docker inspect` nor a shim change was available. An image
+  # that carries its own SHA needs neither.
   #
   # The matching environment URL is set on `deploy-staging` above.
   # =============================================================================
@@ -909,35 +1041,14 @@ jobs:
     needs: [deploy-staging]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     timeout-minutes: 10
-    # REQUIRED for the SSH steps below: EVERGREEN_DEPLOY_SSH_KEY and
-    # EVERGREEN_HOST_KEY exist ONLY as environment-scoped secrets (development
-    # and production), never at repository scope. A job without `environment:`
-    # reads them as empty strings — GitHub does not error, so the composite
-    # writes an EMPTY known_hosts and ssh fails with the misleading
-    # "No ED25519 host key is known for evergreen.thehfhotel.org".
-    # deploy-staging worked only because it declares this environment.
+    # This job now needs NO secrets: both checks are plain HTTPS against the
+    # staging URL. `environment:` is kept only so the deployment shows up
+    # against the development environment in the GitHub UI.
     environment:
       name: development
       url: http://loyalty-dev.saichon.com
 
     steps:
-      # SSH is needed on BOTH paths now — the revision assertion below on the
-      # happy path, log capture on the failure path — so set it up up-front
-      # rather than under an `if: failure()` guard. This job has no checkout
-      # otherwise (it only curls a URL), so fetch just the composite action.
-      - name: Checkout SSH action
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v4
-        with:
-          persist-credentials: false
-          sparse-checkout: .github/actions/evergreen-ssh
-          sparse-checkout-cone-mode: false
-
-      - name: Set up SSH access to evergreen
-        uses: ./.github/actions/evergreen-ssh
-        with:
-          ssh-key: ${{ secrets.EVERGREEN_DEPLOY_SSH_KEY }}
-          host-key: ${{ secrets.EVERGREEN_HOST_KEY }}
-
       - name: Poll staging /api/health
         id: poll
         env:
@@ -963,71 +1074,72 @@ jobs:
           echo "::error::Staging /api/health not responding after 90s"
           exit 1
 
-      # NOTE: a revision assertion used to live here (audit finding #16 — prove
-      # the deploy was not a no-op, not merely that *something* answers 200).
-      # It CANNOT be done over this SSH key: the deploy key carries a FORCED
-      # COMMAND server-side, which is why the deploy job pipes its payload to
-      # stdin and passes no remote command at all. Any client-supplied command
-      # (docker inspect / docker ps) is ignored by the forced command, so the
-      # assertion could only ever report "<could not determine>" and fail every
-      # deploy — it blocked two production releases before this was understood.
+      # ---------------------------------------------------------------------
+      # ASSERT STAGING IS RUNNING THIS COMMIT (issue #345)
       #
-      # The right fix is to make the running app report its own commit: inject
-      # the deploy's COMMIT_SHA into the container and surface it from
-      # /api/health, then assert on that over plain HTTP with no SSH at all.
-      # Tracked as a follow-up issue.
-
-      # The rest of this job runs only when the health poll above fails, to
-      # grab backend logs + container state from the staging host before the
-      # next push overwrites them.
+      # PHASED ROLLOUT — three outcomes, on purpose:
+      #   revision == this SHA        -> pass (the deploy really landed)
+      #   revision absent / "unknown" -> WARN but pass. Images built before
+      #                                  the GIT_SHA bake existed, and any
+      #                                  rollback to one, legitimately cannot
+      #                                  answer. Failing on those would turn
+      #                                  a rollback into a red deploy at the
+      #                                  worst possible moment.
+      #   revision == a DIFFERENT SHA -> FAIL. This is the genuine signal the
+      #                                  audit asked for: staging answered,
+      #                                  but from another build — a no-op,
+      #                                  partial, or overtaken deploy.
       #
-      # CAVEAT: these steps pass explicit remote commands, which the deploy
-      # key's forced command may ignore (see the note above) — in which case
-      # they capture nothing. They are tolerant of failure and only run on the
-      # failure path, so they cannot make a run red, but do NOT treat an empty
-      # artifact as "staging looked fine". Confirming/fixingthis is part of
-      # the same follow-up as the revision assertion.
-
-      - name: Capture staging logs + container state (on failure)
-        if: failure()
+      # Once no pre-bake image can be rolled back to, the warn branch should
+      # become a failure.
+      # ---------------------------------------------------------------------
+      - name: Assert staging is running this commit
+        env:
+          STAGING_HEALTH_URL: http://loyalty-dev.saichon.com/api/health
+          EXPECTED_SHA: ${{ github.sha }}
         run: |
           set -uo pipefail
-          mkdir -p staging-failure-logs
 
-          # Tolerate per-command failure: even partial output is useful when
-          # the box is sick. We `|| true` each remote invocation so a missing
-          # service or auth error doesn't truncate the rest.
-          SSH_CMD=(ssh -i ~/.ssh/deploy_key
-            -o StrictHostKeyChecking=yes
-            -o UserKnownHostsFile=~/.ssh/known_hosts
-            -o ProxyCommand="cloudflared --edge-ip-version 4 access ssh --hostname %h"
-            -o ConnectTimeout=15
-            deploy@evergreen.thehfhotel.org)
+          # Poll until it MATCHES rather than classifying the first sample:
+          # for a few seconds after a deploy the outgoing container can still
+          # be answering through nginx while the new one starts, and reading
+          # that as "serving a different commit" would fail a perfectly good
+          # deploy. Only a revision that never becomes this SHA is a finding.
+          #
+          # Deliberately NOT `curl -f`: /api/health answers 503 when a
+          # dependency is degraded, and -f discards the body on a 4xx/5xx —
+          # which is exactly the body carrying `revision`. A degraded staging
+          # still tells us WHICH BUILD is degraded, and that is the question
+          # this step exists to answer.
+          REVISION=""
+          for attempt in $(seq 1 20); do
+            BODY=$(curl -sS --max-time 5 "$STAGING_HEALTH_URL" 2>/dev/null || true)
+            REVISION=$(printf '%s' "$BODY" | jq -r '.revision // empty' 2>/dev/null || true)
+            if [ "$REVISION" = "$EXPECTED_SHA" ]; then
+              echo "Staging is running $EXPECTED_SHA (after ${attempt} attempt(s))."
+              exit 0
+            fi
+            sleep 3
+          done
 
-          "${SSH_CMD[@]}" 'docker ps --filter "name=loyalty_" --format "table {{.Names}}\t{{.Status}}\t{{.Image}}"' \
-            > staging-failure-logs/containers.txt 2>&1 || true
+          echo "expected revision:  $EXPECTED_SHA"
+          echo "last seen revision: ${REVISION:-<absent>}"
 
-          "${SSH_CMD[@]}" 'docker logs --tail 200 loyalty_backend_dev 2>&1' \
-            > staging-failure-logs/backend.log 2>&1 || true
+          if [ -z "$REVISION" ] || [ "$REVISION" = "unknown" ]; then
+            echo "::warning::Staging /api/health reports no revision (${REVISION:-absent}). The running image predates the GIT_SHA bake, or this is a rollback to such an image. Cannot prove the deploy landed — NOT failing the deploy for it."
+            {
+              echo "## Verify Staging: revision unavailable"
+              echo ""
+              echo "- Expected: \`$EXPECTED_SHA\`"
+              echo "- Reported: \`${REVISION:-absent}\`"
+              echo ""
+              echo "The running image was built before \`GIT_SHA\` was baked in."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
 
-          "${SSH_CMD[@]}" 'docker logs --tail 100 loyalty_postgres_dev 2>&1' \
-            > staging-failure-logs/postgres.log 2>&1 || true
-
-          "${SSH_CMD[@]}" 'docker logs --tail 100 loyalty_nginx_dev 2>&1' \
-            > staging-failure-logs/nginx.log 2>&1 || true
-
-          echo "--- containers.txt ---"
-          cat staging-failure-logs/containers.txt || true
-          echo "--- backend.log (tail) ---"
-          tail -40 staging-failure-logs/backend.log || true
-
-      - name: Upload failure logs as artifact (on failure)
-        if: failure()
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
-        with:
-          name: staging-failure-logs-${{ github.sha }}
-          path: staging-failure-logs/
-          retention-days: 14
+          echo "::error::Staging is serving a DIFFERENT commit. Expected $EXPECTED_SHA, got $REVISION. The deploy was a no-op, partial, or has been overtaken — staging must NOT be treated as verified for this commit."
+          exit 1
 
   # =============================================================================
   # NOTIFY ON STAGING HEALTHCHECK FAILURE
@@ -1081,16 +1193,26 @@ jobs:
           checks and the run log says which one failed:
           - \`/api/health\` never answered 200 twice in a row → the new image is
             up but not serving (crash loop, bad migration, missing env var).
-          - \`loyalty_backend_dev\` is not running this commit's image → the
-            deploy was a no-op, partial, or overtaken; staging is still on an
-            older build and must NOT be treated as verified.
+          - \`/api/health\` reported a \`revision\` that is a DIFFERENT commit →
+            the deploy was a no-op, partial, or overtaken; staging is still on
+            an older build and must NOT be treated as verified. (An absent or
+            \`unknown\` revision only warns — it means the running image
+            predates the SHA bake.)
 
           Investigate:
           1. Open the run log linked above to see which check failed.
-          2. Download the \`staging-failure-logs-*\` artifact (container state +
-             backend/postgres/nginx logs captured from evergreen).
+          2. Ask staging what it thinks it is running:
+             \`curl -sS http://loyalty-dev.saichon.com/api/health | jq '{status, revision, services}'\`
+             (no \`-f\` — a degraded backend answers 503 and the body is the
+             part you need).
           3. Roll back via \`docs/rollback-runbook.md\` if root cause is not
              a quick fix.
+
+          There is deliberately NO log artifact attached. The steps that used to
+          SSH to evergreen for \`docker logs\` could never work — the deploy key
+          carries a forced command, so client-supplied commands are ignored —
+          and a silently empty artifact is worse than none. Host logs need a
+          human session on evergreen.
           EOF
           )
 

--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -523,10 +523,14 @@ jobs:
         env:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/backend@${{ steps.build-backend.outputs.digest }}
         run: |
-          # Deliberately no `-e` anywhere in this step: the EXPECTED outcome is
-          # a non-zero exit from `docker run`, and errexit would abort before
-          # the exit code could be inspected. Every failure path below exits
-          # explicitly instead.
+          # errexit must be turned OFF explicitly: GitHub runs `run:` blocks
+          # under `bash -e {0}`, so omitting `-e` from the `set` line is not
+          # enough. The EXPECTED outcome here is a non-zero exit from
+          # `docker run` (nothing listens on 4001 in a bare container), and
+          # under errexit the command substitution aborts the step before the
+          # exit code can be inspected — silently, with no output. Every
+          # failure path below exits explicitly instead.
+          set +e
           set -uo pipefail
 
           if ! docker pull "$IMAGE"; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -338,6 +338,62 @@ jobs:
           echo "::error::Production /api/health not responding 90s after deploy"
           exit 1
 
+      # A 200 proves only that *something* answers — `version` is
+      # CARGO_PKG_VERSION, identical on every commit. `revision` is the commit
+      # SHA baked into the image at build time (ARG/ENV GIT_SHA), so it proves
+      # WHICH BUILD is serving. That matters most here: production deploys are
+      # unattended, and the deploy host's shim cannot be reached for a
+      # `docker inspect` (the deploy key carries a forced command). Issue #345.
+      #
+      # PHASED ROLLOUT — three outcomes, same contract as verify-staging:
+      #   revision == deploying SHA   -> pass
+      #   revision absent / "unknown" -> WARN but pass (image predates the
+      #                                  bake, or this is a rollback to one;
+      #                                  a rollback must not go red for it)
+      #   revision == a DIFFERENT SHA -> FAIL (no-op / partial / overtaken)
+      - name: Verify production is running this commit
+        env:
+          PROD_HEALTH_URL: https://loyalty.saichon.com/api/health
+          EXPECTED_SHA: ${{ needs.check-prerequisites.outputs.commit-sha }}
+        run: |
+          set -uo pipefail
+
+          # Poll until it MATCHES rather than classifying the first sample:
+          # for a few seconds after a deploy the outgoing container can still
+          # answer through nginx while the new one starts, and reading that as
+          # "serving a different commit" would fail a perfectly good deploy.
+          #
+          # Deliberately NOT `curl -f`: /api/health answers 503 when a
+          # dependency is degraded and -f throws away the body, which is the
+          # only place `revision` lives.
+          REVISION=""
+          for attempt in $(seq 1 20); do
+            BODY=$(curl -sS --max-time 5 "$PROD_HEALTH_URL" 2>/dev/null || true)
+            REVISION=$(printf '%s' "$BODY" | jq -r '.revision // empty' 2>/dev/null || true)
+            if [ "$REVISION" = "$EXPECTED_SHA" ]; then
+              echo "Production is running $EXPECTED_SHA (after ${attempt} attempt(s))."
+              exit 0
+            fi
+            sleep 3
+          done
+
+          echo "expected revision:  $EXPECTED_SHA"
+          echo "last seen revision: ${REVISION:-<absent>}"
+
+          if [ -z "$REVISION" ] || [ "$REVISION" = "unknown" ]; then
+            echo "::warning::Production /api/health reports no revision (${REVISION:-absent}). The running image predates the GIT_SHA bake, or this is a rollback to such an image. Cannot prove the deploy landed — NOT failing for it."
+            {
+              echo "## Production revision unavailable"
+              echo ""
+              echo "- Expected: \`$EXPECTED_SHA\`"
+              echo "- Reported: \`${REVISION:-absent}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "::error::Production is serving a DIFFERENT commit. Expected $EXPECTED_SHA, got $REVISION. The deploy was a no-op, partial, or has been overtaken."
+          exit 1
+
       - name: Deployment Summary
         run: |
           echo "## Production Deployment Complete" >> $GITHUB_STEP_SUMMARY

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,10 @@ Workflows fire on push to `main`:
   (`regression-api`, the Playwright `api` project — `*.api.spec.ts`),
   which uses Playwright's request context with **no browser**, so it has
   no `cdn.playwright.dev` dependency and is reliable enough to block
-  deploys.
+  deploys. Build & Push also runs `/app/healthcheck` inside the image it
+  just pushed and requires the binary's own connection-refused message
+  and exit 1 — the compose `HEALTHCHECK` had no gate before, so a
+  binary that could not even load was invisible.
 - `e2e.yml` (**Browser E2E**) — the full browser suite (Playwright
   `browser` project — `*.browser.spec.ts`), run inside the
   `mcr.microsoft.com/playwright` container so browsers are pre-baked (no
@@ -198,6 +201,15 @@ that reviewer:
   reach production, because it skips the staging deploy.
 - **Post-deploy health check.** Polls production `/api/health` for 90s;
   a crash-looping release fails the job instead of reporting green.
+- **Revision assertion.** Images bake their commit SHA in at build time
+  (`ARG GIT_SHA`) and `/api/health` reports it as `revision`, so both
+  `Verify Staging` and the production verify step prove the deploy
+  actually shipped *this* commit rather than merely that something
+  answers 200. Phased: a matching SHA passes, an absent/`unknown` one
+  warns (pre-bake images and rollbacks), a *different* SHA fails.
+  Check it by hand with
+  `curl -sS <url>/api/health | jq -r .revision` (no `-f` — a 503 still
+  carries the body you need).
 - Failure *or cancellation* files a `Production deploy failed` issue.
 
 Verify a deploy with

--- a/backend-rust/Cargo.lock
+++ b/backend-rust/Cargo.lock
@@ -1872,7 +1872,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loyalty-backend"
-version = "4.4.0"
+version = "4.4.1"
 dependencies = [
  "anyhow",
  "argon2",

--- a/backend-rust/Dockerfile
+++ b/backend-rust/Dockerfile
@@ -121,6 +121,13 @@ USER nonroot:nonroot
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=0
 
+# Commit SHA baked in at build time and surfaced by /api/health as `revision`
+# (issue #345). Mirrors Dockerfile.ci so a locally built image reports the same
+# shape as a CI-built one; defaults to `unknown`, which the deploy verifiers
+# treat as "cannot tell" rather than a mismatch.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
+
 EXPOSE 4001
 
 # No HEALTHCHECK directive: the docker-compose.prod.yml `healthcheck:` block

--- a/backend-rust/Dockerfile.ci
+++ b/backend-rust/Dockerfile.ci
@@ -1,23 +1,39 @@
 # syntax=docker/dockerfile:1.7
 # ==============================================================================
-# CI Dockerfile - Pairs a pre-built loyalty-backend binary with a tiny
-#                 in-Dockerfile-compiled healthcheck binary on Distroless.
+# CI Dockerfile - Packages the two pre-built binaries from the GitHub Actions
+#                 runner (`loyalty-backend` + `healthcheck`) onto Distroless.
 #
-# Why two binaries:
-#   - `loyalty-backend` is built on the GitHub runner (saves ~15 min vs
-#     compiling inside Docker) and copied in as a build-context artifact.
-#   - `healthcheck` is a small pure-Rust binary (~1MB) compiled HERE in
-#     stage 1 because the CI workflow only uploads one artifact path
-#     (`backend-rust/target/release/loyalty-backend`). A focused build of
-#     one tiny bin with one transitive dep (ureq, no TLS) finishes in
-#     well under a minute, so this doesn't reintroduce the ~15-minute
-#     full-backend penalty.
+# Why the binaries come from the build context:
+#   Both are produced by ci-build-e2e.yml's `build-backend-release` job with
+#   `cargo build --release --bin loyalty-backend --bin healthcheck`, uploaded
+#   as one artifact and downloaded into `./backend-binary`, which is this
+#   build's context. actions/upload-artifact roots the archive at the LEAST
+#   COMMON ANCESTOR of its paths — here `backend-rust/target/release/` — so
+#   both binaries land FLAT next to each other in the context.
 #
-#   Why not change the workflow to upload both?
-#     This Dockerfile lives in the same PR as the Distroless flip and the
-#     compose healthcheck change. Touching the workflow expands the blast
-#     radius. A follow-up PR can move the healthcheck build back to the
-#     runner once this lands cleanly.
+#   Building on the runner (instead of inside Docker) saves ~15 minutes on the
+#   deploy critical path, which is why loyalty-backend has always worked this
+#   way.
+#
+# Why there is no longer an `hc-builder` stage (issue #360):
+#   This file used to vendor a COPY of src/bin/healthcheck.rs inline as a
+#   heredoc and compile it here, because the workflow uploaded only one
+#   artifact path. That was wrong twice over:
+#
+#     1. Two sources for one binary. The vendored copy was the one that
+#        SHIPPED, and it was the one CI never compiled, linted, or tested —
+#        drift could only be discovered in production.
+#     2. Build/runtime libc skew. The vendored copy was compiled in
+#        `rust:1.97-slim`, which is `debian:trixie-slim` (glibc 2.41), then
+#        shipped into `gcr.io/distroless/cc-debian12` (bookworm, glibc 2.36).
+#        Nothing asserted the result could even be loaded.
+#
+#   Both are gone: the healthcheck is now built by the same job, in the same
+#   `rust:1.93-bookworm` container, as loyalty-backend — so it is compiled
+#   against the SAME glibc 2.36 the runtime ships — and ci-build-e2e.yml runs
+#   `/app/healthcheck` inside the pushed image and requires it to exit 1 with
+#   its own connection-refused message. A loader failure now turns CI red
+#   instead of sitting invisible in an `unhealthy` container.
 #
 # Why Distroless:
 #   - gcr.io/distroless/cc-debian12 has no shell, no apt, no curl — just
@@ -26,11 +42,7 @@
 #     reports against debian:bookworm-slim.
 #   - The standard `curl`-based HEALTHCHECK is replaced by /app/healthcheck.
 #
-# IMPORTANT - Two-stage build:
-#   - Stage 1 ("hc-builder") compiles src/bin/healthcheck.rs, vendored
-#     inline below to keep the build context unchanged (./backend-binary).
-#   - Stage 2 ("runner") is the Distroless runtime that ships only the
-#     two binaries.
+# IMPORTANT - single stage:
 #   - INCOMPATIBLE with `target:` selection in compose files. Running e.g.
 #     `docker compose -f docker-compose.yml -f docker-compose.dev.yml up`
 #     against a server that points at this Dockerfile WILL FAIL because the
@@ -41,93 +53,23 @@
 # ==============================================================================
 
 # -----------------------------------------------------------------------------
-# Stage 1: hc-builder — compile the Distroless-friendly healthcheck binary.
-# -----------------------------------------------------------------------------
-# Source is vendored inline (not COPY'd from context) because the workflow
-# build context is `./backend-binary`, which contains only the pre-built
-# loyalty-backend binary. Keep this in sync with src/bin/healthcheck.rs.
-FROM rust:1.97-slim@sha256:5c6f46a6e4472ab1ca7ba7d494e6677f2f219ebc02f32025d3986f057635ec9c AS hc-builder
-
-WORKDIR /hc
-
-RUN cat <<'EOF' > Cargo.toml
-[package]
-name = "healthcheck"
-version = "0.1.0"
-edition = "2021"
-
-[dependencies]
-ureq = { version = "3", default-features = false }
-
-[profile.release]
-opt-level = "z"
-lto = true
-codegen-units = 1
-panic = "abort"
-strip = true
-EOF
-
-RUN mkdir -p src && cat <<'EOF' > src/main.rs
-//! KEEP IN SYNC with backend-rust/src/bin/healthcheck.rs.
-//! Vendored inline because the CI build context (./backend-binary) does
-//! not include workspace sources. The canonical copy lives in the Rust
-//! workspace and is what local builds (Dockerfile, target=runner) ship.
-use std::process::ExitCode;
-use std::time::Duration;
-
-const DEFAULT_PORT: &str = "4001";
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
-
-fn main() -> ExitCode {
-    let port = std::env::var("PORT").unwrap_or_else(|_| DEFAULT_PORT.to_string());
-    let url = format!("http://127.0.0.1:{port}/api/health");
-
-    // ureq 3 builds the agent from a `Config`; `timeout_global` is the direct
-    // successor of ureq 2's `AgentBuilder::timeout` (whole-call, end to end).
-    let agent: ureq::Agent = ureq::Agent::config_builder()
-        .timeout_global(Some(REQUEST_TIMEOUT))
-        .build()
-        .into();
-
-    match agent.get(&url).call() {
-        // `status()` is an `http::StatusCode` in ureq 3 — compare the raw u16 so
-        // the 2xx criterion and the stderr text stay what ureq 2 produced.
-        Ok(response) if (200..300).contains(&response.status().as_u16()) => ExitCode::SUCCESS,
-        Ok(response) => {
-            eprintln!("healthcheck: unexpected status {} from {url}", response.status().as_u16());
-            ExitCode::FAILURE
-        },
-        // ureq 3 renamed `Error::Status(code, response)` to `Error::StatusCode(code)`.
-        Err(ureq::Error::StatusCode(code)) => {
-            eprintln!("healthcheck: HTTP {code} from {url}");
-            ExitCode::FAILURE
-        },
-        Err(err) => {
-            eprintln!("healthcheck: request to {url} failed: {err}");
-            ExitCode::FAILURE
-        },
-    }
-}
-EOF
-
-RUN cargo build --release --target-dir /hc/target
-
-# -----------------------------------------------------------------------------
-# Stage 2: runner — Distroless runtime.
+# runner — Distroless runtime.
 # -----------------------------------------------------------------------------
 # See the long comment in backend-rust/Dockerfile (Stage 5) for the full
-# rationale on what cc-debian12 ships and why it's safe for this binary.
+# rationale on what cc-debian12 ships and why it's safe for these binaries.
 FROM gcr.io/distroless/cc-debian12@sha256:e8e7ee4b8b106d4c5fde9e422a321b2b8a2d5cca546c97adcce927f3e1d36e36 AS runner
 
 WORKDIR /app
 
-# Pre-built loyalty-backend binary from the GitHub Actions runner artifact
-# (placed in the build context at ./loyalty-backend by docker/build-push-action).
+# Pre-built binaries from the GitHub Actions runner artifact (placed in the
+# build context at ./loyalty-backend and ./healthcheck by
+# docker/build-push-action).
 # --chmod=755 because actions/upload-artifact roundtrips lose the executable
-# bit, and Distroless has no shell to chmod after the fact.
-COPY --chown=nonroot:nonroot --chmod=755 loyalty-backend      /app/loyalty-backend
-# Tiny healthcheck binary compiled in stage 1.
-COPY --from=hc-builder --chown=nonroot:nonroot --chmod=755 /hc/target/release/healthcheck /app/healthcheck
+# bit, and Distroless has no shell to chmod after the fact. Both binaries need
+# it for the same reason — the healthcheck is invoked directly by the
+# docker-compose.prod.yml `healthcheck:` block.
+COPY --chown=nonroot:nonroot --chmod=755 loyalty-backend /app/loyalty-backend
+COPY --chown=nonroot:nonroot --chmod=755 healthcheck     /app/healthcheck
 
 # Drop privileges. cc-debian12 ships the `nonroot` user as uid/gid 65532.
 # (Previous image used a manually-created `appuser` at uid/gid 1000.
@@ -137,6 +79,14 @@ USER nonroot:nonroot
 
 ENV RUST_LOG=info
 ENV RUST_BACKTRACE=0
+
+# Commit SHA baked in at build time and surfaced by /api/health as `revision`
+# (issue #345). Baked rather than injected at run time on purpose: the deploy
+# host's shim cannot be edited from CI, and an image that carries its own SHA
+# proves WHICH BUILD is serving even when the runtime env says nothing. The
+# `unknown` default keeps local `docker build` honest instead of blank.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=${GIT_SHA}
 
 EXPOSE 4001
 

--- a/backend-rust/src/openapi.rs
+++ b/backend-rust/src/openapi.rs
@@ -251,6 +251,10 @@ pub mod schemas {
         /// Application version
         #[schema(example = "0.1.0")]
         pub version: String,
+        /// Commit SHA the running image was built from, or `"unknown"` when
+        /// the image was built without the `GIT_SHA` build-arg.
+        #[schema(example = "2658193601995b203dd856ac28c69d6cb1c49c2a")]
+        pub revision: String,
     }
 
     /// Database health check response
@@ -290,6 +294,10 @@ pub mod schemas {
         /// Application version
         #[schema(example = "0.1.0")]
         pub version: String,
+        /// Commit SHA the running image was built from, or `"unknown"` when
+        /// the image was built without the `GIT_SHA` build-arg.
+        #[schema(example = "2658193601995b203dd856ac28c69d6cb1c49c2a")]
+        pub revision: String,
         /// Database connection status
         #[schema(example = "connected")]
         pub database: String,

--- a/backend-rust/src/routes/health.rs
+++ b/backend-rust/src/routes/health.rs
@@ -2,11 +2,49 @@
 //!
 //! Provides endpoints for health monitoring and readiness checks.
 
+use std::sync::OnceLock;
+
 use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
 use chrono::Utc;
 use serde::Serialize;
 
 use crate::state::AppState;
+
+/// Value reported in `revision` when the image carries no build SHA.
+///
+/// Images built before the `GIT_SHA` build-arg existed (and any local
+/// `cargo run`) report this. The deploy verifiers treat it as "cannot
+/// tell" and warn rather than fail — see the phased rollout note on
+/// [`resolve_revision`].
+const UNKNOWN_REVISION: &str = "unknown";
+
+/// Normalise a raw `GIT_SHA` value into the `revision` field.
+///
+/// Baked into the image at build time (`ARG GIT_SHA` / `ENV GIT_SHA` in
+/// both Dockerfiles) so a running container can prove which commit it was
+/// built from — `version` is `CARGO_PKG_VERSION`, which is identical across
+/// commits and therefore cannot distinguish a real deploy from a no-op
+/// (issue #345).
+///
+/// An UNSET var and an EMPTY one must behave identically: compose
+/// interpolates a missing `${GIT_SHA}` to the empty string, so
+/// `Some("")` reaching the payload as a real revision would clobber the
+/// image's own value with something the verifier reads as a mismatch.
+///
+/// Kept pure (env read by the caller) so unit tests exercise every branch
+/// without mutating process env, which races across parallel tests.
+fn resolve_revision(raw: Option<String>) -> String {
+    match raw {
+        Some(value) if !value.trim().is_empty() => value.trim().to_string(),
+        _ => UNKNOWN_REVISION.to_string(),
+    }
+}
+
+/// Process-wide revision, resolved from `GIT_SHA` exactly once.
+fn revision() -> &'static str {
+    static REVISION: OnceLock<String> = OnceLock::new();
+    REVISION.get_or_init(|| resolve_revision(std::env::var("GIT_SHA").ok()))
+}
 
 /// Health check response
 #[derive(Serialize)]
@@ -14,6 +52,8 @@ pub struct HealthResponse {
     pub status: String,
     pub timestamp: String,
     pub version: String,
+    /// Commit SHA this image was built from, or `"unknown"`.
+    pub revision: String,
 }
 
 /// Database health check response
@@ -54,6 +94,8 @@ pub struct SystemHealthResponse {
     pub status: String,
     pub timestamp: String,
     pub version: String,
+    /// Commit SHA this image was built from, or `"unknown"`.
+    pub revision: String,
     pub environment: String,
     pub services: ServicesHealth,
     pub uptime: u64,
@@ -67,6 +109,7 @@ async fn health_check() -> Json<HealthResponse> {
         status: "ok".to_string(),
         timestamp: Utc::now().to_rfc3339(),
         version: env!("CARGO_PKG_VERSION").to_string(),
+        revision: revision().to_string(),
     })
 }
 
@@ -180,6 +223,7 @@ async fn health_check_full(
         },
         timestamp,
         version: env!("CARGO_PKG_VERSION").to_string(),
+        revision: revision().to_string(),
         environment,
         services,
         uptime: 0, // Would need to track start time for actual uptime
@@ -214,5 +258,53 @@ mod tests {
         assert_eq!(response.status, "ok");
         assert!(!response.timestamp.is_empty());
         assert!(!response.version.is_empty());
+        // Never empty: the deploy verifiers distinguish "unknown" (warn) from
+        // a mismatching SHA (fail), and an empty string is neither.
+        assert!(!response.revision.is_empty());
+    }
+
+    // ------------------------------------------------------------------
+    // revision resolution (issue #345)
+    //
+    // These call the pure function directly rather than setting GIT_SHA:
+    // process env is global, so mutating it races every other test in the
+    // binary.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn resolve_revision_uses_the_value_when_set() {
+        assert_eq!(
+            resolve_revision(Some("2658193601995b203dd856ac28c69d6cb1c49c2a".to_string())),
+            "2658193601995b203dd856ac28c69d6cb1c49c2a"
+        );
+    }
+
+    #[test]
+    fn resolve_revision_trims_surrounding_whitespace() {
+        assert_eq!(resolve_revision(Some("  abc123\n".to_string())), "abc123");
+    }
+
+    #[test]
+    fn resolve_revision_falls_back_when_unset() {
+        assert_eq!(resolve_revision(None), UNKNOWN_REVISION);
+    }
+
+    /// An unset `${GIT_SHA}` in a compose file interpolates to the EMPTY
+    /// string, not to nothing — so the empty case must land on the same
+    /// fallback as the unset case, or a stale container would advertise a
+    /// blank revision that reads as "present but wrong".
+    #[test]
+    fn resolve_revision_falls_back_on_empty_or_blank() {
+        assert_eq!(resolve_revision(Some(String::new())), UNKNOWN_REVISION);
+        assert_eq!(
+            resolve_revision(Some("   \t\n".to_string())),
+            UNKNOWN_REVISION
+        );
+    }
+
+    #[test]
+    fn revision_is_stable_across_calls() {
+        assert_eq!(revision(), revision());
+        assert!(!revision().is_empty());
     }
 }

--- a/backend-rust/tests/integration/health_test.rs
+++ b/backend-rust/tests/integration/health_test.rs
@@ -55,6 +55,35 @@ async fn test_health_basic_json_structure() {
         json.get("version").is_some(),
         "Response should have 'version' field"
     );
+    assert!(
+        json.get("revision").is_some(),
+        "Response should have 'revision' field"
+    );
+}
+
+/// Test that the basic health endpoint exposes a non-empty `revision`.
+///
+/// Issue #345: the deploy verifiers read `.revision` from `/api/health` to
+/// prove a deploy was not a no-op. It is the commit SHA baked into the image
+/// (`ARG GIT_SHA`), falling back to `"unknown"` — so it must never be empty
+/// or absent, in any build, or the verifier cannot tell "no SHA baked in"
+/// (warn) from "serving a different commit" (fail).
+#[tokio::test]
+async fn test_health_basic_revision_present_and_non_empty() {
+    let app = TestApp::new().await.expect("Failed to create test app");
+    let client = app.client();
+
+    let response = client.get("/api/health/basic").await;
+    response.assert_status(200);
+
+    let json: Value = response.json().expect("Response should be valid JSON");
+    let revision = json.get("revision").and_then(|v| v.as_str());
+
+    assert!(revision.is_some(), "Revision should be present");
+    assert!(
+        !revision.unwrap().is_empty(),
+        "Revision should never be empty — it falls back to \"unknown\""
+    );
 }
 
 /// Test that the basic health endpoint returns status "ok".
@@ -159,6 +188,18 @@ async fn test_health_endpoint_json_structure() {
         "Should have 'timestamp' field"
     );
     assert!(json.get("version").is_some(), "Should have 'version' field");
+    // Issue #345: the staging/production verify steps read `.revision` from
+    // THIS payload (`/api/health` is the full check), so its absence here is
+    // what would silently turn the deploy assertion into a no-op.
+    let revision = json.get("revision").and_then(|v| v.as_str());
+    assert!(
+        revision.is_some(),
+        "Should have 'revision' field — the deploy verifiers read it"
+    );
+    assert!(
+        !revision.unwrap().is_empty(),
+        "Revision should never be empty — it falls back to \"unknown\""
+    );
     assert!(
         json.get("environment").is_some(),
         "Should have 'environment' field"

--- a/docs/production-approval-checklist.md
+++ b/docs/production-approval-checklist.md
@@ -17,7 +17,8 @@ What to verify **after** a production deploy lands.
 ## TL;DR — five checks, ~2 minutes
 
 1. Staging `/api/health` returns **200**.
-2. The deploy's commit SHA **matches the latest green** staging deploy.
+2. Production and staging **report the deployed SHA** as their
+   `revision`, and it matches the latest green staging deploy.
 3. E2E for that SHA on `main` is **green**.
 4. Skim `CHANGELOG.md` and the squash-merge PRs for **surprises**
    (migrations, infra changes, secret-touch).
@@ -31,7 +32,9 @@ If all five pass: the deploy is good. If any fail: roll back
 ## 1. Staging is healthy *right now*
 
 ```bash
-curl -fsS https://loyalty-dev.saichon.com/api/health | jq .
+# No -f: a degraded backend answers 503 and -f discards the body, which
+# is the part that tells you what is wrong and which build is wrong.
+curl -sS https://loyalty-dev.saichon.com/api/health | jq .
 ```
 
 - **Required**: HTTP `200` and `status: "healthy"`.
@@ -46,7 +49,35 @@ human is approving production, that poll may be hours old. A staging
 container that died after the poll passed won't show up unless someone
 asks now.
 
-## 2. Commit SHA matches the latest green staging deploy
+## 2. The running app reports the SHA you think it is running
+
+**Ask the app, not the pipeline.** `/api/health` exposes a `revision`
+field: the commit SHA baked into the image at build time (`ARG GIT_SHA`
+in `backend-rust/Dockerfile.ci`). Unlike `version` — which is
+`CARGO_PKG_VERSION` and identical across commits — it can distinguish a
+real deploy from one that silently no-op'd, partially applied, or was
+overtaken by a newer run.
+
+```bash
+# Again no -f: 503 still carries the body, and a degraded prod still
+# tells you WHICH build is degraded.
+curl -sS https://loyalty.saichon.com/api/health     | jq -r .revision
+curl -sS https://loyalty-dev.saichon.com/api/health | jq -r .revision
+```
+
+- **Expected**: the SHA of the commit that was deployed.
+- `unknown` (or the field missing) means the running image was built
+  before this bake existed, or is a rollback to such an image. It is
+  not a failure — it just means this check can't answer, so fall back
+  to the SHA comparison below.
+- A **different, real SHA** is the bad case: the deploy did not land.
+  Go to the rollback section.
+
+`ci-build-e2e.yml`'s `Verify Staging` job and `deploy.yml`'s
+`Verify production is running this commit` step run exactly this
+assertion automatically, with the same three outcomes.
+
+## 2b. Commit SHA matches the latest green staging deploy
 
 The production deploy ships **the same SHA** that ran on staging — verify
 nothing accidentally points at a stale or unrelated build.

--- a/docs/rollback-runbook.md
+++ b/docs/rollback-runbook.md
@@ -110,9 +110,22 @@ environment, which requires a human approver. The approver should:
 ### 5. Verify
 
 ```bash
-curl -fsS https://loyalty.saichon.com/api/health
-# Expect HTTP 200 with a JSON body that mentions postgres + redis healthy.
+# No -f: a degraded backend answers 503 and -f throws the body away —
+# and the body is what tells you which build is serving.
+curl -sS https://loyalty.saichon.com/api/health | jq '{status, revision, services}'
 ```
+
+Expect HTTP 200, `status: "healthy"`, and postgres + redis healthy.
+
+**Also check `revision`** — the commit SHA baked into the image at build
+time. After a rollback it must be the **good** SHA you rolled back *to*,
+not the bad one you rolled back *from*. If it still shows the bad SHA,
+the rollback did not actually take effect (the container was not
+recreated, or `IMAGE_TAG` was not picked up) — do not walk away.
+
+`revision: "unknown"` means you rolled back to an image built before this
+field existed. That is expected for older SHAs and is not a failure; fall
+back to comparing the image digest the host pulled.
 
 Spot-check the obvious user paths: `/`, login, recent booking page,
 admin dashboard. The post-deploy `Verify Staging` workflow does **not**

--- a/tests/health.api.spec.ts
+++ b/tests/health.api.spec.ts
@@ -15,6 +15,41 @@ test.describe('Application Health Checks', () => {
     expect(health.timestamp).toBeTruthy();
   });
 
+  /**
+   * Issue #345 — prove a deploy shipped the intended commit.
+   *
+   * `revision` is the commit SHA baked into the image at build time
+   * (`ARG GIT_SHA` / `ENV GIT_SHA` in both Dockerfiles). `version` cannot do
+   * this job: it is CARGO_PKG_VERSION, identical across commits.
+   *
+   * In CI this spec runs against the image that was just built and pushed for
+   * the current commit, with EXPECTED_REVISION set to that SHA — so a green
+   * run here means the image really carries its own identity, proven BEFORE
+   * anything is deployed. The SHA is deliberately NOT injected into the
+   * container by start-app-stack; if it were, this would assert its own input.
+   *
+   * Locally (or against a stack built without the build-arg) the value is
+   * "unknown", which is still non-empty — the deploy verifiers treat that as
+   * "cannot tell" and warn rather than fail.
+   */
+  test('Backend health endpoint should expose the image revision', async ({ request }) => {
+    const response = await retryRequest(request, `${backendUrl}/api/health`, 5);
+
+    const health = await response.json();
+    expect(typeof health.revision).toBe('string');
+    expect(health.revision.length).toBeGreaterThan(0);
+
+    const expectedRevision = process.env.EXPECTED_REVISION;
+    if (expectedRevision) {
+      expect(
+        health.revision,
+        `The running image reports revision "${health.revision}" but this run built ` +
+          `"${expectedRevision}". Either GIT_SHA was not baked into the image, or the ` +
+          `stack is running a different build than the one under test.`
+      ).toBe(expectedRevision);
+    }
+  });
+
   test('API endpoints should be accessible', async ({ request }) => {
     // Test that API endpoints are reachable (but may require auth)
     const endpoints = [


### PR DESCRIPTION
Closes #360. Closes #345.

Both issues are the same shape: **the pipeline reports green without having checked the thing it claims to check.**

---

## Part A — #360: stop shipping a second, unverified healthcheck

`backend-rust/Dockerfile.ci` vendored an **inline copy** of `src/bin/healthcheck.rs` as a heredoc (stage `hc-builder`) and compiled it inside the image build. So the binary that *shipped* was the one CI never compiled, linted, or unit-tested — drift could only be discovered in production. And `docker-compose.prod.yml` runs it as the container `HEALTHCHECK` with nothing consuming the result, so a binary that couldn't even be **loaded** would leave the container `unhealthy` forever while serving traffic normally.

**What changed**

1. `build-backend-release` now builds `cargo build --release --bin loyalty-backend --bin healthcheck` and uploads both. `upload-artifact` roots the archive at the **least common ancestor** of its paths (`backend-rust/target/release/`), so both land flat in `./backend-binary` — which is exactly the `context:` the backend image build uses. A new step asserts both files are present before BuildKit gets a chance to emit a `COPY failed` trace.
2. The whole `hc-builder` stage is **deleted**. `Dockerfile.ci` now does
   `COPY --chown=nonroot:nonroot --chmod=755 healthcheck /app/healthcheck`,
   mirroring the existing `loyalty-backend` line exactly — `--chmod` is required because the artifact roundtrip drops the exec bit and distroless has no shell to fix it. The stale "Why two binaries" comment is rewritten.
3. **A CI assertion that the shipped binary executes.** Right after the backend image is pushed, we pull it and run `/app/healthcheck`. Nothing listens on 4001 in a bare container, so the correct outcome is a clean **exit 1 with the binary's own connection-refused message**. The step is written so a loader failure can never be mistaken for that refusal:
   - loader signatures (`exec format error`, `GLIBC_`, `cannot open shared object`, `error while loading shared libraries`, `no such file or directory`, `permission denied`) fail **first and unconditionally**;
   - docker exit `125/126/127` fail;
   - then it requires the binary's **own stderr line**, which only executing compiled code can emit — a positive proof no loader failure can satisfy;
   - and only then requires exit code `1`.

   Verified against six fixtures: the real refusal passes; glibc-version-not-found, missing exec bit, wrong arch, missing binary and missing `.so` are each caught and each fail the positive proof.

The image is addressed **by digest**, not by the SHA tag: `docker/metadata-action` does not necessarily use `github.sha` for `type=sha` on `pull_request` events, and the digest is unambiguously the image this step just pushed.

---

## The glibc finding — hypothesis **disproven**, with direct evidence

The issue suspected the vendored healthcheck was built against a newer glibc than it runs on. Half of that is true, and it is now confirmed rather than suspected — but the feared consequence is not.

**What is confirmed:**

| | source | libc |
|---|---|---|
| `hc-builder` (deleted) | `rust:1.97-slim@sha256:5c6f46a6…` — the registry's OCI annotation says `org.opencontainers.image.base.name: debian:trixie-slim`, version `1-slim-trixie` | Debian 13 trixie, glibc **2.41** |
| runtime | `gcr.io/distroless/cc-debian12@sha256:e8e7ee4b…` — `/usr/lib/os-release` says `Debian GNU/Linux 12 (bookworm)`, `/etc/debian_version` = `12.15`, and the shipped `libc.so.6` banner reads `GNU C Library (Debian GLIBC 2.36-9+deb12u14) … version 2.36` | glibc **2.36** |
| `loyalty-backend` | built on the runner inside `container: rust:1.93-bookworm` | glibc 2.36 — never skewed |

So yes: the *healthcheck* was the one binary in the image built on a newer libc than the runtime.

**What it does not mean.** I pulled the actual shipped image (`ghcr.io/thehfhotel/loyalty-app/backend:latest`, revision `2658193`), extracted `/app/healthcheck`, and read its ELF `.gnu.version_r`:

```
PT_INTERP:  /lib64/ld-linux-x86-64.so.2
DT_NEEDED:  libgcc_s.so.1, libc.so.6
REQUIRED from libc.so.6:        GLIBC_2.2.5 … GLIBC_2.33, GLIBC_2.34
  -> MAX GLIBC symbol version required: GLIBC_2.34
REQUIRED from libgcc_s.so.1:    GCC_3.0, GCC_3.3, GCC_4.2.0
```

`2.34 ≤ 2.36`, and both `libc.so.6` and `libgcc_s.so.1` are present in `cc-debian12`. **The currently shipped healthcheck loads and runs fine.** Building on trixie only *raises the ceiling* of symbol versions the linker may reach for; this binary (pure Rust + `ureq` with no TLS, so no C dependency that would pull in a newer versioned symbol) never reaches above 2.34. For reference the shipped `loyalty-backend` tops out at `GLIBC_2.34` too.

So this PR fixes a **real latent hazard, not an active outage**: the skew was one dependency change away from mattering, and nothing would have told us. After this PR the healthcheck is built in the same `rust:1.93-bookworm` container as the backend — same libc as the runtime, skew eliminated at the source — and the new CI assertion means any future skew turns a run red instead of sitting invisible.

---

## Part B — #345: prove a deploy shipped the intended commit

`/api/health`'s `version` is `CARGO_PKG_VERSION` — identical on every commit — so a 200 proved only that *something* answers. It could not distinguish a real deploy from one that silently no-op'd, partially applied, or was overtaken.

The shim on the deploy host can't be edited from here, so **the SHA is baked into the image** instead of injected at run time.

1. `health.rs` gains `revision` on **both** payloads (basic and full), resolved once via `OnceLock` from `GIT_SHA` through a pure `resolve_revision(Option<String>) -> String` — trimmed, falling back to `"unknown"`. **Unset and empty behave identically**, so an empty `${GIT_SHA}` compose interpolation cannot clobber it. Pure so the unit tests don't race on process env. `version` is untouched. Mirrored in `openapi.rs`.
2. `ARG GIT_SHA=unknown` + `ENV GIT_SHA=${GIT_SHA}` in the runner stages of **both** `Dockerfile.ci` and `Dockerfile`; `build-args: GIT_SHA=${{ github.sha }}` on the backend image build.
3. **Proven before any deploy.** `tests/health.api.spec.ts` asserts a non-empty `revision` and strict equality when `EXPECTED_REVISION` is set; `regression-api` sets `EXPECTED_REVISION: ${{ github.sha }}`. That job runs the freshly built image, so green = the image really carries its own SHA. `GIT_SHA` is deliberately **not** injected by `start-app-stack` — that would make the test assert its own input. A backend integration assertion covers the field's presence on both payloads.

### Phased rollout of the deployed-revision assertion

Added to `verify-staging` and to production in `deploy.yml`. Three outcomes, on purpose:

| observed `revision` | outcome | why |
|---|---|---|
| equals the deploying SHA | **pass** | the deploy really landed |
| absent or `"unknown"` | **warn, pass** | images built before this change, and rollbacks to them, legitimately can't answer. Failing here would turn a rollback red at the worst possible moment |
| a **different** real SHA | **fail** | the genuine no-op / partial / overtaken-deploy signal |

Both poll **until match** rather than classifying the first sample — right after a deploy the outgoing container can still answer through nginx while the new one starts, and reading that as "different commit" would fail a perfectly good deploy. Neither uses `curl -f`, because `/api/health` answers **503** when degraded and `-f` discards exactly the body that carries `revision`.

Once no pre-bake image can be rolled back to, the warn branch should become a failure.

### Dead diagnostics removed

`verify-staging`'s on-failure SSH log-capture steps could never work, and the workflow already said so in its own comments: the deploy key carries a **forced command** (which is why `deploy-staging` pipes its payload to *stdin* and passes no remote command at all), so the client-supplied `docker ps` / `docker logs` were always ignored. The artifact could only ever be silently empty — worse than none, because an empty artifact reads as "staging looked fine". Removed, along with the now-unneeded SSH setup and checkout in that job (it needs no secrets at all now). The failure-notification issue template no longer advertises the artifact or the `docker inspect` check, and points at the revision curl instead.

### Docs

`docs/production-approval-checklist.md`, `docs/rollback-runbook.md` and the CI/CD section of `CLAUDE.md` now use the revision curl (with a note about `-f` and 503 bodies). The rollback runbook additionally calls out that after a rollback `revision` must be the SHA you rolled back **to**.

---

## Verification

All run locally before pushing:

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo nextest run --lib --bins health` — **8/8 pass** (5 new)
- `cargo nextest run --test lib integration::health_test` — **19/19 pass**, against a real Postgres 17 + Redis (not skipped)
- `SQLX_OFFLINE=true cargo build --bin loyalty-backend --bin healthcheck` — ok; **`git status` shows no `.sqlx` changes**
- The healthcheck binary I built: with nothing listening it exits **1** with `healthcheck: request to http://127.0.0.1:4001/api/health failed: io: Connection refused`; against a `python3 -m http.server` serving `/api/health` it exits **0**
- `GIT_SHA` → `revision` end-to-end through the running backend, all four cases: real SHA → the SHA; unset → `unknown`; **empty → `unknown`** (does not clobber); `"  abc123def  "` → `abc123def` — on both `/api/health` and `/api/health/basic`
- `health.api.spec.ts` against that live backend: passes when `EXPECTED_REVISION` matches, and **fails with a readable message when it doesn't** — the assertion is red-capable, not vacuous
- The staging and production revision scripts executed with a stubbed `curl`: **12/12 branch cases** behave as specified (match / unknown / absent / no-body / different-SHA / 503-with-correct-SHA, in both workflows)
- Every YAML touched parses (`yaml.safe_load`), and the parsed graph re-checked: build command, both artifact paths, `build-args`, `EXPECTED_REVISION`, step ordering, `start-app-stack` contains **no** `GIT_SHA`, and `verify-staging` now references no secrets and no ssh

Also syncs `backend-rust/Cargo.lock`, which the 4.4.1 release bump left at `4.4.0` — any `cargo build` regenerates it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU
