### PR TITLE
fix: wire SMTP_FROM end-to-end and stop /api/health faking email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,32 @@ PROMPTPAY_HF_ID=
 PROMPTPAY_HFVILLE_ID=
 
 # ===========================================
+# OUTBOUND EMAIL (SMTP) — optional in development
+# ===========================================
+# Leave every value blank to run without email: the backend logs
+# "SMTP Email: Not configured", skips sends, and /api/health reports
+# "email": "not_configured". Blank counts as unset — compose passes these as
+# ${SMTP_HOST:-}, so an absent value arrives as an empty string.
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+
+# From address on every outgoing message (issue #352).
+#
+# - Unset or blank => falls back to SMTP_USER, which is the historical
+#   behaviour, so leaving this empty changes nothing.
+# - Accepts a bare address (noreply@example.com) or the display-name form
+#   ("Loyalty App <noreply@example.com>"). A malformed value is logged as an
+#   ERROR at startup, because it fails every send.
+# - MUST be an address the authenticated mailbox genuinely OWNS. Providers
+#   accept the AUTH and then reject the message with
+#   `553 5.7.1 <addr>: Sender address rejected: not owned by user ...` if it
+#   is only an alias — the same error a lapsed subscription produces, which
+#   is what made this hard to diagnose.
+SMTP_FROM=
+
+# ===========================================
 # ADMIN USER (DEVELOPMENT)
 # ===========================================
 LOYALTY_USERNAME=admin@localhost

--- a/.env.production.example
+++ b/.env.production.example
@@ -47,6 +47,36 @@ LINE_CHANNEL_SECRET=CHANGE_ME_LINE_CHANNEL_SECRET
 LINE_CALLBACK_URL=https://your-domain.com/api/oauth/line/callback
 
 # ===========================================
+# OUTBOUND EMAIL (SMTP)
+# ===========================================
+# Configure these as GitHub Actions *production environment* secrets — the
+# deploy workflow reads them and writes the server-side .env. Password
+# resets, address verification and booking mail all go through this relay;
+# with it unset the backend logs the skip and /api/health reports
+# "email": "not_configured" (informational only — it never fails the deploy).
+SMTP_HOST=CHANGE_ME_smtp.your-provider.com
+SMTP_PORT=587
+SMTP_USER=CHANGE_ME_mailbox@your-domain.com
+SMTP_PASS=CHANGE_ME_MAILBOX_PASSWORD
+
+# From address on every outgoing message (issue #352).
+#
+# - Unset or blank => falls back to SMTP_USER (historical behaviour).
+# - Accepts a bare address or the display-name form
+#   ("Loyalty App <noreply@your-domain.com>"). A malformed value is logged as
+#   an ERROR at startup, because it fails every send.
+# - MUST be an address the authenticated mailbox genuinely OWNS. An alias is
+#   refused *after* a successful AUTH with
+#   `553 5.7.1 <addr>: Sender address rejected: not owned by user ...`.
+#   A lapsed mailbox subscription produces the SAME 553, so treat that error
+#   as "check billing" before "check the alias".
+#
+# NOTE: /api/health can only ever prove this is CONFIGURED, never that a
+# message is DELIVERABLE. Verify a real send with
+# `POST /api/admin/email/test` after changing any value here.
+SMTP_FROM=CHANGE_ME_Loyalty App <noreply@your-domain.com>
+
+# ===========================================
 # ADMIN USER CONFIGURATION
 # ===========================================
 LOYALTY_USERNAME=CHANGE_ME_admin@your-domain.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,6 +221,9 @@ jobs:
           SMTP_PORT:            ${{ secrets.SMTP_PORT }}
           SMTP_USER:            ${{ secrets.SMTP_USER }}
           SMTP_PASS:            ${{ secrets.SMTP_PASS }}
+          # The secret existed and was documented, but was never sent — so the
+          # backend always fell back to SMTP_USER as its From address (#352).
+          SMTP_FROM:            ${{ secrets.SMTP_FROM }}
           IMAP_HOST:            ${{ secrets.IMAP_HOST }}
           IMAP_PORT:            ${{ secrets.IMAP_PORT }}
           IMAP_USER:            ${{ secrets.IMAP_USER }}
@@ -272,6 +275,7 @@ jobs:
             --arg SMTP_PORT            "${SMTP_PORT:-587}" \
             --arg SMTP_USER            "${SMTP_USER:-}" \
             --arg SMTP_PASS            "${SMTP_PASS:-}" \
+            --arg SMTP_FROM            "${SMTP_FROM:-}" \
             --arg IMAP_HOST            "${IMAP_HOST:-}" \
             --arg IMAP_PORT            "${IMAP_PORT:-993}" \
             --arg IMAP_USER            "${IMAP_USER:-}" \
@@ -305,6 +309,7 @@ jobs:
                 SMTP_PORT:            $SMTP_PORT,
                 SMTP_USER:            $SMTP_USER,
                 SMTP_PASS:            $SMTP_PASS,
+                SMTP_FROM:            $SMTP_FROM,
                 IMAP_HOST:            $IMAP_HOST,
                 IMAP_PORT:            $IMAP_PORT,
                 IMAP_USER:            $IMAP_USER,

--- a/backend-rust/.env.example
+++ b/backend-rust/.env.example
@@ -24,10 +24,16 @@ LINE_CLIENT_SECRET=your_line_client_secret
 LINE_REDIRECT_URI=http://localhost:4000/api/auth/line/callback
 
 # Email Service (SMTP)
+# All values optional: leave them blank to run without email. Blank counts as
+# unset (compose passes ${SMTP_HOST:-}), and /api/health then reports
+# "email": "not_configured".
 SMTP_HOST=smtp.your-email-provider.com
 SMTP_PORT=465
 SMTP_USER=noreply@yourdomain.com
 SMTP_PASS=your_password
+# From address on outgoing mail. Falls back to SMTP_USER when unset or blank.
+# Must be an address the mailbox genuinely OWNS — an alias is refused with
+# `553 5.7.1 ...: Sender address rejected` after a successful AUTH (#352).
 SMTP_FROM="Loyalty App <noreply@yourdomain.com>"
 
 # Email Service (IMAP)

--- a/backend-rust/README.md
+++ b/backend-rust/README.md
@@ -408,7 +408,7 @@ backend-rust/
 | `SMTP_PORT` | SMTP server port (default: 465) |
 | `SMTP_USER` | SMTP username |
 | `SMTP_PASS` | SMTP password |
-| `SMTP_FROM` | Email from address |
+| `SMTP_FROM` | From address on outgoing mail. Falls back to `SMTP_USER` when unset or blank. Bare (`x@y.com`) or display-name (`Name <x@y.com>`) form; a malformed value is logged as an ERROR at startup. Must be an address the mailbox genuinely **owns** — an alias is refused with `553 5.7.1 …: Sender address rejected` *after* a successful AUTH (issue #352) |
 | `IMAP_HOST` | IMAP server hostname |
 | `IMAP_PORT` | IMAP server port (default: 993) |
 | `IMAP_USER` | IMAP username |

--- a/backend-rust/src/config/mod.rs
+++ b/backend-rust/src/config/mod.rs
@@ -238,6 +238,20 @@ pub struct OAuthConfig {
     pub line: LineOAuthConfig,
 }
 
+/// `Some(trimmed)` when a value is present and not blank, `None` otherwise.
+///
+/// Every compose file passes its optional settings as `VAR: ${VAR:-}`, so an
+/// **unset** secret does not arrive as `None` — it arrives as `Some("")`. A
+/// bare `.is_some()` therefore reports a stack with no SMTP at all as fully
+/// configured, which is exactly why `/api/health` claimed `"email":
+/// "configured"` everywhere (issue #352). Blank means absent.
+fn present(value: &Option<String>) -> Option<&str> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|trimmed| !trimmed.is_empty())
+}
+
 /// SMTP email configuration
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct SmtpConfig {
@@ -254,6 +268,18 @@ pub struct SmtpConfig {
     /// SMTP password
     pub pass: Option<String>,
 
+    /// Sender address for outgoing mail (`SMTP_FROM`).
+    ///
+    /// Accepts a bare address (`noreply@example.com`) or the display-name
+    /// form (`Loyalty App <noreply@example.com>`). Falls back to `SMTP_USER`
+    /// when unset or blank — see [`SmtpConfig::from_address`] — so
+    /// environments that never set it keep the previous behaviour exactly.
+    ///
+    /// The address must be one the authenticated mailbox genuinely **owns**:
+    /// a relay accepts AUTH and then rejects the message with
+    /// `553 5.7.1 ... Sender address rejected` if it is a mere alias.
+    pub from: Option<String>,
+
     /// Use TLS for SMTP connection
     #[serde(default = "default_smtp_tls")]
     pub use_tls: bool,
@@ -268,8 +294,36 @@ fn default_smtp_tls() -> bool {
 }
 
 impl SmtpConfig {
+    /// SMTP host, or `None` when unset/blank.
+    pub fn host(&self) -> Option<&str> {
+        present(&self.host)
+    }
+
+    /// SMTP username, or `None` when unset/blank.
+    pub fn user(&self) -> Option<&str> {
+        present(&self.user)
+    }
+
+    /// SMTP password, or `None` when unset/blank.
+    ///
+    /// Returned **untrimmed**: a password may legitimately begin or end with
+    /// whitespace, so trimming could silently break authentication. Only the
+    /// blank/non-blank decision uses the trimmed form.
+    pub fn pass(&self) -> Option<&str> {
+        self.pass.as_deref().filter(|pass| !pass.trim().is_empty())
+    }
+
+    /// Address that outgoing mail is sent **From**.
+    ///
+    /// `SMTP_FROM` when set, otherwise `SMTP_USER`. This is the single reader
+    /// of the setting — the From header is built from it in
+    /// `services::email`.
+    pub fn from_address(&self) -> Option<&str> {
+        present(&self.from).or_else(|| self.user())
+    }
+
     pub fn is_configured(&self) -> bool {
-        self.host.is_some() && self.user.is_some() && self.pass.is_some()
+        self.host().is_some() && self.user().is_some() && self.pass().is_some()
     }
 }
 
@@ -303,8 +357,16 @@ fn default_imap_tls() -> bool {
 }
 
 impl ImapConfig {
+    /// Same blank-is-absent rule as [`SmtpConfig::is_configured`]: compose
+    /// passes `IMAP_HOST: ${IMAP_HOST:-}`, so an unset secret arrives as an
+    /// empty string rather than as nothing at all.
     pub fn is_configured(&self) -> bool {
-        self.host.is_some() && self.user.is_some() && self.pass.is_some()
+        present(&self.host).is_some()
+            && present(&self.user).is_some()
+            && self
+                .pass
+                .as_deref()
+                .is_some_and(|pass| !pass.trim().is_empty())
     }
 }
 
@@ -772,6 +834,7 @@ impl Settings {
             .set_override_option("email.smtp.port", env::var("SMTP_PORT").ok())?
             .set_override_option("email.smtp.user", env::var("SMTP_USER").ok())?
             .set_override_option("email.smtp.pass", env::var("SMTP_PASS").ok())?
+            .set_override_option("email.smtp.from", env::var("SMTP_FROM").ok())?
             .set_override_option("email.imap.host", env::var("IMAP_HOST").ok())?
             .set_override_option("email.imap.port", env::var("IMAP_PORT").ok())?
             .set_override_option("email.imap.user", env::var("IMAP_USER").ok())?
@@ -1085,6 +1148,119 @@ mod tests {
         config.user = Some("user".to_string());
         config.pass = Some("pass".to_string());
         assert!(config.is_configured());
+    }
+
+    /// Issue #352 — every compose file passes `SMTP_HOST: ${SMTP_HOST:-}`, so
+    /// a stack with no SMTP secrets at all hands the backend `Some("")`, not
+    /// `None`. Reporting that as configured is what made `/api/health` lie.
+    #[test]
+    fn smtp_is_not_configured_when_values_are_empty_strings() {
+        let config = SmtpConfig {
+            host: Some(String::new()),
+            user: Some(String::new()),
+            pass: Some(String::new()),
+            ..SmtpConfig::default()
+        };
+        assert!(!config.is_configured());
+
+        let whitespace = SmtpConfig {
+            host: Some("   ".to_string()),
+            user: Some("\t\n".to_string()),
+            pass: Some("  ".to_string()),
+            ..SmtpConfig::default()
+        };
+        assert!(!whitespace.is_configured());
+    }
+
+    /// A partially-empty triple is still not configured — a host with blank
+    /// credentials cannot authenticate.
+    #[test]
+    fn smtp_is_not_configured_when_only_some_values_are_empty() {
+        let config = SmtpConfig {
+            host: Some("smtp.example.com".to_string()),
+            user: Some("user@example.com".to_string()),
+            pass: Some(String::new()),
+            ..SmtpConfig::default()
+        };
+        assert!(!config.is_configured());
+    }
+
+    #[test]
+    fn imap_is_not_configured_when_values_are_empty_strings() {
+        let config = ImapConfig {
+            host: Some(String::new()),
+            user: Some(String::new()),
+            pass: Some(String::new()),
+            ..ImapConfig::default()
+        };
+        assert!(!config.is_configured());
+    }
+
+    /// A password may legitimately carry leading/trailing whitespace, so the
+    /// accessor must not trim the value it hands to the SMTP client — only
+    /// the blank/non-blank decision uses the trimmed form.
+    #[test]
+    fn smtp_pass_is_returned_untrimmed() {
+        let config = SmtpConfig {
+            pass: Some(" hunter2 ".to_string()),
+            ..SmtpConfig::default()
+        };
+        assert_eq!(config.pass(), Some(" hunter2 "));
+    }
+
+    // ------------------------------------------------------------------
+    // SMTP_FROM precedence (issue #352)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn from_address_prefers_smtp_from_over_smtp_user() {
+        let config = SmtpConfig {
+            user: Some("mailbox@example.com".to_string()),
+            from: Some("Loyalty App <mailbox@example.com>".to_string()),
+            ..SmtpConfig::default()
+        };
+        assert_eq!(
+            config.from_address(),
+            Some("Loyalty App <mailbox@example.com>")
+        );
+    }
+
+    #[test]
+    fn from_address_falls_back_to_user_when_from_is_unset() {
+        let config = SmtpConfig {
+            user: Some("mailbox@example.com".to_string()),
+            from: None,
+            ..SmtpConfig::default()
+        };
+        assert_eq!(config.from_address(), Some("mailbox@example.com"));
+    }
+
+    /// The important fallback: an unset `SMTP_FROM` secret reaches the
+    /// container as an empty string, and must behave identically to unset so
+    /// nothing changes for stacks that never configure it.
+    #[test]
+    fn from_address_falls_back_to_user_when_from_is_blank() {
+        let config = SmtpConfig {
+            user: Some("mailbox@example.com".to_string()),
+            from: Some("   ".to_string()),
+            ..SmtpConfig::default()
+        };
+        assert_eq!(config.from_address(), Some("mailbox@example.com"));
+    }
+
+    #[test]
+    fn from_address_is_trimmed() {
+        let config = SmtpConfig {
+            user: Some("mailbox@example.com".to_string()),
+            from: Some("  noreply@example.com\n".to_string()),
+            ..SmtpConfig::default()
+        };
+        assert_eq!(config.from_address(), Some("noreply@example.com"));
+    }
+
+    #[test]
+    fn from_address_is_none_when_neither_is_set() {
+        assert_eq!(SmtpConfig::default().from_address(), None);
     }
 
     #[test]

--- a/backend-rust/src/main.rs
+++ b/backend-rust/src/main.rs
@@ -40,6 +40,7 @@ use loyalty_backend::{
     middleware::cors::{cors_layer, cors_layer_multiple_origins},
     redis::RedisManager,
     routes,
+    services::email::is_valid_mailbox,
     state::AppState,
 };
 
@@ -381,9 +382,35 @@ fn log_startup_info(config: &Settings) {
         info!("  LINE OAuth: Not configured");
     }
 
-    // Log email configuration status
+    // Log email configuration status, including the effective From address.
+    //
+    // The From address ships in the header of every outgoing message, so it
+    // is not a secret — and printing it is the only way an operator can tell
+    // whether SMTP_FROM actually reached the container or whether the app
+    // silently fell back to SMTP_USER (issue #352). `{:?}` keeps a stray
+    // newline in the value from forging a log line.
+    //
+    // A malformed value is an ERROR, not a warning: it fails *every* send,
+    // and until now did so at request time with nothing at startup to point
+    // at the cause.
     if config.email.smtp.is_configured() {
-        info!("  SMTP Email: Enabled");
+        match config.email.smtp.from_address() {
+            Some(from) => {
+                info!("  SMTP Email: Enabled (From: {:?})", from);
+                if !is_valid_mailbox(from) {
+                    error!(
+                        "  SMTP From address {:?} is not a valid mailbox — every outgoing \
+                         email will fail. Expected `user@example.com` or \
+                         `Name <user@example.com>`. Check the SMTP_FROM secret \
+                         (it falls back to SMTP_USER when unset).",
+                        from
+                    );
+                }
+            },
+            // Unreachable while is_configured() requires a user, but reported
+            // rather than assumed away.
+            None => info!("  SMTP Email: Enabled (From: unset)"),
+        }
     } else {
         info!("  SMTP Email: Not configured");
     }

--- a/backend-rust/src/routes/health.rs
+++ b/backend-rust/src/routes/health.rs
@@ -8,6 +8,7 @@ use axum::{extract::State, http::StatusCode, routing::get, Json, Router};
 use chrono::Utc;
 use serde::Serialize;
 
+use crate::config::SmtpConfig;
 use crate::state::AppState;
 
 /// Value reported in `revision` when the image carries no build SHA.
@@ -44,6 +45,39 @@ fn resolve_revision(raw: Option<String>) -> String {
 fn revision() -> &'static str {
     static REVISION: OnceLock<String> = OnceLock::new();
     REVISION.get_or_init(|| resolve_revision(std::env::var("GIT_SHA").ok()))
+}
+
+/// `services.email` when SMTP credentials are present.
+const EMAIL_CONFIGURED: &str = "configured";
+
+/// `services.email` when SMTP is absent — the honest answer for a stack with
+/// no mail credentials.
+const EMAIL_NOT_CONFIGURED: &str = "not_configured";
+
+/// Report whether outgoing email is configured — nothing more.
+///
+/// This used to be the string literal `"configured"`, unconditionally, so
+/// every environment claimed working email including CI stacks and staging,
+/// which have no SMTP credentials at all (issue #352).
+///
+/// Two deliberate limits:
+///
+/// 1. **Configuration only, never deliverability.** A relay can accept AUTH
+///    and still reject the message (`553 ... Sender address rejected` on a
+///    lapsed subscription is what prompted this). Proving a message can be
+///    delivered needs a canary that actually sends; `/api/health` cannot.
+///    `GET /api/admin/email/status` probes the SMTP handshake for operators.
+/// 2. **Never folded into the overall `status`.** `deploy.yml` and
+///    `ci-build-e2e.yml`'s verify-staging poll this endpoint and treat a 503
+///    as a failed deploy, which also files a "Production deploy failed"
+///    issue. A lapsed mail subscription must not block shipping code, so the
+///    field stays informational — see `health_check_full`.
+fn email_status(smtp: &SmtpConfig) -> &'static str {
+    if smtp.is_configured() {
+        EMAIL_CONFIGURED
+    } else {
+        EMAIL_NOT_CONFIGURED
+    }
 }
 
 /// Health check response
@@ -191,6 +225,11 @@ async fn health_check_full(
 
     let db_healthy = db_status == "healthy";
     let redis_healthy = redis_status == "healthy";
+    // Email is deliberately NOT part of this conjunction: a 503 from this
+    // endpoint fails the deploy (deploy.yml / verify-staging) and files a
+    // "Production deploy failed" issue. Unconfigured or broken mail is an
+    // operational problem, not a reason to refuse to ship code. See
+    // `email_status`.
     let all_healthy = db_healthy && redis_healthy;
 
     // Get environment from config
@@ -206,7 +245,7 @@ async fn health_check_full(
         database: db_status,
         redis: redis_status,
         storage: "healthy".to_string(), // Storage is always available in Rust backend
-        email: "configured".to_string(), // Email service status
+        email: email_status(&state.config().email.smtp).to_string(),
     };
 
     // Memory info (simplified for Rust - we don't have direct access like Node.js)
@@ -300,6 +339,44 @@ mod tests {
             resolve_revision(Some("   \t\n".to_string())),
             UNKNOWN_REVISION
         );
+    }
+
+    // ------------------------------------------------------------------
+    // email status honesty (issue #352)
+    //
+    // The field was the literal "configured" on every stack, including ones
+    // with no SMTP credentials whatsoever. Pure function so these run without
+    // an AppState.
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn email_status_reports_configured_when_credentials_are_present() {
+        let smtp = SmtpConfig {
+            host: Some("smtp.example.com".to_string()),
+            user: Some("mailbox@example.com".to_string()),
+            pass: Some("secret".to_string()),
+            ..SmtpConfig::default()
+        };
+        assert_eq!(email_status(&smtp), EMAIL_CONFIGURED);
+    }
+
+    #[test]
+    fn email_status_reports_not_configured_when_smtp_is_absent() {
+        assert_eq!(email_status(&SmtpConfig::default()), EMAIL_NOT_CONFIGURED);
+    }
+
+    /// The case that made the old report a lie: compose passes
+    /// `SMTP_HOST: ${SMTP_HOST:-}`, so a stack with no SMTP secrets hands the
+    /// backend empty strings rather than nothing.
+    #[test]
+    fn email_status_reports_not_configured_for_empty_env_vars() {
+        let smtp = SmtpConfig {
+            host: Some(String::new()),
+            user: Some(String::new()),
+            pass: Some(String::new()),
+            ..SmtpConfig::default()
+        };
+        assert_eq!(email_status(&smtp), EMAIL_NOT_CONFIGURED);
     }
 
     #[test]

--- a/backend-rust/src/services/email.rs
+++ b/backend-rust/src/services/email.rs
@@ -1,7 +1,8 @@
 //! Email service module
 //!
 //! Provides email sending functionality including:
-//! - SMTP configuration from environment variables
+//! - SMTP configuration derived from [`crate::config::SmtpConfig`] (never read
+//!   from the environment here — see [`EmailConfig::from_smtp_config`])
 //! - Send generic emails with HTML content
 //! - Send password reset emails
 //! - Send welcome emails
@@ -206,55 +207,49 @@ pub struct EmailConfig {
     pub user: String,
     /// SMTP password
     pub pass: String,
-    /// Sender email address
+    /// Sender address for the `From` header, already resolved by
+    /// [`SmtpConfig::from_address`] (`SMTP_FROM`, else `SMTP_USER`).
     pub from: String,
     /// Frontend URL for constructing links
     pub frontend_url: String,
 }
 
 impl EmailConfig {
-    /// Create a new EmailConfig from environment variables
+    /// Create a new EmailConfig from [`SmtpConfig`].
     ///
-    /// Required environment variables:
-    /// - SMTP_HOST: SMTP server hostname
-    /// - SMTP_PORT: SMTP server port (default: 465)
-    /// - SMTP_USER: SMTP username
-    /// - SMTP_PASS: SMTP password
-    /// - SMTP_FROM: Sender email address (defaults to SMTP_USER)
-    /// - FRONTEND_URL: Frontend URL for links (default: http://localhost:3000)
-    pub fn from_env() -> Option<Self> {
-        let host = std::env::var("SMTP_HOST").ok()?;
-        let port = std::env::var("SMTP_PORT")
-            .ok()
-            .and_then(|p| p.parse().ok())
-            .unwrap_or(465);
-        let user = std::env::var("SMTP_USER").ok()?;
-        let pass = std::env::var("SMTP_PASS").ok()?;
-        let from = std::env::var("SMTP_FROM").unwrap_or_else(|_| user.clone());
-        let frontend_url =
-            std::env::var("FRONTEND_URL").unwrap_or_else(|_| "http://localhost:3000".to_string());
-
-        Some(Self {
-            host,
-            port,
-            user,
-            pass,
-            from,
-            frontend_url,
-        })
-    }
-
-    /// Create a new EmailConfig from SmtpConfig
+    /// This is the **only** path from configuration to a live mailer. There
+    /// used to be a second one — a `from_env()` that read `SMTP_*` directly
+    /// and was the sole reader of `SMTP_FROM` — but it had zero call sites,
+    /// so the documented `SMTP_FROM` setting quietly did nothing while this
+    /// constructor hardcoded the From address to `SMTP_USER` (issue #352).
+    /// Keep it single-sourced: [`SmtpConfig::from_address`] decides the
+    /// sender, nothing here reads the environment.
+    ///
+    /// Returns `None` when host/user/pass are missing **or blank** — an unset
+    /// secret arrives from compose as an empty string, and an empty relay
+    /// host would otherwise build a transport that can never connect.
     pub fn from_smtp_config(smtp: &SmtpConfig, frontend_url: &str) -> Option<Self> {
         Some(Self {
-            host: smtp.host.clone()?,
+            host: smtp.host()?.to_string(),
             port: smtp.port,
-            user: smtp.user.clone()?,
-            pass: smtp.pass.clone()?,
-            from: smtp.user.clone()?,
+            user: smtp.user()?.to_string(),
+            pass: smtp.pass()?.to_string(),
+            // `from_address()` falls back to the user, so this is Some
+            // whenever `user()` was — no environment loses its sender.
+            from: smtp.from_address()?.to_string(),
             frontend_url: frontend_url.to_string(),
         })
     }
+}
+
+/// Does `address` parse as a `lettre` mailbox?
+///
+/// Accepts both the bare form (`noreply@example.com`) and the display-name
+/// form (`Loyalty App <noreply@example.com>`). Used at startup so a malformed
+/// `SMTP_FROM` is reported once, loudly, instead of failing every send at
+/// request time (issue #352).
+pub fn is_valid_mailbox(address: &str) -> bool {
+    address.parse::<Mailbox>().is_ok()
 }
 
 /// Email service trait defining email operations
@@ -357,11 +352,6 @@ impl EmailServiceImpl {
         Self { config, mailer }
     }
 
-    /// Create a new EmailServiceImpl from environment variables
-    pub fn from_env() -> Self {
-        Self::new(EmailConfig::from_env())
-    }
-
     /// Create a new EmailServiceImpl from SmtpConfig
     pub fn from_smtp_config(smtp: &SmtpConfig, frontend_url: &str) -> Self {
         Self::new(EmailConfig::from_smtp_config(smtp, frontend_url))
@@ -405,6 +395,10 @@ impl EmailService for EmailServiceImpl {
             },
         };
 
+        // `config.from` is `SMTP_FROM` when set, else `SMTP_USER` — resolved
+        // once in `SmtpConfig::from_address`. A malformed value is also
+        // reported at startup (see `log_startup_info`) so it doesn't surface
+        // for the first time here, mid-request.
         let from_mailbox = Self::parse_mailbox(&config.from)?;
         let to_mailbox = Self::parse_mailbox(to)?;
 
@@ -665,6 +659,86 @@ mod tests {
             .send_email("test@example.com", "Test Subject", "<p>Test</p>")
             .await;
         assert!(result.is_ok());
+    }
+
+    // ------------------------------------------------------------------
+    // SMTP_FROM plumbing (issue #352)
+    //
+    // `SMTP_FROM` was documented and stored as a secret, but the only code
+    // that read it was a `from_env()` with no call sites; the live path
+    // hardcoded the sender to SMTP_USER. These pin the wiring.
+    // ------------------------------------------------------------------
+
+    fn smtp_config_with_from(from: Option<&str>) -> SmtpConfig {
+        SmtpConfig {
+            host: Some("smtp.example.com".to_string()),
+            port: 587,
+            user: Some("mailbox@example.com".to_string()),
+            pass: Some("secret".to_string()),
+            from: from.map(str::to_string),
+            use_tls: true,
+        }
+    }
+
+    #[test]
+    fn email_config_uses_smtp_from_as_the_sender() {
+        let config = EmailConfig::from_smtp_config(
+            &smtp_config_with_from(Some("Loyalty App <mailbox@example.com>")),
+            "https://example.com",
+        )
+        .expect("fully configured SMTP should build an EmailConfig");
+
+        assert_eq!(config.from, "Loyalty App <mailbox@example.com>");
+        assert_eq!(config.user, "mailbox@example.com");
+    }
+
+    #[test]
+    fn email_config_falls_back_to_smtp_user_when_from_is_unset_or_blank() {
+        for from in [None, Some(""), Some("   ")] {
+            let config =
+                EmailConfig::from_smtp_config(&smtp_config_with_from(from), "https://example.com")
+                    .expect("fully configured SMTP should build an EmailConfig");
+
+            assert_eq!(
+                config.from, "mailbox@example.com",
+                "SMTP_FROM={:?} should fall back to SMTP_USER",
+                from
+            );
+        }
+    }
+
+    /// An unset secret arrives as `Some("")` from compose. Building a mailer
+    /// against an empty host produces a transport that can never connect,
+    /// while `is_configured()` would happily report success.
+    #[test]
+    fn email_config_is_none_when_credentials_are_blank() {
+        let blank = SmtpConfig {
+            host: Some(String::new()),
+            port: 587,
+            user: Some(String::new()),
+            pass: Some(String::new()),
+            from: None,
+            use_tls: true,
+        };
+        assert!(EmailConfig::from_smtp_config(&blank, "https://example.com").is_none());
+
+        let service = EmailServiceImpl::from_smtp_config(&blank, "https://example.com");
+        assert!(!service.is_configured());
+    }
+
+    /// The display-name form is the one an operator naturally writes into the
+    /// `SMTP_FROM` secret, and `lettre` must accept it — otherwise every send
+    /// fails with "Invalid email address".
+    #[test]
+    fn display_name_form_parses_as_a_mailbox() {
+        assert!(is_valid_mailbox("Loyalty App <noreply@example.com>"));
+        assert!(is_valid_mailbox("noreply@example.com"));
+    }
+
+    #[test]
+    fn malformed_from_addresses_are_rejected() {
+        assert!(!is_valid_mailbox("not an address"));
+        assert!(!is_valid_mailbox(""));
     }
 
     #[tokio::test]

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -69,6 +69,9 @@ services:
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
+      # From address for outgoing mail. Falls back to SMTP_USER when unset,
+      # and must be an address the mailbox genuinely OWNS (issue #352).
+      SMTP_FROM: ${SMTP_FROM:-}
       IMAP_HOST: ${IMAP_HOST:-}
       IMAP_PORT: ${IMAP_PORT:-993}
       IMAP_USER: ${IMAP_USER:-}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -103,6 +103,9 @@ services:
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
+      # From address for outgoing mail. Falls back to SMTP_USER when unset,
+      # and must be an address the mailbox genuinely OWNS (issue #352).
+      SMTP_FROM: ${SMTP_FROM:-}
       IMAP_HOST: ${IMAP_HOST:-}
       IMAP_PORT: ${IMAP_PORT:-993}
       IMAP_USER: ${IMAP_USER:-}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -64,6 +64,9 @@ services:
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
+      # From address for outgoing mail. Falls back to SMTP_USER when unset,
+      # and must be an address the mailbox genuinely OWNS (issue #352).
+      SMTP_FROM: ${SMTP_FROM:-}
       IMAP_HOST: ${IMAP_HOST:-}
       IMAP_PORT: ${IMAP_PORT:-993}
       IMAP_USER: ${IMAP_USER:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,9 @@ services:
       SMTP_PORT: ${SMTP_PORT:-587}
       SMTP_USER: ${SMTP_USER:-}
       SMTP_PASS: ${SMTP_PASS:-}
+      # From address for outgoing mail. Falls back to SMTP_USER when unset,
+      # and must be an address the mailbox genuinely OWNS (issue #352).
+      SMTP_FROM: ${SMTP_FROM:-}
       IMAP_HOST: ${IMAP_HOST:-}
       IMAP_PORT: ${IMAP_PORT:-993}
       IMAP_USER: ${IMAP_USER:-}

--- a/tests/email-delivery.api.spec.ts
+++ b/tests/email-delivery.api.spec.ts
@@ -28,6 +28,61 @@ test.describe('Email Delivery Tests', () => {
 
       console.log(`Email service status: ${health.services.email}`);
     });
+
+    /**
+     * Issue #352 — the regression gate for the health-honesty fix.
+     *
+     * `services.email` used to be the hard-coded string `"configured"`, so
+     * every stack claimed working outbound mail: CI, staging, and a
+     * production box whose mail subscription had lapsed alike. The value now
+     * reflects whether SMTP_HOST/USER/PASS are actually present and non-blank
+     * (compose passes `SMTP_HOST: ${SMTP_HOST:-}`, so an unset secret arrives
+     * as an empty string — which must read as absent, not as configured).
+     *
+     * The api project runs against `.github/actions/start-app-stack`, which
+     * sets no SMTP_* variables at all, so the only honest answer here is
+     * `not_configured`. If you point this suite at a stack that DOES have
+     * SMTP credentials, this test failing is correct behaviour, not a flake.
+     *
+     * What this cannot prove: that a message is deliverable. `/api/health`
+     * only ever sees configuration — a relay can authenticate and still
+     * reject the message. That gap is tracked as a separate canary follow-up.
+     */
+    test('Health endpoint should report email as not configured without SMTP credentials', async ({
+      request,
+    }) => {
+      const response = await request.get(`${backendUrl}/api/health`);
+      expect(response.ok()).toBeTruthy();
+
+      const health = await response.json();
+
+      expect(
+        health.services.email,
+        'The CI stack sets no SMTP_* variables, so /api/health must report ' +
+          '"not_configured". Reporting "configured" means the field is not ' +
+          'reading the real SMTP config (issue #352).'
+      ).toBe('not_configured');
+    });
+
+    /**
+     * The email field must stay OUT of the overall status. `deploy.yml` and
+     * `ci-build-e2e.yml`'s verify-staging poll this endpoint and treat a 503
+     * as a failed deploy (which also files a "Production deploy failed"
+     * issue). Unconfigured or broken mail must never block shipping code.
+     */
+    test('Unconfigured email must not degrade overall health status', async ({ request }) => {
+      const response = await request.get(`${backendUrl}/api/health`);
+
+      expect(response.status()).toBe(200);
+
+      const health = await response.json();
+      expect(health.services.email).toBe('not_configured');
+      expect(
+        health.status,
+        'Email is informational only — folding it into the overall status ' +
+          'would 503 the endpoint the deploy gates poll (issue #352).'
+      ).toBe('healthy');
+    });
   });
 
   test.describe('Admin Endpoints Require Auth', () => {


### PR DESCRIPTION
Fixes the deployment half of #352. Monitoring (the issue's part 2) is deliberately out of scope and filed as a follow-up — see the bottom.

## Root cause: three independent breaks, not one

The issue reports that `SMTP_FROM` is a production secret that `deploy.yml` never sends. That's true, but plumbing the secret alone would have changed nothing, because the backend had no reader for it either:

1. **No reader.** `SmtpConfig` (`backend-rust/src/config/mod.rs`) had no `from` field and `Settings::new()` had no `SMTP_FROM` override. The *only* code that read the variable was `EmailConfig::from_env()` / `EmailServiceImpl::from_env()` in `services/email.rs` — which had **zero call sites**. The live path, `EmailConfig::from_smtp_config()`, hardcoded the From address to `smtp.user`. Two divergent sources of truth is how this survived: the documented one was dead, the live one ignored the setting.
2. **Never deployed.** `deploy.yml` sent `SMTP_HOST/PORT/USER/PASS` and not `SMTP_FROM`, so no container ever saw it (matching the `docker inspect` evidence in the issue).
3. **Never declared.** No compose file listed `SMTP_FROM`, so even a correct payload had nowhere to land.

## What changed

**Config → one reader**
- `SmtpConfig.from` (`Option<String>`, documented) + `.set_override_option("email.smtp.from", env::var("SMTP_FROM").ok())` alongside the existing `smtp.user`/`smtp.pass` overrides.
- New `SmtpConfig::from_address()` → `SMTP_FROM` when non-blank, else `SMTP_USER`. Used where the `From` mailbox is built in `services/email.rs`.
- Deleted the dead `EmailConfig::from_env()` / `EmailServiceImpl::from_env()`. `SMTP_FROM` now has exactly one reader.
- **Behaviour is unchanged wherever `SMTP_FROM` is unset** — it falls back to `SMTP_USER`, which is what the code did before.

**Honest health**
- `services.email` in `/api/health` was the literal string `"configured"`, unconditionally — it never consulted the config at all. Every stack claimed working outbound mail: CI, staging, and a production box with a lapsed mail subscription alike. It now reports `configured` / `not_configured` from the real SMTP config.
- `is_configured()` now treats blank as absent. Every compose file passes `SMTP_HOST: ${SMTP_HOST:-}`, so an unset secret arrives as `Some("")`, not `None` — a bare `.is_some()` reported a stack with no SMTP at all as fully configured. Same fix applied to `ImapConfig`, which shared the pattern.
- Passwords are checked for blankness on the trimmed form but returned **untrimmed**, so a password with leading/trailing whitespace still authenticates.

**Deploy-gate constraint honored (important)**
- Email is **not** folded into `all_healthy` / the overall `status`. `deploy.yml` and `ci-build-e2e.yml`'s `verify-staging` poll `/api/health` and treat a 503 as a failed deploy — which, in production, also files a "Production deploy failed" issue. A lapsed mail subscription must never block shipping code or page anyone with a bogus deploy failure. The field stays informational, and there's a Playwright assertion pinning that: unconfigured email, `status: healthy`, HTTP 200.

**Startup visibility**
- `log_startup_info` now logs the effective From address (it ships in the header of every outgoing message — not a secret) and logs an **ERROR** if it doesn't parse as a `lettre::Mailbox`. Today a malformed value fails every send at request time with nothing at startup pointing at the cause. `{:?}` formatting keeps a stray newline from forging a log line.

**Plumbing**
- `SMTP_FROM` added to the deploy payload in `.github/workflows/deploy.yml` (env block, `--arg`, and the `env` object).
- `SMTP_FROM: ${SMTP_FROM:-}` added to `docker-compose.yml`, `.staging.yml`, `.prod.yml`, `.dev.yml`.
- **Not** added to the staging deploy in `ci-build-e2e.yml`: I checked, and that job sends no `SMTP_*` values at all, so staging has no mail config to extend.

**Docs** — `.env.example`, `.env.production.example`, `backend-rust/.env.example`, `backend-rust/README.md`: what `SMTP_FROM` does, that it falls back to `SMTP_USER`, and that the address must be one the mailbox genuinely **owns** — an alias is refused *after* a successful AUTH with `553 5.7.1 …: Sender address rejected`, the same error a lapsed subscription produces, which is exactly what made this hard to diagnose.

## Tests

Unit (`--lib`, cheap, run in CI):
- `from_address` precedence: `SMTP_FROM` wins / blank falls back to `SMTP_USER` / unset falls back / value is trimmed / `None` when neither is set.
- `is_configured()` false when host/user/pass are empty or whitespace strings (SMTP and IMAP), false when only one is blank.
- Password returned untrimmed.
- `EmailConfig::from_smtp_config` picks up `SMTP_FROM`, falls back for `None`/`""`/`"   "`, returns `None` for blank credentials.
- The display-name form `Loyalty App <x@y.com>` parses as a `lettre` `Mailbox`; malformed values don't.
- `email_status()` → `configured` / `not_configured`, including the empty-string case.

API project (`tests/email-delivery.api.spec.ts`, the deploy gate — `regression-api`):
- `/api/health` reports `email: "not_configured"` on the CI stack, which sets no `SMTP_*` variables. **This is red against today's code** (which hardcodes `"configured"`) and is the regression gate for the honesty fix.
- Unconfigured email still returns HTTP 200 with `status: "healthy"` — the deploy-gate guarantee above.

Per the build policy for this change, heavy builds were delegated to CI; locally I ran only `cargo fmt --all -- --check`, the YAML parse checks, and `scripts/validate-test-integrity.sh`. No new `sqlx` query macros, so the offline cache is untouched.

## What still needs host / secret action — read this before assuming it works

- **I cannot verify from here that the value will actually reach the container.** The remote shim (`/srv/run-deploy-loyalty-app-*.sh` on evergreen) is not in this repo, and the deploy key carries a forced command, so there was no way to inspect it. If the shim copies arbitrary keys from the payload's `env` object into the deploy-directory `.env`, `SMTP_FROM` lands with no further action. **If it filters against a hardcoded allowlist, someone must add `SMTP_FROM` to the shim on evergreen or this stays broken.** I am not claiming the secret will definitely arrive.
- Verify after deploy: `docker inspect loyalty_backend_production --format '{{range .Config.Env}}{{println .}}{{end}}' | grep '^SMTP_FROM='` should now print a value, and the backend startup log should show `SMTP Email: Enabled (From: "…")`.
- The `SMTP_FROM` secret must be set to an address the mailbox **owns**. If it's an alias, the 553 comes back — this PR makes that failure legible (startup log + admin status endpoint), it does not make an alias work.
- Nothing here changes the value of the secret itself.

## What this does NOT fix: deliverability is still unmonitored

`/api/health` can only ever prove **configuration**, never **delivery**. A relay can accept AUTH and still reject the message — that's precisely what happened in #352, where a lapsed PrivateEmail subscription returned `553 5.7.1 <info@saichon.com>: Sender address rejected` after a *successful* login. During that window every password reset, address verification and booking email failed silently, and nothing would have caught it. This PR narrows the lie (health no longer claims "configured" when there's no config) but does not close that gap.

The canary — a job that actually sends and alerts on failure — is filed as a follow-up: #364 — https://github.com/thehfhotel/loyalty-app/issues/364

Refs #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU
