### PR TITLE
feat(ops): email canary that proves mail is deliverable, alerting off-channel (#364)

### DIFF
--- a/.github/workflows/email-canary.yml
+++ b/.github/workflows/email-canary.yml
@@ -1,0 +1,498 @@
+name: Email Canary
+
+# =============================================================================
+# PROVES OUTBOUND MAIL IS DELIVERABLE — issue #364, follow-up to #352/#363.
+#
+# `/api/health` can only ever prove email is *configured*: it reads whether
+# SMTP_HOST/USER/PASS are present. In the #352 incident the PrivateEmail
+# subscription lapsed, SMTP AUTH still succeeded, and every message was then
+# refused at MAIL FROM with
+#
+#   553 5.7.1 <info@saichon.com>: Sender address rejected: not owned by user
+#
+# Health stayed green for days. This workflow closes that gap by doing the one
+# thing health cannot: a real MAIL FROM / RCPT TO / DATA send ("tier 2" in
+# #364), which is exactly the stage where a 553 appears.
+#
+# THIS WORKFLOW IS NON-GATING AND MUST STAY THAT WAY.
+#   * It never touches /api/health, so it can never fail a deploy's health
+#     poll (deploy.yml and verify-staging both gate on that endpoint).
+#   * No workflow lists it in `workflow_run`, and it lists none itself.
+#   * It runs in its own concurrency group, so it can never evict or be
+#     evicted by a deploy.
+# A mail problem is an ops alert, never a shipping blocker.
+#
+# ALERTS DO NOT GO OUT BY EMAIL. #364's design question 1 suggested reusing
+# scripts/evergreen/loyalty-backup-notify-email.sh as the transport, but that
+# script rides the *same* info@saichon.com mailbox this canary is watching —
+# the outage would suppress its own alarm. Alerts are GitHub issues instead,
+# using the create-or-comment idiom from deploy.yml's `notify-on-failure`.
+# =============================================================================
+
+on:
+  schedule:
+    # Every 6 hours, at :23 past.
+    #
+    # WHY 6h: the failure mode this catches is a *persistent* relay/billing/DNS
+    # class problem (a lapsed subscription, a revoked sender, an expired card),
+    # not a flicker — once it starts, it stays broken until a human acts. So the
+    # question is only "how long may we stay blind", and a quarter-day ceiling
+    # is proportionate for a hotel loyalty app whose email carries password
+    # resets and address verification. Going faster buys little and costs more:
+    # each run puts a real message in a real mailbox, and 4/day stays far below
+    # any relay rate limit and well under the volume that trains a spam filter.
+    # WHY :23: jobs scheduled on the hour sit in the longest GitHub cron queue;
+    # an off-the-hour minute gets picked up sooner and more predictably.
+    - cron: '23 */6 * * *'
+  workflow_dispatch:
+    inputs:
+      simulate_failure:
+        description: 'Force the send to fail (exercises the alert path end to end)'
+        type: boolean
+        default: false
+      skip_alert:
+        description: 'Probe only — never create, comment on, or close an issue'
+        type: boolean
+        default: false
+
+# Own group, never shared with `deploy` or any build group: a canary must not be
+# able to evict a deploy, and a deploy must not be able to cancel the canary into
+# a fake green. `cancel-in-progress: false` so overlapping runs queue instead.
+concurrency:
+  group: email-canary
+  cancel-in-progress: false
+
+# Least privilege at workflow scope. `issues: write` is granted on the single
+# job below because that is where the alert is filed; nothing here needs more.
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    name: "Probe outbound mail"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    # REQUIRED. SMTP_* are ENVIRONMENT-scoped secrets on `production`. A job
+    # without this line reads every one of them as an EMPTY STRING with no
+    # error at all — which is precisely how the old nightly backup workflow
+    # reported green while backing nothing up. The guard step below turns that
+    # silent misconfiguration into a loud failure, but this line is what stops
+    # it happening in the first place. The `production` environment has no
+    # required reviewers and no branch policy, so this neither blocks nor
+    # queues for approval.
+    environment:
+      name: production
+    permissions:
+      contents: read
+      issues: write
+    env:
+      # One alarm for this canary: delivery failures AND "the canary could not
+      # run at all" both land on this issue, so the recovery path closes it.
+      ISSUE_TITLE: 'Email canary: outbound mail is failing'
+    steps:
+      # -----------------------------------------------------------------------
+      # A canary that silently probes nothing is worse than no canary: it
+      # manufactures the exact false confidence it exists to remove.
+      # -----------------------------------------------------------------------
+      - name: Guard — SMTP secrets must actually be visible to this job
+        id: guard
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+        run: |
+          set -euo pipefail
+          missing=""
+          [ -n "${SMTP_HOST:-}" ] || missing="${missing} SMTP_HOST"
+          [ -n "${SMTP_USER:-}" ] || missing="${missing} SMTP_USER"
+          [ -n "${SMTP_PASS:-}" ] || missing="${missing} SMTP_PASS"
+
+          if [ -n "$missing" ]; then
+            echo "::error title=Email canary cannot run::Empty SMTP secret(s):${missing}. These are ENVIRONMENT-scoped secrets on the 'production' environment. A job that omits 'environment: production' (or that runs before the environment is resolved) reads them as EMPTY STRINGS with NO error — the same trap that made the old nightly backup report green while backing nothing up. Check (a) this job still declares 'environment: production', and (b) the secrets still exist under Settings -> Environments -> production."
+            exit 1
+          fi
+          echo "SMTP_HOST / SMTP_USER / SMTP_PASS are all non-empty."
+
+      # -----------------------------------------------------------------------
+      # THE PROBE — a real send, modelled on
+      # scripts/evergreen/loyalty-backup-notify-email.sh (curl SMTPS, no MTA).
+      # Two deliberate improvements over that script:
+      #   1. the password is NEVER on the process argv (that script passes it
+      #      via --user, visible in /proc to any local user); here curl reads it
+      #      from a mode-0600 --config file in a private temp dir.
+      #   2. the relay's own response text is captured, because "553 ... Sender
+      #      address rejected" vs "535 auth failed" vs a timeout are three
+      #      completely different incidents.
+      # This step NEVER fails the job — it reports through its `result` output
+      # so the alert steps below can run. The job is failed at the very end.
+      # -----------------------------------------------------------------------
+      - name: Send the canary message
+        id: probe
+        env:
+          SMTP_HOST: ${{ secrets.SMTP_HOST }}
+          SMTP_PORT: ${{ secrets.SMTP_PORT }}
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          SMTP_FROM: ${{ secrets.SMTP_FROM }}
+          # Optional override. Neither a CANARY_EMAIL_TO secret nor variable
+          # exists today (checked with `gh secret list` / `gh variable list`),
+          # so the canary sends the mailbox a message to ITSELF. That is the
+          # right default: it needs no second mailbox to exist, it exercises the
+          # same sender the app uses, and a self-addressed message still has to
+          # pass MAIL FROM — the stage where #352 failed. Set either one (secret
+          # or repo/environment variable) to route the copies elsewhere.
+          CANARY_EMAIL_TO: ${{ secrets.CANARY_EMAIL_TO || vars.CANARY_EMAIL_TO }}
+          SIMULATE_FAILURE: ${{ github.event.inputs.simulate_failure || 'false' }}
+        run: |
+          # NOT `set -e`: curl failing is an expected outcome we handle.
+          set -uo pipefail
+          umask 077
+
+          WORKDIR="$(mktemp -d)"
+          trap 'rm -rf "$WORKDIR"' EXIT
+          CURL_CFG="$WORKDIR/curlrc"
+          MAIL_FILE="$WORKDIR/message.eml"
+          TRACE="$WORKDIR/trace.log"
+
+          # --- credentials off argv -------------------------------------------
+          # curl's config-file syntax takes a double-quoted parameter, so a
+          # password containing spaces survives; backslash and quote need
+          # escaping. Done with parameter expansion so the secret is never an
+          # argument to any external process.
+          esc_user="${SMTP_USER//\\/\\\\}"; esc_user="${esc_user//\"/\\\"}"
+          esc_pass="${SMTP_PASS//\\/\\\\}"; esc_pass="${esc_pass//\"/\\\"}"
+          printf 'user = "%s:%s"\n' "$esc_user" "$esc_pass" > "$CURL_CFG"
+          unset esc_pass
+
+          # --- endpoint --------------------------------------------------------
+          PORT="${SMTP_PORT:-465}"
+          if [ "$PORT" = "465" ]; then
+            URL="smtps://${SMTP_HOST}:${PORT}"   # implicit TLS
+          else
+            URL="smtp://${SMTP_HOST}:${PORT}"    # STARTTLS (--ssl-reqd below)
+          fi
+
+          # --- addresses -------------------------------------------------------
+          # Mirrors the backend's SmtpConfig::from_address(): SMTP_FROM when set,
+          # else SMTP_USER. The header may carry the display-name form
+          # ("Loyalty App <x@y>"); the SMTP envelope may not, so strip it.
+          HEADER_FROM="${SMTP_FROM:-}"
+          [ -n "$HEADER_FROM" ] || HEADER_FROM="$SMTP_USER"
+          ENVELOPE_FROM="$HEADER_FROM"
+          case "$ENVELOPE_FROM" in
+            *"<"*">"*)
+              ENVELOPE_FROM="${ENVELOPE_FROM#*<}"
+              ENVELOPE_FROM="${ENVELOPE_FROM%%>*}"
+              ;;
+          esac
+
+          RCPT="${CANARY_EMAIL_TO:-}"
+          [ -n "$RCPT" ] || RCPT="$SMTP_USER"
+
+          if [ "${SIMULATE_FAILURE}" = "true" ]; then
+            # Reproduce the #352 failure for real rather than faking an exit
+            # code: .invalid is a reserved TLD (RFC 2606), so the relay must
+            # refuse this sender — typically with the same 553 "not owned by
+            # user" wording — and no message can escape to a real mailbox.
+            echo "::warning title=Simulated failure::simulate_failure=true — sending with a deliberately unowned envelope sender."
+            ENVELOPE_FROM="simulated-failure@canary.invalid"
+            HEADER_FROM="$ENVELOPE_FROM"
+          fi
+
+          # Masked forms are the only ones that may reach a log or a PUBLIC
+          # issue body. The domain is kept because it says which relay/tenant
+          # refused; the local part is not a diagnostic.
+          MASKED_RCPT="***@${RCPT#*@}"
+          MASKED_FROM="***@${ENVELOPE_FROM#*@}"
+          echo "Probing ${URL} — envelope from ${MASKED_FROM} to ${MASKED_RCPT}"
+
+          # --- message ---------------------------------------------------------
+          STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          {
+            printf 'From: %s\r\n' "$HEADER_FROM"
+            printf 'To: %s\r\n' "$RCPT"
+            printf 'Subject: [loyalty] email canary %s (automated - safe to delete)\r\n' "$STAMP"
+            printf 'Date: %s\r\n' "$(date -R)"
+            printf 'Message-ID: <canary-%s-%s@loyalty.saichon.com>\r\n' \
+              "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}"
+            # RFC 3834: tells well-behaved mailboxes not to auto-reply, and
+            # keeps the canary out of vacation/autoresponder loops.
+            printf 'Auto-Submitted: auto-generated\r\n'
+            printf 'X-Loyalty-Canary: 1\r\n'
+            printf 'Content-Type: text/plain; charset=UTF-8\r\n'
+            printf '\r\n'
+            printf 'This is an AUTOMATED DELIVERABILITY CANARY for the loyalty app.\r\n'
+            printf '\r\n'
+            printf 'Nothing is wrong. It is sent every few hours purely to prove that\r\n'
+            printf 'outbound mail still leaves the relay, because /api/health can only\r\n'
+            printf 'prove that SMTP is CONFIGURED, never that a message ARRIVES.\r\n'
+            printf '\r\n'
+            printf 'No action is required. It is safe to ignore or delete, and safe to\r\n'
+            printf 'filter into a folder. It is NOT safe to make the relay reject it.\r\n'
+            printf '\r\n'
+            printf 'Sent at:  %s\r\n' "$STAMP"
+            printf 'Workflow: %s\r\n' "$RUN_URL"
+            printf 'Context:  github.com/%s issue #364\r\n' "${GITHUB_REPOSITORY}"
+          } > "$MAIL_FILE"
+
+          # --- sanitiser -------------------------------------------------------
+          # ONLY server-side response lines ever leave this step. The client side
+          # of a verbose SMTP trace contains the AUTH line, whose base64 payload
+          # IS the password (GitHub's secret masking does not cover base64), so
+          # '> ' lines and the 334 challenge are dropped outright rather than
+          # filtered. Local parts are masked because this text is quoted into an
+          # issue on a PUBLIC repository.
+          sanitize() {
+            grep -aE '^(< [0-9]{3}|curl: )' "$1" 2>/dev/null \
+              | grep -avE '^< 334' \
+              | sed -E 's/[A-Za-z0-9._%+-]+@/***@/g' \
+              | tail -n 25
+          }
+
+          # --- send, with retries ----------------------------------------------
+          # Only a run where EVERY attempt fails counts as a confirmed failure.
+          # One refused connection at 03:23 is a blip, not an incident; the
+          # repo's alerting convention is to page on confirmed failures only.
+          BACKOFF="0 20 60"
+          ATTEMPT=0
+          RESULT="failed"
+          DETAIL=""
+          for delay in $BACKOFF; do
+            ATTEMPT=$((ATTEMPT + 1))
+            if [ "$delay" -gt 0 ]; then
+              echo "Attempt $ATTEMPT: waiting ${delay}s before retrying..."
+              sleep "$delay"
+            fi
+
+            : > "$TRACE"
+            # --silent kills the progress meter, --verbose keeps the SMTP dialog
+            # (on stderr), --ssl-reqd refuses to fall back to plaintext.
+            # NOTE: the status is captured into RC on the next line rather than
+            # tested with `if curl ...`, because after a false `if` with no
+            # `else` branch `$?` is 0, not the command's status.
+            curl --silent --show-error --verbose --ssl-reqd \
+                 --config "$CURL_CFG" \
+                 --url "$URL" \
+                 --mail-from "$ENVELOPE_FROM" \
+                 --mail-rcpt "$RCPT" \
+                 --upload-file "$MAIL_FILE" \
+                 --max-time 60 \
+                 > "$TRACE" 2>&1
+            RC=$?
+
+            if [ "$RC" -eq 0 ]; then
+              RESULT="ok"
+              DETAIL="$(sanitize "$TRACE")"
+              echo "Attempt ${ATTEMPT}: ACCEPTED by the relay."
+              printf '%s\n' "$DETAIL"
+              break
+            fi
+
+            ATTEMPT_DETAIL="$(sanitize "$TRACE")"
+            echo "Attempt ${ATTEMPT}: FAILED (curl exit ${RC})."
+            printf '%s\n' "$ATTEMPT_DETAIL"
+            DETAIL="$(printf 'attempt %s — curl exit %s\n%s\n' \
+              "$ATTEMPT" "$RC" "$ATTEMPT_DETAIL")"
+          done
+
+          [ -n "$DETAIL" ] || DETAIL="(no SMTP response captured — the relay was not reached at all)"
+
+          {
+            echo "result=${RESULT}"
+            echo "attempts=${ATTEMPT}"
+            echo "recipient=${MASKED_RCPT}"
+            echo "sender=${MASKED_FROM}"
+            echo "detail<<CANARY_DETAIL_EOF"
+            printf '%s\n' "$DETAIL"
+            echo "CANARY_DETAIL_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Email canary: ${RESULT}"
+            echo ""
+            echo "- Relay: \`${SMTP_HOST}:${PORT}\`"
+            echo "- Envelope: \`${MASKED_FROM}\` -> \`${MASKED_RCPT}\`"
+            echo "- Attempts: ${ATTEMPT}"
+            echo ""
+            echo '```'
+            printf '%s\n' "$DETAIL"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # -----------------------------------------------------------------------
+      # ALERT — GitHub issue, never email (see the header). Same create-or-comment
+      # idiom as deploy.yml's `notify-on-failure`: search for an OPEN issue with
+      # this exact title, comment if found, create if not.
+      # -----------------------------------------------------------------------
+      - name: File or update the email-canary issue
+        if: steps.probe.outputs.result == 'failed' && github.event.inputs.skip_alert != 'true'
+        env:
+          GH_TOKEN:  ${{ github.token }}
+          REPO:      ${{ github.repository }}
+          RUN_URL:   ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ATTEMPTS:  ${{ steps.probe.outputs.attempts }}
+          RECIPIENT: ${{ steps.probe.outputs.recipient }}
+          SENDER:    ${{ steps.probe.outputs.sender }}
+          # Read through env, never interpolated into the script body: the relay
+          # controls this text, and `${{ }}` inside `run:` would splice it into
+          # the shell source.
+          DETAIL:    ${{ steps.probe.outputs.detail }}
+          SIMULATED: ${{ github.event.inputs.simulate_failure || 'false' }}
+        run: |
+          set -euo pipefail
+          TITLE="$ISSUE_TITLE"
+
+          BODY=$(cat <<EOF
+          **Outbound mail is not being accepted by the relay.** All ${ATTEMPTS}
+          attempts in this run failed, so this is a confirmed failure, not a blip.
+
+          - Run: $RUN_URL
+          - Envelope: \`${SENDER}\` -> \`${RECIPIENT}\` (local parts masked)
+          - Simulated (\`simulate_failure=true\`): \`${SIMULATED}\`
+
+          Relay response (server side only; local parts masked):
+
+          \`\`\`
+          ${DETAIL}
+          \`\`\`
+
+          **What this means.** The canary performs a real MAIL FROM / RCPT TO /
+          DATA send. Reaching this issue means the relay refused the message —
+          which is what happened in #352, when the mailbox subscription lapsed,
+          AUTH kept succeeding and every send was refused with
+          \`553 5.7.1 ... Sender address rejected: not owned by user\`.
+          Password resets, email verification and booking mail are failing
+          silently RIGHT NOW; \`/api/health\` will still say email is
+          \`configured\`, because configuration is all it can see.
+
+          **Response.** See \`docs/email-canary-runbook.md\`. In short: read the
+          response code above (553 = sender/billing/ownership, 535 = credentials,
+          timeout = network/relay down), fix the mailbox, then re-run this
+          workflow. On the next green run the canary comments here and closes
+          this issue automatically.
+
+          This issue is filed by \`.github/workflows/email-canary.yml\`. The
+          canary does NOT gate deploys — shipping is unaffected.
+          EOF
+          )
+
+          EXISTING=$(gh issue list -R "$REPO" \
+            --search "$TITLE in:title is:open" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "${EXISTING:-}" ]; then
+            gh issue comment "$EXISTING" -R "$REPO" --body "$BODY"
+            echo "Commented on existing issue #$EXISTING"
+          else
+            # Label only if it already exists — the repo's convention (see
+            # cargo-audit.yml) is that alerting must never depend on label
+            # config, so an unlabelled issue beats a failed alert.
+            LABEL_ARGS=()
+            if gh label list -R "$REPO" --json name --jq '.[].name' | grep -qx 'bug'; then
+              LABEL_ARGS=(--label bug)
+            fi
+            gh issue create -R "$REPO" --title "$TITLE" --body "$BODY" "${LABEL_ARGS[@]}"
+            echo "Filed a new email-canary issue"
+          fi
+
+      # -----------------------------------------------------------------------
+      # The canary could not even try. Same issue, because from an operator's
+      # seat "mail is broken" and "the thing that watches mail is broken" demand
+      # the same response: look now. Routed here so a misconfiguration cannot
+      # sit unnoticed as a red run in the Actions tab that nobody opens.
+      # -----------------------------------------------------------------------
+      - name: File or update the email-canary issue (canary could not run)
+        if: failure() && steps.guard.outcome == 'failure' && github.event.inputs.skip_alert != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO:     ${{ github.repository }}
+          RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="$ISSUE_TITLE"
+
+          BODY=$(cat <<EOF
+          **The email canary could not run: one or more SMTP secrets were empty.**
+
+          - Run: $RUN_URL
+
+          Nothing was probed, so the state of outbound mail is currently UNKNOWN
+          — treat it as unverified, not as working.
+
+          The usual cause is the environment-scope trap: \`SMTP_HOST\`,
+          \`SMTP_USER\` and \`SMTP_PASS\` are secrets on the \`production\`
+          *environment*, and a job that does not declare
+          \`environment: production\` reads them as empty strings with no error.
+          Check that the \`probe\` job in
+          \`.github/workflows/email-canary.yml\` still declares it, and that the
+          secrets still exist under Settings -> Environments -> production.
+
+          See \`docs/email-canary-runbook.md\`.
+          EOF
+          )
+
+          EXISTING=$(gh issue list -R "$REPO" \
+            --search "$TITLE in:title is:open" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -n "${EXISTING:-}" ]; then
+            gh issue comment "$EXISTING" -R "$REPO" --body "$BODY"
+          else
+            gh issue create -R "$REPO" --title "$TITLE" --body "$BODY"
+          fi
+
+      # -----------------------------------------------------------------------
+      # RECOVERY — the repo's convention is that every failure alert is paired
+      # with a recovery notification, so the signal stays trusted.
+      # -----------------------------------------------------------------------
+      - name: Comment and close the email-canary issue on recovery
+        if: steps.probe.outputs.result == 'ok' && github.event.inputs.skip_alert != 'true'
+        env:
+          GH_TOKEN:  ${{ github.token }}
+          REPO:      ${{ github.repository }}
+          RUN_URL:   ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RECIPIENT: ${{ steps.probe.outputs.recipient }}
+          SENDER:    ${{ steps.probe.outputs.sender }}
+        run: |
+          set -euo pipefail
+          TITLE="$ISSUE_TITLE"
+
+          # Note: `gh issue list --search` reads GitHub's search index, which
+          # lags writes by a few seconds. Worst case a recovery lands one run
+          # late — acceptable, and the same idiom deploy.yml already uses.
+          EXISTING=$(gh issue list -R "$REPO" \
+            --search "$TITLE in:title is:open" \
+            --json number --jq '.[0].number // empty')
+
+          if [ -z "${EXISTING:-}" ]; then
+            echo "Mail is delivering and no canary issue is open — nothing to do."
+            exit 0
+          fi
+
+          BODY=$(cat <<EOF
+          **Recovered: outbound mail is delivering again.**
+
+          - Run: $RUN_URL
+          - Envelope: \`${SENDER}\` -> \`${RECIPIENT}\` (local parts masked)
+
+          The relay accepted a real MAIL FROM / RCPT TO / DATA send, so password
+          resets, email verification and booking mail should be flowing again.
+          Closing automatically; the canary will reopen a fresh issue if it
+          fails again.
+          EOF
+          )
+
+          gh issue comment "$EXISTING" -R "$REPO" --body "$BODY"
+          gh issue close "$EXISTING" -R "$REPO"
+          echo "Closed recovered issue #$EXISTING"
+
+      # -----------------------------------------------------------------------
+      # Fail LAST, so the alert steps above always got their chance to run. A
+      # red run here blocks nothing: no workflow consumes this one.
+      # -----------------------------------------------------------------------
+      - name: Fail the run on a confirmed delivery failure
+        if: steps.probe.outputs.result == 'failed'
+        run: |
+          echo "::error title=Outbound mail is failing::Every send attempt was refused. See the issue filed above and docs/email-canary-runbook.md."
+          exit 1

--- a/.github/workflows/email-canary.yml
+++ b/.github/workflows/email-canary.yml
@@ -86,9 +86,15 @@ jobs:
       contents: read
       issues: write
     env:
-      # One alarm for this canary: delivery failures AND "the canary could not
-      # run at all" both land on this issue, so the recovery path closes it.
-      ISSUE_TITLE: 'Email canary: outbound mail is failing'
+      # Two distinct alarms — "mail is refused" and "the canary never ran" call
+      # for different first moves — and the recovery step closes whichever is
+      # open. NOTE: no colons in these titles. `gh issue list --search` speaks
+      # GitHub search syntax, where `word:` reads as a qualifier; the searches
+      # below also wrap the title in quotes so it is matched as a phrase. Get
+      # this wrong and the search silently returns nothing, which files a fresh
+      # duplicate issue on every probe instead of commenting on the open one.
+      ISSUE_TITLE_FAIL: 'Email canary - outbound mail is failing'
+      ISSUE_TITLE_MISCONFIG: 'Email canary - probe could not run, SMTP secrets empty'
     steps:
       # -----------------------------------------------------------------------
       # A canary that silently probes nothing is worse than no canary: it
@@ -341,7 +347,7 @@ jobs:
           SIMULATED: ${{ github.event.inputs.simulate_failure || 'false' }}
         run: |
           set -euo pipefail
-          TITLE="$ISSUE_TITLE"
+          TITLE="$ISSUE_TITLE_FAIL"
 
           BODY=$(cat <<EOF
           **Outbound mail is not being accepted by the relay.** All ${ATTEMPTS}
@@ -377,8 +383,11 @@ jobs:
           EOF
           )
 
+          # Quoted phrase: the title is matched literally instead of being
+          # tokenised (and a stray qualifier-looking word silently zeroing the
+          # result, which would file a duplicate on every probe).
           EXISTING=$(gh issue list -R "$REPO" \
-            --search "$TITLE in:title is:open" \
+            --search "\"$TITLE\" in:title is:open" \
             --json number --jq '.[0].number // empty')
 
           if [ -n "${EXISTING:-}" ]; then
@@ -397,10 +406,10 @@ jobs:
           fi
 
       # -----------------------------------------------------------------------
-      # The canary could not even try. Same issue, because from an operator's
-      # seat "mail is broken" and "the thing that watches mail is broken" demand
-      # the same response: look now. Routed here so a misconfiguration cannot
-      # sit unnoticed as a red run in the Actions tab that nobody opens.
+      # The canary could not even try. Its own issue, because the first move
+      # differs from a delivery failure (fix the workflow/secrets, not the
+      # mailbox) — but it is still an alert, not a red run sitting unread in the
+      # Actions tab. Unverified is not the same as working.
       # -----------------------------------------------------------------------
       - name: File or update the email-canary issue (canary could not run)
         if: failure() && steps.guard.outcome == 'failure' && github.event.inputs.skip_alert != 'true'
@@ -410,7 +419,7 @@ jobs:
           RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          TITLE="$ISSUE_TITLE"
+          TITLE="$ISSUE_TITLE_MISCONFIG"
 
           BODY=$(cat <<EOF
           **The email canary could not run: one or more SMTP secrets were empty.**
@@ -433,7 +442,7 @@ jobs:
           )
 
           EXISTING=$(gh issue list -R "$REPO" \
-            --search "$TITLE in:title is:open" \
+            --search "\"$TITLE\" in:title is:open" \
             --json number --jq '.[0].number // empty')
 
           if [ -n "${EXISTING:-}" ]; then
@@ -456,19 +465,6 @@ jobs:
           SENDER:    ${{ steps.probe.outputs.sender }}
         run: |
           set -euo pipefail
-          TITLE="$ISSUE_TITLE"
-
-          # Note: `gh issue list --search` reads GitHub's search index, which
-          # lags writes by a few seconds. Worst case a recovery lands one run
-          # late — acceptable, and the same idiom deploy.yml already uses.
-          EXISTING=$(gh issue list -R "$REPO" \
-            --search "$TITLE in:title is:open" \
-            --json number --jq '.[0].number // empty')
-
-          if [ -z "${EXISTING:-}" ]; then
-            echo "Mail is delivering and no canary issue is open — nothing to do."
-            exit 0
-          fi
 
           BODY=$(cat <<EOF
           **Recovered: outbound mail is delivering again.**
@@ -478,14 +474,33 @@ jobs:
 
           The relay accepted a real MAIL FROM / RCPT TO / DATA send, so password
           resets, email verification and booking mail should be flowing again.
-          Closing automatically; the canary will reopen a fresh issue if it
-          fails again.
+          A successful probe also proves the canary's own secrets are visible.
+          Closing automatically; the canary files a fresh issue if it fails
+          again.
           EOF
           )
 
-          gh issue comment "$EXISTING" -R "$REPO" --body "$BODY"
-          gh issue close "$EXISTING" -R "$REPO"
-          echo "Closed recovered issue #$EXISTING"
+          # Both alarms clear on a good probe: a send that the relay accepted
+          # disproves "mail is failing" and "the canary cannot see its secrets"
+          # at the same time.
+          #
+          # Note: `gh issue list --search` reads GitHub's search index, which
+          # lags writes by a few seconds. Worst case a recovery lands one run
+          # late — acceptable, and the same idiom deploy.yml already uses.
+          for TITLE in "$ISSUE_TITLE_FAIL" "$ISSUE_TITLE_MISCONFIG"; do
+            EXISTING=$(gh issue list -R "$REPO" \
+              --search "\"$TITLE\" in:title is:open" \
+              --json number --jq '.[0].number // empty')
+
+            if [ -z "${EXISTING:-}" ]; then
+              echo "No open issue titled '$TITLE' — nothing to close."
+              continue
+            fi
+
+            gh issue comment "$EXISTING" -R "$REPO" --body "$BODY"
+            gh issue close "$EXISTING" -R "$REPO"
+            echo "Closed recovered issue #$EXISTING"
+          done
 
       # -----------------------------------------------------------------------
       # Fail LAST, so the alert steps above always got their chance to run. A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,14 @@ Workflows fire on push to `main`:
   non-gating security scanners. `cargo-audit` also runs on
   `backend-rust/Cargo.{lock,toml}` changes so a vulnerable crate cannot
   merge and auto-deploy inside the daily cron window.
+- `email-canary.yml` (**Email Canary**) — **non-gating.** Every 6h it
+  sends a real message through the production relay (`environment:
+  production`, so the env-scoped `SMTP_*` secrets resolve) to prove
+  outbound mail is *deliverable*, which `/api/health` can never do — it
+  only sees configuration. Alerts are GitHub issues, never email: the
+  only mailbox available would be the one that is down. It touches no
+  health endpoint and no deploy workflow depends on it. Runbook:
+  [`docs/email-canary-runbook.md`](docs/email-canary-runbook.md).
 Postgres backups deliberately do **not** run in CI. A systemd timer on
 evergreen (`scripts/evergreen/`) dumps, gzips and `age`-encrypts to
 `/srv/backups/loyalty`, so production data never transits a runner. The

--- a/backend-rust/src/services/email.rs
+++ b/backend-rust/src/services/email.rs
@@ -9,6 +9,7 @@
 //! - Email templates
 
 use async_trait::async_trait;
+use axum_prometheus::metrics::counter;
 use lettre::{
     message::{header::ContentType, Mailbox, MultiPart, SinglePart},
     transport::smtp::authentication::Credentials,
@@ -16,10 +17,11 @@ use lettre::{
 };
 use rand::Rng;
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::config::SmtpConfig;
 use crate::error::AppError;
+use crate::utils::{hash_email, sanitize_log_value};
 
 /// Email templates module
 pub mod templates {
@@ -252,6 +254,104 @@ pub fn is_valid_mailbox(address: &str) -> bool {
     address.parse::<Mailbox>().is_ok()
 }
 
+// ---------------------------------------------------------------------------
+// Observability (issue #352 part 3, carried into #364)
+//
+// Before this, a hard send failure produced one `tracing::error!` inside the
+// caller (`routes/auth.rs`) and nothing else: no metric, no alert, and the
+// caller still returned success to the user (deliberately — email
+// enumeration). The #352 outage was therefore invisible for days.
+//
+// These counters render on `/metrics` with no new dependency: `axum_prometheus`
+// re-exports the `metrics` crate, and `routes::create_router` already installs
+// the global Prometheus recorder. When no recorder is installed (unit tests,
+// binaries that never build the router) the macros are no-ops, so this is safe
+// to call from anywhere.
+// ---------------------------------------------------------------------------
+
+/// Messages the relay accepted (a real `MAIL FROM`/`RCPT TO`/`DATA` returning
+/// 250). Deliberately NOT incremented when SMTP is unconfigured — see
+/// [`EMAIL_SENDS_SKIPPED`].
+const EMAIL_SENDS_TOTAL: &str = "loyalty_email_sends_total";
+
+/// Sends that failed, labelled with a bounded `kind` from
+/// [`classify_send_failure`]. Alert on `increase(...[1h]) > 0`.
+const EMAIL_SEND_FAILURES_TOTAL: &str = "loyalty_email_send_failures_total";
+
+/// Sends that never happened because SMTP is not configured. This is the
+/// silent-success hazard made visible: `send_email` returns `Ok(())` on that
+/// path, so counting it as a success would claim mail is flowing on a stack
+/// that cannot send at all. A stack with a non-zero rate here and a zero rate
+/// on [`EMAIL_SENDS_TOTAL`] is *not* healthy — it is mute.
+const EMAIL_SENDS_SKIPPED_TOTAL: &str = "loyalty_email_sends_skipped_total";
+
+/// Map a send error to a small, bounded metric label.
+///
+/// Cardinality matters: the raw error text embeds server-specific detail and
+/// would blow up the time series, so the label is always one of a fixed set of
+/// `&'static str`. The *first* arm is the #352 signature —
+/// `553 5.7.1 <info@saichon.com>: Sender address rejected: not owned by user` —
+/// because "the relay no longer lets us send as ourselves" (lapsed
+/// subscription, revoked alias, expired card) demands a different response
+/// from "the password is wrong" or "the network blipped".
+pub fn classify_send_failure(error: &str) -> &'static str {
+    let e = error.to_ascii_lowercase();
+
+    if e.contains("sender address rejected") || e.contains("not owned by user") {
+        "sender_rejected"
+    } else if e.contains("authentication") || e.contains("535") || e.contains("auth failed") {
+        "auth"
+    } else if e.contains("recipient address rejected")
+        || e.contains("user unknown")
+        || e.contains("mailbox unavailable")
+        || e.contains("relay access denied")
+        || e.contains("relaying denied")
+    {
+        "recipient_rejected"
+    } else if e.contains("quota")
+        || e.contains("rate limit")
+        || e.contains("too many")
+        || e.contains("try again later")
+    {
+        "throttled"
+    } else if e.contains("timed out")
+        || e.contains("timeout")
+        || e.contains("connection")
+        || e.contains("dns")
+        || e.contains("certificate")
+        || e.contains("tls")
+    {
+        "transport"
+    } else if e.contains("invalid email address") {
+        "invalid_address"
+    } else {
+        "other"
+    }
+}
+
+/// Replace anything that looks like an email address with its stable
+/// [`hash_email`] token.
+///
+/// Relay errors quote the addresses they refused (`550 <someone@example.com>:
+/// User unknown`), so logging the error verbatim would put a *user's* address
+/// in the logs — exactly what LOW-4 removed. Hashing keeps the line
+/// correlatable with the rest of the request's logs while dropping the PII,
+/// and leaves the diagnostic wording (`553 5.7.1 ... Sender address rejected`)
+/// intact, which is the part an operator actually reads.
+///
+/// Fails closed: if the pattern cannot be compiled, nothing of the original
+/// text is returned.
+pub fn redact_email_addresses(text: &str) -> String {
+    match regex_lite::Regex::new(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}") {
+        Ok(re) => re
+            .replace_all(text, |caps: &regex_lite::Captures<'_>| {
+                format!("<email:{}>", hash_email(&caps[0]))
+            })
+            .into_owned(),
+        Err(_) => "<email address redaction unavailable>".to_string(),
+    }
+}
+
 /// Email service trait defining email operations
 #[async_trait]
 pub trait EmailService: Send + Sync {
@@ -379,9 +479,14 @@ impl EmailService for EmailServiceImpl {
         let config = match &self.config {
             Some(c) => c,
             None => {
+                // Returns Ok(()) so an unconfigured dev stack still works, but
+                // it must never look like a delivered message — hence the
+                // *skipped* counter rather than the success one.
+                counter!(EMAIL_SENDS_SKIPPED_TOTAL, "reason" => "unconfigured").increment(1);
                 warn!(
-                    "SMTP not configured, skipping email to {} with subject: {}",
-                    to, subject
+                    email_hash = %hash_email(to),
+                    subject = %subject,
+                    "SMTP not configured, skipping email"
                 );
                 return Ok(());
             },
@@ -390,7 +495,12 @@ impl EmailService for EmailServiceImpl {
         let mailer = match &self.mailer {
             Some(m) => m,
             None => {
-                warn!("SMTP mailer not initialized, skipping email to {}", to);
+                counter!(EMAIL_SENDS_SKIPPED_TOTAL, "reason" => "no_mailer").increment(1);
+                warn!(
+                    email_hash = %hash_email(to),
+                    subject = %subject,
+                    "SMTP mailer not initialized, skipping email"
+                );
                 return Ok(());
             },
         };
@@ -399,8 +509,12 @@ impl EmailService for EmailServiceImpl {
         // once in `SmtpConfig::from_address`. A malformed value is also
         // reported at startup (see `log_startup_info`) so it doesn't surface
         // for the first time here, mid-request.
-        let from_mailbox = Self::parse_mailbox(&config.from)?;
-        let to_mailbox = Self::parse_mailbox(to)?;
+        let from_mailbox = Self::parse_mailbox(&config.from).inspect_err(|_| {
+            counter!(EMAIL_SEND_FAILURES_TOTAL, "kind" => "invalid_address").increment(1);
+        })?;
+        let to_mailbox = Self::parse_mailbox(to).inspect_err(|_| {
+            counter!(EMAIL_SEND_FAILURES_TOTAL, "kind" => "invalid_address").increment(1);
+        })?;
 
         // Create plain text version by stripping HTML tags (simple approach)
         let plain_text = html_body
@@ -434,14 +548,44 @@ impl EmailService for EmailServiceImpl {
                             .body(html_body.to_string()),
                     ),
             )
-            .map_err(|e| AppError::Internal(format!("Failed to build email: {}", e)))?;
+            .map_err(|e| {
+                counter!(EMAIL_SEND_FAILURES_TOTAL, "kind" => "message_build").increment(1);
+                AppError::Internal(format!("Failed to build email: {}", e))
+            })?;
 
-        mailer
-            .send(email)
-            .await
-            .map_err(|e| AppError::Internal(format!("Failed to send email: {}", e)))?;
+        if let Err(e) = mailer.send(email).await {
+            // The hard failure path. #352 lived here for days as a single
+            // `tracing::error!` in the *caller*, with the caller still
+            // returning success to the user (email enumeration). Three things
+            // change that:
+            //   * a counter, so `/metrics` shows it and an alert can fire;
+            //   * a fixed, greppable marker (`EMAIL_SEND_FAILED`) — the string
+            //     to search for in the journal during an incident;
+            //   * a bounded `kind`, so "the relay rejects our sender" is
+            //     distinguishable from "the password is wrong" at a glance.
+            // No address and no credential is logged: the recipient is hashed,
+            // and the relay's text is scrubbed of addresses and then passed
+            // through `sanitize_log_value` because it is remote-controlled
+            // input going into a log line (log injection).
+            let detail = e.to_string();
+            let kind = classify_send_failure(&detail);
+            counter!(EMAIL_SEND_FAILURES_TOTAL, "kind" => kind).increment(1);
+            error!(
+                email_hash = %hash_email(to),
+                subject = %subject,
+                kind = %kind,
+                error = %sanitize_log_value(&redact_email_addresses(&detail), None),
+                "EMAIL_SEND_FAILED: the SMTP relay refused the message"
+            );
+            return Err(AppError::Internal(format!("Failed to send email: {}", e)));
+        }
 
-        info!("Email sent to {} with subject: {}", to, subject);
+        counter!(EMAIL_SENDS_TOTAL).increment(1);
+        info!(
+            email_hash = %hash_email(to),
+            subject = %subject,
+            "Email sent"
+        );
         Ok(())
     }
 
@@ -749,5 +893,124 @@ mod tests {
             .send_email("test@example.com", "Test", "<p>Test</p>")
             .await;
         assert!(result.is_ok());
+    }
+
+    // ------------------------------------------------------------------
+    // Send-failure observability (issue #352 part 3 / #364)
+    // ------------------------------------------------------------------
+
+    /// The exact wording from the #352 incident must classify as
+    /// `sender_rejected` — the label that means "the relay will not let us
+    /// send as ourselves", i.e. check the mailbox subscription, not the code.
+    #[test]
+    fn the_352_incident_wording_classifies_as_sender_rejected() {
+        let e = "Failed to send email: permanent error (553): 553 5.7.1 \
+                 <info@saichon.com>: Sender address rejected: not owned by user \
+                 info@saichon.com";
+        assert_eq!(classify_send_failure(e), "sender_rejected");
+    }
+
+    #[test]
+    fn send_failures_classify_into_bounded_kinds() {
+        let cases = [
+            (
+                "permanent error (535): 5.7.8 Error: authentication failed",
+                "auth",
+            ),
+            (
+                "permanent error (550): 5.1.1 <nobody@example.com>: Recipient address rejected: User unknown",
+                "recipient_rejected",
+            ),
+            (
+                "transient error (452): 4.2.2 Mailbox quota exceeded, try again later",
+                "throttled",
+            ),
+            ("Connection error: connection timed out", "transport"),
+            ("Invalid email address: not-an-address", "invalid_address"),
+            ("something nobody has seen before", "other"),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(
+                classify_send_failure(error),
+                expected,
+                "classifying {:?}",
+                error
+            );
+        }
+    }
+
+    /// Sender rejection wins over the other arms even when the message also
+    /// mentions a connection or a code that another arm looks for — the
+    /// ordering in `classify_send_failure` is load-bearing.
+    #[test]
+    fn sender_rejection_takes_priority_over_generic_matches() {
+        let e = "connection to relay: 553 Sender address rejected: not owned by user";
+        assert_eq!(classify_send_failure(e), "sender_rejected");
+    }
+
+    #[test]
+    fn classification_is_case_insensitive() {
+        assert_eq!(
+            classify_send_failure("SENDER ADDRESS REJECTED"),
+            "sender_rejected"
+        );
+    }
+
+    #[test]
+    fn redaction_replaces_addresses_with_their_hash() {
+        let redacted = redact_email_addresses(
+            "553 5.7.1 <info@saichon.com>: Sender address rejected: not owned by user",
+        );
+
+        assert!(
+            !redacted.contains("info@saichon.com"),
+            "raw address survived redaction: {}",
+            redacted
+        );
+        assert!(
+            redacted.contains(&format!("<email:{}>", hash_email("info@saichon.com"))),
+            "expected the stable hash token in: {}",
+            redacted
+        );
+        // The diagnostic wording — the part an operator actually reads — must
+        // survive intact.
+        assert!(redacted.contains("553 5.7.1"));
+        assert!(redacted.contains("Sender address rejected"));
+    }
+
+    #[test]
+    fn redaction_handles_multiple_addresses_and_leaves_other_text_alone() {
+        let redacted = redact_email_addresses("from alice@example.com to bob@example.org: 250 ok");
+
+        assert!(!redacted.contains("alice@example.com"));
+        assert!(!redacted.contains("bob@example.org"));
+        assert_ne!(
+            hash_email("alice@example.com"),
+            hash_email("bob@example.org"),
+            "distinct addresses must stay distinguishable in logs"
+        );
+        assert!(redacted.contains("250 ok"));
+        assert!(redacted.starts_with("from "));
+    }
+
+    #[test]
+    fn redaction_is_a_no_op_for_text_without_addresses() {
+        let text = "connection timed out after 30s";
+        assert_eq!(redact_email_addresses(text), text);
+    }
+
+    /// The relay controls this text, so the failure log runs it through
+    /// `sanitize_log_value` after redaction — a hostile relay must not be able
+    /// to forge log lines. This pins the exact composition used in
+    /// `send_email`.
+    #[test]
+    fn the_failure_log_pipeline_defeats_log_injection() {
+        let hostile = "550 rejected\nERROR forged line from mailbox@evil.example";
+        let logged = sanitize_log_value(&redact_email_addresses(hostile), None);
+
+        assert!(!logged.contains('\n'), "newline survived: {:?}", logged);
+        assert!(!logged.contains("mailbox@evil.example"));
+        assert!(logged.contains("550 rejected"));
     }
 }

--- a/backend-rust/src/services/email.rs
+++ b/backend-rust/src/services/email.rs
@@ -509,11 +509,17 @@ impl EmailService for EmailServiceImpl {
         // once in `SmtpConfig::from_address`. A malformed value is also
         // reported at startup (see `log_startup_info`) so it doesn't surface
         // for the first time here, mid-request.
-        let from_mailbox = Self::parse_mailbox(&config.from).inspect_err(|_| {
+        //
+        // `map_err(|e| { …; e })` rather than `inspect_err`: the crate's MSRV
+        // is 1.75 (Cargo.toml `rust-version`) and `Result::inspect_err` is
+        // 1.76, which `clippy::incompatible_msrv` rejects.
+        let from_mailbox = Self::parse_mailbox(&config.from).map_err(|e| {
             counter!(EMAIL_SEND_FAILURES_TOTAL, "kind" => "invalid_address").increment(1);
+            e
         })?;
-        let to_mailbox = Self::parse_mailbox(to).inspect_err(|_| {
+        let to_mailbox = Self::parse_mailbox(to).map_err(|e| {
             counter!(EMAIL_SEND_FAILURES_TOTAL, "kind" => "invalid_address").increment(1);
+            e
         })?;
 
         // Create plain text version by stripping HTML tags (simple approach)

--- a/docs/email-canary-runbook.md
+++ b/docs/email-canary-runbook.md
@@ -68,12 +68,19 @@ outage.
 - Each run retries the send **3 times** (0s / 20s / 60s backoff). Only a run
   where *every* attempt fails counts as a confirmed failure — one refused
   connection at 03:23 is a blip, not an incident.
-- Failure → create the issue `Email canary: outbound mail is failing`, or
+- Failure → create the issue `Email canary - outbound mail is failing`, or
   comment on it if it is already open.
-- Success while that issue is open → comment "delivering again" and **close
-  it**. Failure alerts are always paired with a recovery notification.
-- "The canary could not run at all" (empty SMTP secrets) files the *same*
-  issue: unverified is not the same as working.
+- "The canary could not run at all" (empty SMTP secrets) files a second issue,
+  `Email canary - probe could not run, SMTP secrets empty`, because the first
+  move differs: fix the workflow or the secrets, not the mailbox. Unverified is
+  still an alert — it is not the same as working.
+- Success → comment "delivering again" on **either** issue if open and **close
+  it**. A probe the relay accepted disproves both alarms at once. Failure
+  alerts are always paired with a recovery notification.
+- Neither title contains a colon, and both are searched as quoted phrases:
+  `gh issue list --search` speaks GitHub search syntax, where `word:` reads as
+  a qualifier. Get that wrong and the lookup silently returns nothing, filing a
+  duplicate issue on every probe instead of commenting on the open one.
 
 ---
 

--- a/docs/email-canary-runbook.md
+++ b/docs/email-canary-runbook.md
@@ -1,0 +1,195 @@
+# Email Canary Runbook
+
+The canary is `.github/workflows/email-canary.yml`. Every 6 hours it sends a
+real message through the production SMTP relay and files a GitHub issue when
+the relay refuses it.
+
+It exists because of the #352 outage: the PrivateEmail subscription lapsed,
+SMTP `AUTH` kept succeeding, and every message was then refused at `MAIL FROM`
+with
+
+```
+553 5.7.1 <info@saichon.com>: Sender address rejected: not owned by user info@saichon.com
+```
+
+Password resets, address verification and booking mail failed silently for
+days while `/api/health` stayed green throughout.
+
+---
+
+## What it proves
+
+- The relay is reachable, TLS negotiates, and the credentials still
+  authenticate.
+- **The relay accepts a message from our configured sender.** This is the part
+  no health check can do. `MAIL FROM` / `RCPT TO` / `DATA` all return 250.
+- Therefore: at the moment of the probe, mail that the backend hands to this
+  relay leaves the building.
+
+## What it does NOT prove
+
+- **Not that anything arrived.** There is no IMAP round trip (tier 3 in #364),
+  so a message accepted with 250 and then silently dropped, greylisted,
+  spam-foldered, or DMARC-quarantined at the *recipient* looks green here.
+- **Not that the app sends correctly.** It exercises the same *relay* and the
+  same `SMTP_FROM`/`SMTP_USER` resolution as the backend, but not the
+  backend's own code path — a bug in `services/email.rs` or a bad template
+  will not show up. The `loyalty_email_*` counters on `/metrics` cover that
+  half (see below).
+- **Not continuous coverage.** Up to 6 hours can pass between probes; a short
+  outage inside that window leaves no trace here.
+- **Not inbound mail.** Nothing checks that the mailbox can receive.
+
+## What it must never do
+
+Gate a deploy. It never touches `/api/health`, no workflow lists it in
+`workflow_run`, and it has its own concurrency group. A mail problem is an ops
+alert, never a shipping blocker (#364, design question 5).
+
+---
+
+## Why alerts are GitHub issues and not email
+
+#364's design question 1 suggested reusing
+`scripts/evergreen/loyalty-backup-notify-email.sh` as the canary's transport.
+**That would have been wrong**: that script sends through the *same*
+`info@saichon.com` PrivateEmail mailbox the canary is watching. In the exact
+incident this monitor exists for, the alert would have been refused with the
+same 553 as everything else — a self-suppressing alarm.
+
+So the probe borrows that script's *technique* (curl over SMTPS, no MTA) but
+the alert channel is a GitHub issue, via the create-or-comment idiom already
+used by `deploy.yml`'s `notify-on-failure` and `cargo-audit.yml`. GitHub is
+already the channel for "production deploy failed", and it survives a mail
+outage.
+
+## Alert hygiene
+
+- Each run retries the send **3 times** (0s / 20s / 60s backoff). Only a run
+  where *every* attempt fails counts as a confirmed failure — one refused
+  connection at 03:23 is a blip, not an incident.
+- Failure → create the issue `Email canary: outbound mail is failing`, or
+  comment on it if it is already open.
+- Success while that issue is open → comment "delivering again" and **close
+  it**. Failure alerts are always paired with a recovery notification.
+- "The canary could not run at all" (empty SMTP secrets) files the *same*
+  issue: unverified is not the same as working.
+
+---
+
+## When it fires
+
+Open the run linked in the issue and read the captured relay response. The
+response code is the diagnosis:
+
+| Response | Meaning | Action |
+| --- | --- | --- |
+| `553 ... Sender address rejected` / `not owned by user` | The relay will not let us send as our own `SMTP_FROM`. This is #352: lapsed subscription, expired card, revoked alias, or a `SMTP_FROM` the mailbox does not own. | Check the PrivateEmail account's billing and the alias list. Compare `SMTP_FROM` against the mailbox's owned addresses. |
+| `535` / `authentication failed` | Credentials rejected. | Rotate `SMTP_PASS` in Settings → Environments → production, then redeploy so the backend picks it up. |
+| `550` / `User unknown` | The recipient no longer exists (only reachable if `CANARY_EMAIL_TO` is set to a stale address). | Fix or unset `CANARY_EMAIL_TO`. |
+| `4xx`, "try again later" | Throttling. Three failures in a row is still worth a look. | Check send volume; consider whether the relay is rate-limiting. |
+| `curl: (7)` / timeout / TLS error | Network or relay down. | Check the provider's status page; re-run the workflow. |
+| "one or more SMTP secrets were empty" | The canary never probed. | See "the environment-scope trap" below. |
+
+While any of these is unresolved, assume **password resets, email verification
+and booking mail are all failing**, and that `/api/health` will keep saying
+email is `configured` — configuration is all that endpoint can see.
+
+Once fixed, re-run the workflow by hand (below). A green run comments on the
+issue and closes it automatically.
+
+## Testing it by hand
+
+Actions → **Email Canary** → *Run workflow*:
+
+- **Normal probe** — leave both inputs unchecked. Sends a real canary message
+  and, if an alert issue is open, closes it.
+- **Exercise the alert path** — check `simulate_failure`. The send is retried
+  with a deliberately unowned envelope sender
+  (`simulated-failure@canary.invalid`, a reserved TLD per RFC 2606), so the
+  relay refuses it exactly the way it refused everything in #352 — a real
+  rejection, not a faked exit code, and no message can escape to a real
+  mailbox. The alert issue is then filed for real, so **close it yourself**
+  afterwards or let the next scheduled run close it.
+- **Probe without side effects** — check `skip_alert`. Sends (or fails) and
+  reports in the job summary, but never creates, comments on, or closes an
+  issue. Useful when verifying a relay change.
+
+`workflow_dispatch` only appears once the workflow is on `main`.
+
+---
+
+## Configuration
+
+| Name | Where | Notes |
+| --- | --- | --- |
+| `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` | Secrets on the **`production` environment** | The same values `deploy.yml` already pipes through a runner on every production deploy — using them here is not a new exposure class. |
+| `CANARY_EMAIL_TO` | *Optional* secret or variable | Where the canary mail goes. **Unset today**, so the canary sends the mailbox a message to itself. That default needs no second mailbox to exist and still has to pass `MAIL FROM`, which is the stage where #352 failed. |
+
+### The environment-scope trap
+
+`SMTP_*` are **environment-scoped** secrets. A job that does not declare
+`environment: production` reads every one of them as an **empty string, with
+no error** — which is exactly how the old nightly backup workflow reported
+green while backing nothing up. The canary defends against this twice:
+
+1. the `probe` job declares `environment: production`;
+2. its first step fails loudly, naming this trap, if any of `SMTP_HOST` /
+   `SMTP_USER` / `SMTP_PASS` is empty — and files the alert issue, because a
+   canary that silently probes nothing is worse than no canary.
+
+If you ever copy this job, copy both.
+
+### Handling of credentials and PII
+
+- The password is **never on the process argv**. The host script
+  (`loyalty-backup-notify-email.sh`) passes it via `curl --user`, which is
+  visible in `/proc` to any local user; here curl reads it from a mode-0600
+  `--config` file in a private temp dir that is deleted on exit.
+- Only *server-side* lines of the SMTP dialog are ever printed or quoted into
+  an issue. The client side of a verbose trace contains the `AUTH` line, whose
+  base64 payload **is** the password, and GitHub's secret masking does not
+  cover the base64 form.
+- Email local parts are masked (`***@saichon.com`) before anything reaches a
+  log or an issue body — this repository is public.
+- A side effect of `environment: production`: canary runs show up in the
+  production environment's activity log alongside real deploys. Cosmetic, but
+  do not mistake one for a deploy.
+
+---
+
+## The other half: backend send-failure metrics
+
+The canary probes every 6 hours; the backend knows *immediately* when a real
+send fails. `services/email.rs` exports on `/metrics` (internal to the Docker
+network — nginx does not proxy it):
+
+| Metric | Meaning |
+| --- | --- |
+| `loyalty_email_sends_total` | Messages the relay accepted. |
+| `loyalty_email_send_failures_total{kind="..."}` | Failed sends. `kind` is one of `sender_rejected` (the #352 signature), `auth`, `recipient_rejected`, `throttled`, `transport`, `invalid_address`, `message_build`, `other`. |
+| `loyalty_email_sends_skipped_total{reason="..."}` | Sends that never happened because SMTP is unconfigured. **Not** counted as successes — `send_email` returns `Ok(())` on that path, and counting it would claim mail is flowing on a stack that cannot send at all. A stack with a non-zero rate here and zero on `loyalty_email_sends_total` is mute, not healthy. |
+
+A hard failure also logs one greppable line:
+
+```
+EMAIL_SEND_FAILED: the SMTP relay refused the message
+```
+
+with `kind`, a hashed recipient (`crate::utils::hash_email`), and the relay's
+own text scrubbed of email addresses. On the box:
+
+```bash
+docker logs loyalty_backend_production 2>&1 | grep EMAIL_SEND_FAILED
+```
+
+---
+
+## References
+
+- Issue #364 — email canary (this document)
+- Issue #352 — the outage, and part 3 (surface send failures)
+- PR #363 — `SMTP_FROM` plumbing and honest `services.email` in `/api/health`
+- `docs/secrets-runbook.md` — secret inventory and rotation
+- `scripts/evergreen/loyalty-backup-notify-email.sh` — the curl-SMTPS
+  technique this borrows (and the alert channel it deliberately does not)

--- a/docs/secrets-runbook.md
+++ b/docs/secrets-runbook.md
@@ -45,6 +45,23 @@ up **nothing** while reporting success.
 See [`restore-runbook.md`](./restore-runbook.md) for setup, retention and the
 restore drill.
 
+### Email canary secrets — environment-scoped, nothing new to add
+
+`.github/workflows/email-canary.yml` reads `SMTP_HOST` / `SMTP_PORT` /
+`SMTP_USER` / `SMTP_PASS` / `SMTP_FROM` from the **`production` environment**
+(Settings → Environments → production), the same values `deploy.yml` already
+pipes through a runner on every production deploy. No repository-level secret
+is required.
+
+`CANARY_EMAIL_TO` is an *optional* secret or variable that redirects the canary
+mail; unset, the canary sends the mailbox a message to itself.
+
+Because those secrets are environment-scoped, a job that omits
+`environment: production` reads them as **empty strings with no error** — the
+same trap that made the old backup workflow report green while backing up
+nothing. The canary's first step fails loudly on empty values for exactly this
+reason. See [`email-canary-runbook.md`](./email-canary-runbook.md).
+
 ### Inspecting and updating secrets
 
 ```bash


### PR DESCRIPTION
Closes #364.

`/api/health` can only ever prove email is **configured**. In #352 the PrivateEmail subscription lapsed, SMTP `AUTH` kept succeeding, and every message was refused at `MAIL FROM` with

```
553 5.7.1 <info@saichon.com>: Sender address rejected: not owned by user info@saichon.com
```

Health stayed green for days while password resets, address verification and booking mail failed silently. This adds the thing that would have caught it.

## 1. `.github/workflows/email-canary.yml`

A real `MAIL FROM` / `RCPT TO` / `DATA` send every 6 hours — tier 2 in #364, the exact stage where the 553 appears — via curl over SMTPS, modelled on `scripts/evergreen/loyalty-backup-notify-email.sh`.

- **Cadence**: `23 */6 * * *`. The failure mode is persistent (billing, DNS, a revoked sender), not a flicker, so the only question is how long we may stay blind; a quarter-day ceiling is proportionate. 4 messages/day stays far below any relay rate limit. `:23` because on-the-hour cron sits in GitHub's longest queue.
- **`environment: production`**, because `SMTP_*` are environment-scoped secrets. A job that omits it reads every one of them as an **empty string with no error** — the exact bug that made the old nightly backup report green while backing up nothing. The **first step** fails loudly, naming that trap by name, if `SMTP_HOST`/`SMTP_USER`/`SMTP_PASS` is empty, and it files the alert issue too: a canary that silently probes nothing is worse than no canary.
- **Alert hygiene**: 3 attempts (0s/20s/60s backoff); only a run where *every* attempt fails is a confirmed failure. Two distinct alarms — `Email canary - outbound mail is failing` and `Email canary - probe could not run, SMTP secrets empty` (different first move: fix the mailbox vs fix the workflow/secrets) — and a green probe disproves both, so the recovery step comments "delivering again" and **closes** whichever is open, per the repo's pair-failures-with-recoveries convention.
- **Issue lookup**: neither title contains a colon and both are searched as quoted phrases. `gh issue list --search` speaks GitHub search syntax, where a `word:` token reads as a qualifier — get it wrong and the lookup silently returns nothing, filing a duplicate issue on every probe instead of commenting on the open one.
- **Never gates a deploy**: it does not touch `/api/health`, no workflow lists it in `workflow_run` and it lists none, and it has its own concurrency group. Stated in a header comment.
- **Permissions**: `contents: read` at workflow scope, `issues: write` on the one job that needs it.
- **Manual controls**: `workflow_dispatch` with `simulate_failure` (sends with a deliberately unowned envelope sender, `simulated-failure@canary.invalid` — RFC 2606 reserved, so the relay refuses it the same way it refused everything in #352; a *real* rejection, not a faked exit code) and `skip_alert` (probe with no issue side effects).

### Correcting the record on #364's design question 1

The issue recommends sharing the backup email transport, since `loyalty-backup-notify-email.sh` already works and keeps credentials off runners. **That is the wrong choice here, and this PR deliberately does not do it.** That script sends through the *same* `info@saichon.com` PrivateEmail mailbox the canary exists to watch. In the incident this monitor is built for, the alert itself would have been refused with the same 553 — a self-suppressing alarm, failing exactly when it is needed.

So: borrow the *technique* (curl SMTPS, no MTA on the host), reject the *channel*. Alerts are GitHub issues, using the create-or-comment idiom from `deploy.yml`'s `notify-on-failure` — already the channel for "Production deploy failed", and unaffected by a mail outage. On credentials-on-runners: `deploy.yml` already pipes `SMTP_HOST/PORT/USER/PASS/FROM` through a GitHub runner on every production deploy, so this is not a new exposure class.

### Two improvements over the host script

1. **The password is never on the process argv.** The host script passes it via `curl --user`, visible in `/proc` to any local user. Here curl reads it from a mode-0600 `--config` file in a private temp dir, deleted on exit; escaping is done with bash parameter expansion so the secret is never an argument to any process.
2. **Only server-side SMTP lines are ever emitted.** A verbose SMTP trace contains the client's `AUTH` line, whose base64 payload *is* the password — and GitHub's secret masking does not cover the base64 form. `> ` lines and the `334` challenge are dropped outright rather than filtered. Email local parts are masked (`***@saichon.com`) before anything reaches a log or an issue body, because this repository is public. The relay's own wording survives intact, since `553` vs `535` vs a timeout are three different incidents.

## 2. Backend: surface send failures (#352 part 3)

`backend-rust/src/services/email.rs`, using the global recorder `axum_prometheus` already installs — no new dependency, no new sqlx query:

| Metric | Meaning |
| --- | --- |
| `loyalty_email_sends_total` | Relay accepted the message |
| `loyalty_email_send_failures_total{kind}` | `sender_rejected` (the #352 signature), `auth`, `recipient_rejected`, `throttled`, `transport`, `invalid_address`, `message_build`, `other` |
| `loyalty_email_sends_skipped_total{reason}` | SMTP unconfigured |

**The silent-success hazard is handled explicitly:** `send_email` returns `Ok(())` when SMTP is unconfigured ("skipping email"). That path increments *skipped*, never *success* — counting it would claim mail is flowing on a stack that cannot send at all.

A hard failure now logs one greppable line, `EMAIL_SEND_FAILED: the SMTP relay refused the message`, with a hashed recipient (`crate::utils::hash_email`), the bounded `kind`, and the relay's text run through `redact_email_addresses` (addresses → stable hash tokens, so a `550 <user@x>` rejection cannot leak a user's address) and then `sanitize_log_value` (the relay is remote-controlled input going into a log line).

New pure logic is unit-tested: classification of the literal #352 wording, arm ordering, case-insensitivity, redaction (hash token, multiple addresses stay distinguishable, no-op without addresses), and that the composed failure-log pipeline defeats log injection.

## 3. Docs

- New `docs/email-canary-runbook.md`: what it proves, **what it cannot** (no IMAP round trip, so accepted-then-dropped/spam-foldered looks green; not the backend's own code path; up to 6h blind; nothing about inbound), a response table keyed by SMTP response code, how to test by hand, and the metrics half.
- `docs/secrets-runbook.md`: the (optional) `CANARY_EMAIL_TO` and the environment-scope trap.
- `CLAUDE.md` CI/CD: one line listing the workflow as non-gating.

## Recipient choice

`gh secret list` / `gh variable list` show no `CANARY_EMAIL_TO` at either repo or `production` scope, so the canary sends `SMTP_USER`'s mailbox **a message to itself**: no second mailbox has to exist, it exercises the same sender the app uses, and a self-addressed message still has to pass `MAIL FROM`, which is where #352 failed. Setting `CANARY_EMAIL_TO` (secret *or* variable) redirects it; the workflow prefers it when present.

## Separate finding, filed not fixed

Backup failure alerts have the *same* self-suppression defect, and no recovery path: #366

## Verification

- `cargo fmt --all -- --check` clean.
- `actionlint` (with shellcheck) clean on the new workflow; YAML parses.
- The probe script was extracted and **run locally** against (a) a closed port — 3 attempts, correct backoff, correct `result=failed`; (b) a fake SMTP server that accepts — `result=ok`, and the `AUTH` base64 line confirmed *absent* from the captured output; (c) the same server rejecting `MAIL FROM` with the literal #352 553 — captured as `< 553 5.7.1 <***@example.com>: Sender address rejected: not owned by user ***@example.com`, local parts masked, `curl: (55) MAIL failed: 553` retained.
- The issue-lookup search form was checked against the live API: the quoted phrase still resolves a known issue (#364, whose title contains a colon), and both new titles return empty cleanly rather than erroring.
- CI on this branch: Lint Backend (Rust), Test Backend Unit (Rust), Lint Frontend, Frontend Unit Tests, CodeQL (all three analyses) and Trivy `scan-filesystem` observed green. Backend build/clippy/tests are left to CI by design (disk-constrained laptop) — the first clippy run caught a real defect, `Result::inspect_err` being past the crate's 1.75 MSRV, fixed in the second commit.
- **Cannot be verified before merge**: the scheduled trigger, and `workflow_dispatch` (GitHub only offers it once the workflow is on the default branch). First real send happens after merge — either wait for the cron or dispatch it manually, ideally once with `skip_alert` to confirm a green probe.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU
