### PR TITLE
fix(ops): email canary alarm could never fire

### DIFF
--- a/.github/workflows/email-canary.yml
+++ b/.github/workflows/email-canary.yml
@@ -150,7 +150,15 @@ jobs:
           CANARY_EMAIL_TO: ${{ secrets.CANARY_EMAIL_TO || vars.CANARY_EMAIL_TO }}
           SIMULATE_FAILURE: ${{ github.event.inputs.simulate_failure || 'false' }}
         run: |
-          # NOT `set -e`: curl failing is an expected outcome we handle.
+          # errexit must be turned OFF explicitly: GitHub runs `run:` blocks as
+          # `bash -e {0}`, so merely omitting `-e` from this `set` line leaves
+          # errexit ON. A failing curl is the EXPECTED outcome here, and under
+          # errexit the step dies before it can write `result=failed` to
+          # $GITHUB_OUTPUT — which skips every alerting step below (their `if:`
+          # carries no status function, so it is implicitly ANDed with
+          # success()). That is an alarm that silently never fires; it was
+          # caught by dispatching this workflow with simulate_failure=true.
+          set +e
           set -uo pipefail
           umask 077
 


### PR DESCRIPTION
Found by testing the alarm rather than trusting it — dispatched #365's canary with `simulate_failure=true`, and it went red without filing anything.

## Root cause

The probe step writes `result=failed` to `$GITHUB_OUTPUT`, and the alerting steps below key off `steps.probe.outputs.result == 'failed'`. The step carried the comment *"NOT `set -e`: curl failing is an expected outcome we handle"* — but it only omitted `-e` from its own `set` line. GitHub invokes every `run:` block as `bash -e {0}`, so errexit was still on: the failing curl killed the step before it could write the output.

Two consequences compounded:

1. no `result` output was ever written, and
2. the alert steps were skipped anyway — an `if:` expression with no status function is implicitly ANDed with `success()`, and the probe step had failed.

So a genuine mail outage would have produced a red workflow run and **no issue, no notification** — precisely the silent-alarm failure mode #364 exists to prevent.

## Fix

`set +e` in the probe step, with a comment explaining why it is load-bearing (this is the second instance of this exact trap in the repo; the healthcheck assertion in #361 had it too).

## Verification

Before: run 30242407517 — probe `failure`, all four alert/recovery steps `skipped`, zero issues filed.
After merge I will re-dispatch with `simulate_failure=true` and confirm the issue is actually created, then dispatch a normal probe and confirm it comments and auto-closes.

A real probe against the live PrivateEmail relay already passes (run 30242362603: `Attempt 1: ACCEPTED by the relay`), so the send path itself is sound — only the alarm was broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU