### PR TITLE
fix(ci): close the email canary's silent-alarm holes and the SMTP_PORT split

### DIFF
--- a/.github/workflows/email-canary.yml
+++ b/.github/workflows/email-canary.yml
@@ -50,6 +50,10 @@ on:
         description: 'Force the send to fail (exercises the alert path end to end)'
         type: boolean
         default: false
+      simulate_crash:
+        description: 'Make the probe step die before it reports (exercises the catch-all alert path)'
+        type: boolean
+        default: false
       skip_alert:
         description: 'Probe only — never create, comment on, or close an issue'
         type: boolean
@@ -86,15 +90,21 @@ jobs:
       contents: read
       issues: write
     env:
-      # Two distinct alarms — "mail is refused" and "the canary never ran" call
-      # for different first moves — and the recovery step closes whichever is
-      # open. NOTE: no colons in these titles. `gh issue list --search` speaks
-      # GitHub search syntax, where `word:` reads as a qualifier; the searches
-      # below also wrap the title in quotes so it is matched as a phrase. Get
-      # this wrong and the search silently returns nothing, which files a fresh
-      # duplicate issue on every probe instead of commenting on the open one.
+      # THREE distinct alarms, because the first move differs for each: "mail is
+      # refused" (fix the mailbox), "the canary never ran" (fix the secrets), and
+      # "the canary itself broke" (read the run log — mail state is UNKNOWN). The
+      # recovery step below closes all three, so every alarm this workflow can
+      # raise has exactly one automatic closer.
+      #
+      # NOTE: no colons in these titles. The lookups below deliberately do NOT
+      # use `gh issue list --search` any more (see the dedupe comment on the
+      # first alert step), but the rule stands: `--search` speaks GitHub search
+      # syntax, where `word:` reads as a qualifier, so the day someone reaches
+      # for it again a colon would silently match nothing and file a fresh
+      # duplicate on every probe.
       ISSUE_TITLE_FAIL: 'Email canary - outbound mail is failing'
       ISSUE_TITLE_MISCONFIG: 'Email canary - probe could not run, SMTP secrets empty'
+      ISSUE_TITLE_BROKEN: 'Email canary - the canary itself is broken, mail state unknown'
     steps:
       # -----------------------------------------------------------------------
       # A canary that silently probes nothing is worse than no canary: it
@@ -129,8 +139,11 @@ jobs:
       #   2. the relay's own response text is captured, because "553 ... Sender
       #      address rejected" vs "535 auth failed" vs a timeout are three
       #      completely different incidents.
-      # This step NEVER fails the job — it reports through its `result` output
-      # so the alert steps below can run. The job is failed at the very end.
+      # This step never fails the job *on a refused send* — it reports through
+      # its `result` output so the alert steps below can run, and the job is
+      # failed at the very end. It can still die for reasons of its own (a
+      # missing tool, a nounset trip, the runner going away); that is exactly
+      # what the catch-all alert further down exists to catch.
       # -----------------------------------------------------------------------
       - name: Send the canary message
         id: probe
@@ -149,6 +162,7 @@ jobs:
           # or repo/environment variable) to route the copies elsewhere.
           CANARY_EMAIL_TO: ${{ secrets.CANARY_EMAIL_TO || vars.CANARY_EMAIL_TO }}
           SIMULATE_FAILURE: ${{ github.event.inputs.simulate_failure || 'false' }}
+          SIMULATE_CRASH: ${{ github.event.inputs.simulate_crash || 'false' }}
         run: |
           # errexit must be turned OFF explicitly: GitHub runs `run:` blocks as
           # `bash -e {0}`, so merely omitting `-e` from this `set` line leaves
@@ -161,6 +175,27 @@ jobs:
           set +e
           set -uo pipefail
           umask 077
+
+          # --- simulate_crash --------------------------------------------------
+          # A GENUINE abort, in the same spirit as simulate_failure (which
+          # provokes a real 553 with a real .invalid domain rather than faking an
+          # exit code). Dereferencing a variable that is never set trips `set -u`,
+          # and nounset kills a non-interactive shell outright — errexit being
+          # off does not save it. That is a real dead step, not a scripted one.
+          #
+          # It fires HERE, before a single line has been written to
+          # $GITHUB_OUTPUT, which reproduces the nastier of the two probe-death
+          # shapes: `result` is never recorded, so every `if:` keyed on it is
+          # false AND every `if:` without a status function is implicitly ANDed
+          # with success(). Nothing downstream fires; only the catch-all does.
+          #
+          # simulate_crash WINS over simulate_failure when both are set: the
+          # crash happens before the send is even assembled, so nothing is sent.
+          # shellcheck disable=SC2154  # deliberately unset — that is the point
+          if [ "${SIMULATE_CRASH}" = "true" ]; then
+            echo "::warning title=Simulated crash::simulate_crash=true — deliberately killing the probe step before it can report a result, to exercise the catch-all alert. No mail is sent. If simulate_failure was also set it is irrelevant, the crash comes first."
+            echo "${CANARY_THIS_VARIABLE_IS_NEVER_SET}"
+          fi
 
           WORKDIR="$(mktemp -d)"
           trap 'rm -rf "$WORKDIR"' EXIT
@@ -179,7 +214,20 @@ jobs:
           unset esc_pass
 
           # --- endpoint --------------------------------------------------------
-          PORT="${SMTP_PORT:-465}"
+          # SINGLE SOURCE OF TRUTH: `secrets.SMTP_PORT` on the production
+          # environment — the same secret deploy.yml ships to the box. The
+          # fallback is 587 because that is what every OTHER consumer falls back
+          # to: deploy.yml (`${SMTP_PORT:-587}`), all four docker-compose files,
+          # and the backend itself (`email.smtp.port` default in
+          # backend-rust/src/config/mod.rs). If that secret is ever deleted, the
+          # app lands on 587/STARTTLS while a canary defaulting to 465 would
+          # probe implicit TLS on an endpoint the app does not use — green
+          # against the wrong door. Diverging defaults are how a canary lies, so
+          # this one matches the app's and says so out loud when it has to guess.
+          if [ -z "${SMTP_PORT:-}" ]; then
+            echo "::warning title=SMTP_PORT is empty::The canary is falling back to 587/STARTTLS, the same fallback deploy.yml, docker-compose and the backend use. Set SMTP_PORT under Settings -> Environments -> production so the canary can never probe a different endpoint from the one the app uses."
+          fi
+          PORT="${SMTP_PORT:-587}"
           if [ "$PORT" = "465" ]; then
             URL="smtps://${SMTP_HOST}:${PORT}"   # implicit TLS
           else
@@ -336,10 +384,23 @@ jobs:
 
       # -----------------------------------------------------------------------
       # ALERT — GitHub issue, never email (see the header). Same create-or-comment
-      # idiom as deploy.yml's `notify-on-failure`: search for an OPEN issue with
+      # idiom as deploy.yml's `notify-on-failure`: look up an OPEN issue with
       # this exact title, comment if found, create if not.
+      #
+      # The lookup line is BYTE-IDENTICAL in all four places it appears (this
+      # step, the misconfig step, the catch-all step, and the recovery loop),
+      # and the create-or-comment block is byte-identical in the three steps
+      # that can file an issue — so a reviewer can diff them by eye and see at
+      # a glance that no alarm path drifted.
+      #
+      # NO `--label`. cargo-audit.yml and deploy.yml's notifier both say it:
+      # alerting must never depend on label configuration — an unlabelled issue
+      # beats an alert that failed because a label was renamed. Dropping it also
+      # removes a `set -u` hazard, since expanding an empty `LABEL_ARGS[@]` array
+      # aborts the script under nounset on bash < 4.4. Label after triage.
       # -----------------------------------------------------------------------
       - name: File or update the email-canary issue
+        id: alert_fail
         if: steps.probe.outputs.result == 'failed' && github.event.inputs.skip_alert != 'true'
         env:
           GH_TOKEN:  ${{ github.token }}
@@ -391,26 +452,34 @@ jobs:
           EOF
           )
 
-          # Quoted phrase: the title is matched literally instead of being
-          # tokenised (and a stray qualifier-looking word silently zeroing the
-          # result, which would file a duplicate on every probe).
-          EXISTING=$(gh issue list -R "$REPO" \
-            --search "\"$TITLE\" in:title is:open" \
-            --json number --jq '.[0].number // empty')
+          # DEDUPE — no `--search`. `gh issue list --search` queries GitHub's
+          # SEARCH INDEX, which lags writes by seconds to minutes, so two runs
+          # inside that window each see "no open issue" and each file one. Drop
+          # `--search` and gh reads the plain issues API instead, which is
+          # read-after-write consistent: an issue this workflow filed 10 seconds
+          # ago is already visible. The title match moves into `--jq` so it stays
+          # exact (`==`) rather than tokenised.
+          #
+          # Deliberately NOT paired with a post-create re-search: that re-reads
+          # the very index that was stale, so it detects nothing and only adds a
+          # second failure surface.
+          #
+          # Residual window: two creates landing within the same few
+          # milliseconds could still both pass the check. Unreachable in
+          # practice — `concurrency: email-canary` with `cancel-in-progress:
+          # false` queues runs of this workflow instead of overlapping them, so
+          # hitting it would take a second writer of the same title (another
+          # workflow, or a human) firing at the same instant. Accepted.
+          #
+          # (Titles still carry no colon — see the job `env:` block.)
+          EXISTING=$(TITLE="$TITLE" gh issue list -R "$REPO" --state open --limit 200 --json number,title --jq 'map(select(.title == env.TITLE)) | .[0].number // empty')
 
           if [ -n "${EXISTING:-}" ]; then
             gh issue comment "$EXISTING" -R "$REPO" --body "$BODY"
             echo "Commented on existing issue #$EXISTING"
           else
-            # Label only if it already exists — the repo's convention (see
-            # cargo-audit.yml) is that alerting must never depend on label
-            # config, so an unlabelled issue beats a failed alert.
-            LABEL_ARGS=()
-            if gh label list -R "$REPO" --json name --jq '.[].name' | grep -qx 'bug'; then
-              LABEL_ARGS=(--label bug)
-            fi
-            gh issue create -R "$REPO" --title "$TITLE" --body "$BODY" "${LABEL_ARGS[@]}"
-            echo "Filed a new email-canary issue"
+            gh issue create -R "$REPO" --title "$TITLE" --body "$BODY"
+            echo "Filed a new issue titled '$TITLE'"
           fi
 
       # -----------------------------------------------------------------------
@@ -420,6 +489,7 @@ jobs:
       # Actions tab. Unverified is not the same as working.
       # -----------------------------------------------------------------------
       - name: File or update the email-canary issue (canary could not run)
+        id: alert_misconfig
         if: failure() && steps.guard.outcome == 'failure' && github.event.inputs.skip_alert != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -449,22 +519,33 @@ jobs:
           EOF
           )
 
-          EXISTING=$(gh issue list -R "$REPO" \
-            --search "\"$TITLE\" in:title is:open" \
-            --json number --jq '.[0].number // empty')
+          # Byte-identical to the lookup in the delivery-failure step above; see
+          # the DEDUPE comment there for why `--search` is not used.
+          EXISTING=$(TITLE="$TITLE" gh issue list -R "$REPO" --state open --limit 200 --json number,title --jq 'map(select(.title == env.TITLE)) | .[0].number // empty')
 
           if [ -n "${EXISTING:-}" ]; then
             gh issue comment "$EXISTING" -R "$REPO" --body "$BODY"
+            echo "Commented on existing issue #$EXISTING"
           else
             gh issue create -R "$REPO" --title "$TITLE" --body "$BODY"
+            echo "Filed a new issue titled '$TITLE'"
           fi
 
       # -----------------------------------------------------------------------
       # RECOVERY — the repo's convention is that every failure alert is paired
       # with a recovery notification, so the signal stays trusted.
+      #
+      # `always() &&` is load-bearing. Without it this step carries no status
+      # function and is therefore implicitly ANDed with success(), so a probe
+      # that recorded `result=ok` and THEN died (or any later step failing)
+      # would leave a stale alarm open while mail was demonstrably fine — the
+      # relay accepted a real message, which is the whole proof. The `result ==
+      # 'ok'` test still does the gating; `always()` only stops GitHub from
+      # skipping the step on our behalf.
       # -----------------------------------------------------------------------
       - name: Comment and close the email-canary issue on recovery
-        if: steps.probe.outputs.result == 'ok' && github.event.inputs.skip_alert != 'true'
+        id: recovery
+        if: always() && steps.probe.outputs.result == 'ok' && github.event.inputs.skip_alert != 'true'
         env:
           GH_TOKEN:  ${{ github.token }}
           REPO:      ${{ github.repository }}
@@ -488,17 +569,19 @@ jobs:
           EOF
           )
 
-          # Both alarms clear on a good probe: a send that the relay accepted
-          # disproves "mail is failing" and "the canary cannot see its secrets"
-          # at the same time.
+          # ALL THREE alarms clear on a good probe: a send the relay accepted
+          # disproves "mail is failing", "the canary cannot see its secrets" and
+          # "the canary is broken so mail state is unknown" simultaneously — the
+          # canary evidently ran, saw its secrets, and got a 250. Every title
+          # this workflow can raise is listed here, so no alarm can be left
+          # without an automatic closer.
           #
-          # Note: `gh issue list --search` reads GitHub's search index, which
-          # lags writes by a few seconds. Worst case a recovery lands one run
-          # late — acceptable, and the same idiom deploy.yml already uses.
-          for TITLE in "$ISSUE_TITLE_FAIL" "$ISSUE_TITLE_MISCONFIG"; do
-            EXISTING=$(gh issue list -R "$REPO" \
-              --search "\"$TITLE\" in:title is:open" \
-              --json number --jq '.[0].number // empty')
+          # The lookup is byte-identical to the alert steps' (no `--search`; see
+          # the DEDUPE comment on the first one). That also fixes a real bug in
+          # the old version: an index that lagged left recovery closing nothing
+          # and the alarm open past the fix.
+          for TITLE in "$ISSUE_TITLE_FAIL" "$ISSUE_TITLE_MISCONFIG" "$ISSUE_TITLE_BROKEN"; do
+            EXISTING=$(TITLE="$TITLE" gh issue list -R "$REPO" --state open --limit 200 --json number,title --jq 'map(select(.title == env.TITLE)) | .[0].number // empty')
 
             if [ -z "${EXISTING:-}" ]; then
               echo "No open issue titled '$TITLE' — nothing to close."
@@ -509,6 +592,123 @@ jobs:
             gh issue close "$EXISTING" -R "$REPO"
             echo "Closed recovered issue #$EXISTING"
           done
+
+      # -----------------------------------------------------------------------
+      # CATCH-ALL — the canary itself broke.
+      #
+      # Before this step, a probe that died for any reason OTHER than the
+      # secrets guard produced a red run and NOT ONE ALERT. Three holes:
+      #
+      #   1. the probe dies EARLY (missing tool, nounset trip, curl gone,
+      #      mktemp failing): `result` is never written, so the delivery-failure
+      #      step's `if:` is false, and the misconfig step's is false too
+      #      because the guard passed. Nothing fires.
+      #   2. the probe writes `result=failed` to $GITHUB_OUTPUT and THEN dies
+      #      (the trailing summary block, a trap, an OOM). The output is there
+      #      and correct, but the alert step's `if:` carries no status function
+      #      and is therefore implicitly ANDed with success() — so it is
+      #      SKIPPED, on the one run where it mattered most. This is why the
+      #      gate below must NOT key on `steps.probe.outputs.result`.
+      #   3. an alert step itself fails (gh/network), or the run is cancelled
+      #      mid-flight. Again: red run, silence.
+      #
+      # The gate keys on step OUTCOMES only, and stands down when either real
+      # alerting step already succeeded — that alarm is filed, this one would
+      # just be noise on top of it.
+      #
+      # PLACEMENT IS LOAD-BEARING: this must sit AFTER the recovery step and
+      # BEFORE the "Fail the run on a confirmed delivery failure" step below.
+      # That last step deliberately calls `exit 1` on every confirmed mail
+      # outage, which makes `failure()` true for the rest of the job — so a
+      # catch-all placed after it would fire on the ordinary outage path and
+      # file "the canary is broken" alongside every genuine "mail is failing".
+      # Sitting above it, `failure()` here can only mean something genuinely
+      # unmodelled died.
+      # -----------------------------------------------------------------------
+      - name: File or update the email-canary issue (canary itself broke)
+        if: >-
+          (failure() || cancelled())
+          && steps.alert_fail.outcome != 'success'
+          && steps.alert_misconfig.outcome != 'success'
+          && github.event.inputs.skip_alert != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO:     ${{ github.repository }}
+          RUN_URL:  ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Step outcomes, so the issue can show WHERE it broke without anyone
+          # opening the run first. `outcome` is the step's own result before
+          # continue-on-error; a step that never ran reads as `skipped`.
+          GUARD_OUTCOME:           ${{ steps.guard.outcome }}
+          PROBE_OUTCOME:           ${{ steps.probe.outcome }}
+          PROBE_RESULT:            ${{ steps.probe.outputs.result }}
+          ALERT_FAIL_OUTCOME:      ${{ steps.alert_fail.outcome }}
+          ALERT_MISCONFIG_OUTCOME: ${{ steps.alert_misconfig.outcome }}
+          RECOVERY_OUTCOME:        ${{ steps.recovery.outcome }}
+          # `job.status`, not `cancelled()`: status functions are only legal in
+          # an `if:`. This reads `cancelled` when a human (or GitHub) stopped
+          # the run, which is the case the last line of this issue tells the
+          # reader to close it for.
+          JOB_STATUS:              ${{ job.status }}
+        run: |
+          set -euo pipefail
+          TITLE="$ISSUE_TITLE_BROKEN"
+
+          # Deliberately NOT the misconfig title: that issue's body diagnoses
+          # "SMTP secrets are empty" and would send someone at 03:00 to inspect
+          # secrets that are fine. Different first move, different alarm.
+
+          PROBE_RESULT_SHOWN="${PROBE_RESULT:-}"
+          PROBE_NOTE=""
+          if [ "$PROBE_RESULT_SHOWN" = "failed" ]; then
+            PROBE_NOTE="**The probe did record \`result=failed\` before it died, so treat this as a probable mail outage too.** Both things are true at once: the send was refused *and* the canary broke afterwards. Read the run log for the relay's response code and work it like \`${ISSUE_TITLE_FAIL}\`, then fix whatever killed the step."
+          fi
+          [ -n "$PROBE_RESULT_SHOWN" ] || PROBE_RESULT_SHOWN='(never written — the probe died before reporting)'
+
+          BODY=$(cat <<EOF
+          **The email canary did not complete, so the state of outbound mail is
+          UNKNOWN.** Not known broken, not known working — unverified. Nothing
+          here says the relay is down; nothing here says it is up.
+
+          - Run: $RUN_URL
+
+          **Start with the run log, NOT the relay and NOT the secrets.** What
+          failed is the canary's own machinery: a step died in a way the
+          workflow does not model, or the run was cancelled. Chasing the mail
+          path first burns an on-call hour on a system that may be perfectly
+          healthy.
+
+          | Step | Outcome |
+          | --- | --- |
+          | Guard — SMTP secrets visible | \`${GUARD_OUTCOME}\` |
+          | Probe — real send | \`${PROBE_OUTCOME}\` |
+          | Probe recorded \`result\` | \`${PROBE_RESULT_SHOWN}\` |
+          | Alert — outbound mail is failing | \`${ALERT_FAIL_OUTCOME}\` |
+          | Alert — SMTP secrets empty | \`${ALERT_MISCONFIG_OUTCOME}\` |
+          | Recovery — close stale alarms | \`${RECOVERY_OUTCOME}\` |
+          | Job status | \`${JOB_STATUS}\` |
+
+          ${PROBE_NOTE}
+
+          **If you cancelled this run by hand, close this issue.** A cancelled
+          canary is an expected outcome, not an incident.
+
+          This issue is filed by \`.github/workflows/email-canary.yml\`. The
+          canary does NOT gate deploys — shipping is unaffected. Runbook:
+          \`docs/email-canary-runbook.md\`.
+          EOF
+          )
+
+          # Byte-identical to the lookup in the delivery-failure step above; see
+          # the DEDUPE comment there for why `--search` is not used.
+          EXISTING=$(TITLE="$TITLE" gh issue list -R "$REPO" --state open --limit 200 --json number,title --jq 'map(select(.title == env.TITLE)) | .[0].number // empty')
+
+          if [ -n "${EXISTING:-}" ]; then
+            gh issue comment "$EXISTING" -R "$REPO" --body "$BODY"
+            echo "Commented on existing issue #$EXISTING"
+          else
+            gh issue create -R "$REPO" --title "$TITLE" --body "$BODY"
+            echo "Filed a new issue titled '$TITLE'"
+          fi
 
       # -----------------------------------------------------------------------
       # Fail LAST, so the alert steps above always got their chance to run. A

--- a/backend-rust/.env.example
+++ b/backend-rust/.env.example
@@ -28,7 +28,10 @@ LINE_REDIRECT_URI=http://localhost:4000/api/auth/line/callback
 # unset (compose passes ${SMTP_HOST:-}), and /api/health then reports
 # "email": "not_configured".
 SMTP_HOST=smtp.your-email-provider.com
-SMTP_PORT=465
+# 587 = STARTTLS, the default everything else in this repo falls back to
+# (config/mod.rs, docker-compose.*.yml, deploy.yml, the email canary). Use 465
+# only if your provider requires implicit TLS.
+SMTP_PORT=587
 SMTP_USER=noreply@yourdomain.com
 SMTP_PASS=your_password
 # From address on outgoing mail. Falls back to SMTP_USER when unset or blank.

--- a/backend-rust/README.md
+++ b/backend-rust/README.md
@@ -405,7 +405,7 @@ backend-rust/
 | Variable | Description |
 |----------|-------------|
 | `SMTP_HOST` | SMTP server hostname |
-| `SMTP_PORT` | SMTP server port (default: 465) |
+| `SMTP_PORT` | SMTP server port (default: 587 — STARTTLS; matches `config/mod.rs`, `docker-compose.*.yml`, `deploy.yml` and the email canary) |
 | `SMTP_USER` | SMTP username |
 | `SMTP_PASS` | SMTP password |
 | `SMTP_FROM` | From address on outgoing mail. Falls back to `SMTP_USER` when unset or blank. Bare (`x@y.com`) or display-name (`Name <x@y.com>`) form; a malformed value is logged as an ERROR at startup. Must be an address the mailbox genuinely **owns** — an alias is refused with `553 5.7.1 …: Sender address rejected` *after* a successful AUTH (issue #352) |

--- a/docs/email-canary-runbook.md
+++ b/docs/email-canary-runbook.md
@@ -68,19 +68,79 @@ outage.
 - Each run retries the send **3 times** (0s / 20s / 60s backoff). Only a run
   where *every* attempt fails counts as a confirmed failure — one refused
   connection at 03:23 is a blip, not an incident.
-- Failure → create the issue `Email canary - outbound mail is failing`, or
-  comment on it if it is already open.
-- "The canary could not run at all" (empty SMTP secrets) files a second issue,
-  `Email canary - probe could not run, SMTP secrets empty`, because the first
-  move differs: fix the workflow or the secrets, not the mailbox. Unverified is
-  still an alert — it is not the same as working.
-- Success → comment "delivering again" on **either** issue if open and **close
-  it**. A probe the relay accepted disproves both alarms at once. Failure
-  alerts are always paired with a recovery notification.
-- Neither title contains a colon, and both are searched as quoted phrases:
-  `gh issue list --search` speaks GitHub search syntax, where `word:` reads as
-  a qualifier. Get that wrong and the lookup silently returns nothing, filing a
-  duplicate issue on every probe instead of commenting on the open one.
+- Success → comment "delivering again" on **any** of the three alarms below
+  that is open, and **close it**. A probe the relay accepted disproves all
+  three at once: the canary evidently ran, saw its secrets, and got a `250`.
+  Failure alerts are always paired with a recovery notification.
+
+### The three alarms
+
+Each has a different *first move*, which is why they are three issues and not
+one. Every one of them is closed automatically by the same recovery step, so no
+alarm can be left without a closer. That step's `if:` is prefixed with
+`always() &&` deliberately: without it the step would be implicitly ANDed with
+`success()`, so a probe that recorded `result=ok` and then died would leave a
+stale alarm open even though the relay had just accepted a real message.
+
+| Title (no colons — see below) | Means | First move |
+| --- | --- | --- |
+| `Email canary - outbound mail is failing` | The probe ran and the relay refused every attempt. Mail is **known broken**. | Read the relay response quoted in the issue; work the table below. |
+| `Email canary - probe could not run, SMTP secrets empty` | The guard step found an empty `SMTP_HOST`/`USER`/`PASS`. Nothing was probed. | Fix the secrets/workflow — see "the environment-scope trap". |
+| `Email canary - the canary itself is broken, mail state unknown` | The run died somewhere the workflow does not model, or was cancelled. Mail is **neither known broken nor known working**. | **Read the run log first** — not the relay, not the secrets. |
+
+The third one is the catch-all. Before it existed, a probe step that died for
+any reason other than the secrets guard produced a red run and *no alert at
+all* — three separate holes:
+
+1. the probe dies early (missing tool, a `set -u` trip, `mktemp` failing):
+   `result` is never written, so the delivery-failure alert's `if:` is false,
+   and the misconfig alert's is false too because the guard passed;
+2. the probe writes `result=failed` **and then dies**: the output is there and
+   correct, but a step `if:` containing no status function is implicitly ANDed
+   with `success()`, so the alert is skipped on the run where it mattered most.
+   This is why the catch-all's own gate keys on step *outcomes*, never on
+   `steps.probe.outputs.result`;
+3. an alert step itself fails (a `gh`/network hiccup), or the run is cancelled.
+
+Its issue body leads with "the state of outbound mail is UNKNOWN", carries a
+table of every step's outcome, and deliberately contains **no relay
+diagnosis** — sending someone to inspect secrets or a mailbox that are both
+fine is how an alert loses its audience. If the probe *had* recorded
+`result=failed` before dying, the body says so and tells you to treat it as a
+probable mail outage as well. If **you** cancelled the run, close the issue.
+
+The catch-all sits *above* the final "fail the run" step on purpose: that step
+calls `exit 1` on every confirmed delivery failure, which makes `failure()`
+true for everything after it, so a catch-all placed below would file "the
+canary is broken" alongside every genuine mail outage.
+
+### Deduplication
+
+Alert lookups use the issues API, **not** the search index:
+
+```bash
+EXISTING=$(TITLE="$TITLE" gh issue list -R "$REPO" --state open --limit 200 \
+  --json number,title --jq 'map(select(.title == env.TITLE)) | .[0].number // empty')
+```
+
+`gh issue list --search` reads GitHub's *search index*, which lags writes by
+seconds to minutes, so two runs inside that window each conclude "no open
+issue" and each file one. Without `--search`, `gh` reads the issues API, which
+is read-after-write consistent. A post-create re-search would not help — it
+re-reads the same stale index. The residual race is two creates within the same
+few milliseconds; `concurrency: email-canary` (with `cancel-in-progress:
+false`) already serialises this workflow, so that is accepted.
+
+The four lookups in the workflow are byte-identical, so a reviewer can diff
+them by eye. None of the create paths passes `--label`: as in `cargo-audit.yml`
+and `deploy.yml`'s notifier, alerting must never depend on label configuration
+— an unlabelled issue beats an alert that failed because a label was renamed.
+Label after triage.
+
+**No title contains a colon.** The lookups no longer use `--search`, but the
+rule stands for the day someone reaches for it again: `--search` speaks GitHub
+search syntax, where `word:` reads as a qualifier, so a colon silently matches
+nothing and files a duplicate on every probe.
 
 ---
 
@@ -97,6 +157,7 @@ response code is the diagnosis:
 | `4xx`, "try again later" | Throttling. Three failures in a row is still worth a look. | Check send volume; consider whether the relay is rate-limiting. |
 | `curl: (7)` / timeout / TLS error | Network or relay down. | Check the provider's status page; re-run the workflow. |
 | "one or more SMTP secrets were empty" | The canary never probed. | See "the environment-scope trap" below. |
+| "the canary itself is broken, mail state unknown" | No relay response exists — the run died or was cancelled. | Read the run log; the issue's step-outcome table says which step. Mail may be perfectly fine. |
 
 While any of these is unresolved, assume **password resets, email verification
 and booking mail are all failing**, and that `/api/health` will keep saying
@@ -109,20 +170,48 @@ issue and closes it automatically.
 
 Actions → **Email Canary** → *Run workflow*:
 
-- **Normal probe** — leave both inputs unchecked. Sends a real canary message
+- **Normal probe** — leave every input unchecked. Sends a real canary message
   and, if an alert issue is open, closes it.
-- **Exercise the alert path** — check `simulate_failure`. The send is retried
-  with a deliberately unowned envelope sender
+- **Exercise the delivery-failure alert** — check `simulate_failure`. The send
+  is retried with a deliberately unowned envelope sender
   (`simulated-failure@canary.invalid`, a reserved TLD per RFC 2606), so the
   relay refuses it exactly the way it refused everything in #352 — a real
   rejection, not a faked exit code, and no message can escape to a real
   mailbox. The alert issue is then filed for real, so **close it yourself**
   afterwards or let the next scheduled run close it.
+- **Exercise the catch-all alert** — check `simulate_crash`. The probe step
+  dereferences a deliberately unset variable under `set -u`, which kills the
+  shell outright *before* anything is written to `$GITHUB_OUTPUT` — a genuine
+  dead step, not a scripted `exit 1`, and the same discipline `simulate_failure`
+  uses. Expect: the probe step red, the two normal alert steps skipped, and
+  `Email canary - the canary itself is broken, mail state unknown` filed with
+  `Probe recorded result` = *never written*. **No mail is sent.** Close the
+  issue yourself afterwards or let the next scheduled run close it.
+  `simulate_crash` **wins over** `simulate_failure` if both are checked: the
+  crash happens before the send is even assembled.
 - **Probe without side effects** — check `skip_alert`. Sends (or fails) and
   reports in the job summary, but never creates, comments on, or closes an
-  issue. Useful when verifying a relay change.
+  issue — including the catch-all. Useful when verifying a relay change.
 
 `workflow_dispatch` only appears once the workflow is on `main`.
+
+### Known gap — a job-level death cannot alert
+
+Every alarm above is raised by a *step inside the job*. If the job itself never
+gets to run those steps, nothing is filed:
+
+- the job hits its `timeout-minutes: 15` ceiling,
+- the runner is lost (hardware, network, a spot reclaim),
+- the whole workflow is cancelled before the alert steps are reached, or
+- the YAML fails to parse / the `production` environment blocks the job.
+
+In those cases the only signal is **a red run in the Actions list**. This is a
+deliberate call: catching it would need a second job (`if: always()`, `needs:
+probe`) whose only purpose is to watch the first, and a monitor-the-monitor job
+is its own maintenance burden and its own thing to go quietly wrong. A
+scheduled canary that silently stops appearing is a slow failure mode, so the
+compensating habit is: if you have not seen a green **Email Canary** run in the
+last ~12 hours (it runs every 6), open the Actions tab and look.
 
 ---
 
@@ -131,6 +220,7 @@ Actions → **Email Canary** → *Run workflow*:
 | Name | Where | Notes |
 | --- | --- | --- |
 | `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS`, `SMTP_FROM` | Secrets on the **`production` environment** | The same values `deploy.yml` already pipes through a runner on every production deploy — using them here is not a new exposure class. |
+| `SMTP_PORT` specifically | Same secret — **single source of truth** | A repo *variable* named `SMTP_PORT` is read by nothing. When the secret is empty the canary falls back to **587/STARTTLS** and logs a `::warning`, because 587 is what `deploy.yml`, all four `docker-compose.*.yml` files and the backend's `config/mod.rs` fall back to. A canary that defaulted to 465 would probe implicit TLS on a door the app never opens and report green about it. |
 | `CANARY_EMAIL_TO` | *Optional* secret or variable | Where the canary mail goes. **Unset today**, so the canary sends the mailbox a message to itself. That default needs no second mailbox to exist and still has to pass `MAIL FROM`, which is the stage where #352 failed. |
 
 ### The environment-scope trap

--- a/docs/secrets-runbook.md
+++ b/docs/secrets-runbook.md
@@ -56,6 +56,14 @@ is required.
 `CANARY_EMAIL_TO` is an *optional* secret or variable that redirects the canary
 mail; unset, the canary sends the mailbox a message to itself.
 
+**`secrets.SMTP_PORT` is the single source of truth for the SMTP port** — it is
+what `deploy.yml` ships to the box and what the canary probes. A repository
+*variable* named `SMTP_PORT` is read by **nothing**; setting one changes no
+behaviour anywhere. If the secret is missing or empty, every consumer
+(`deploy.yml`, all four `docker-compose.*.yml`, the backend's own
+`config/mod.rs`, and the canary) falls back to **587/STARTTLS**, and the canary
+logs a `::warning` saying it had to guess.
+
 Because those secrets are environment-scoped, a job that omits
 `environment: production` reads them as **empty strings with no error** — the
 same trap that made the old backup workflow report green while backing up


### PR DESCRIPTION
## Why

The email canary could go **red and file nothing at all**. Every alert step's
`if:` either keyed on `steps.probe.outputs.result` or carried no status
function (and a step `if:` with no status function is implicitly ANDed with
`success()`), so any death the workflow did not model produced silence.

Three holes:

1. **The probe dies early** (missing tool, a `set -u` trip, `mktemp` failing).
   `result` is never written → the delivery-failure alert's `if:` is false, and
   the misconfig alert's is false too because the guard passed. Nothing fires.
2. **The probe writes `result=failed` and THEN dies** (the trailing summary
   block, a trap, an OOM). The output is there and correct, but the alert step
   is skipped anyway — implicit `success()`. This is the subtle one, and it is
   why the new catch-all gate keys on step **outcomes**, never on
   `steps.probe.outputs.result`.
3. **An alert step itself fails** (a `gh`/network hiccup), or the run is
   cancelled mid-flight.

## What changed

### 1. Catch-all alert (new third issue)

`Email canary - the canary itself is broken, mail state unknown`.

Deliberately **not** the misconfig title — that issue's body diagnoses "SMTP
secrets empty" and would send someone at 03:00 to inspect secrets that are
fine. The new body:

- **leads with**: the canary did not complete, so outbound mail is **UNKNOWN** —
  not known broken, not known working;
- then "**start with the run log, NOT the relay or the secrets**";
- then a table of every step's outcome (passed in via `env:`, so the reader
  does not have to open the run);
- then, **only when the probe did record `result=failed` before dying**, a line
  saying to treat it as a probable mail outage too;
- then "if you cancelled this run by hand, close this issue";
- then the standard non-gating disclaimer + runbook pointer.

No relay text anywhere in it.

Gate:

```
(failure() || cancelled())
  && steps.alert_fail.outcome != 'success'
  && steps.alert_misconfig.outcome != 'success'
  && github.event.inputs.skip_alert != 'true'
```

**Placement is load-bearing**: it sits *after* recovery and *before* the final
"Fail the run on a confirmed delivery failure" step. That step's deliberate
`exit 1` makes `failure()` true for everything after it, so a catch-all below
it would double-file "the canary is broken" on every genuine mail outage. There
is a comment saying exactly that.

### 2. Recovery closes all three alarms, and runs on `always()`

`if: always() && steps.probe.outputs.result == 'ok' && ...` — without
`always()` the step is implicitly `success()`-gated, so a probe that recorded
`result=ok` and then died would leave a stale alarm open *while the relay had
just accepted a real message*. Every title this workflow can raise now has
exactly one automatic closer.

### 3. Dedupe race killed

Every lookup replaced with:

```bash
EXISTING=$(TITLE="$TITLE" gh issue list -R "$REPO" --state open --limit 200 \
  --json number,title --jq 'map(select(.title == env.TITLE)) | .[0].number // empty')
```

`--search` reads GitHub's **search index**, which lags writes, so two runs
inside that window each conclude "no open issue" and each file one. Without
`--search`, `gh` reads the issues API, which is read-after-write consistent.
No post-create re-search was added: it re-reads the same stale index and buys
nothing. Residual race is two creates within the same few milliseconds, and
`concurrency: email-canary` (`cancel-in-progress: false`) already serialises
this workflow. The no-colon title rule is kept and re-documented anyway.

All four lookups are byte-identical; the create-or-comment block is
byte-identical in the three steps that can file. Diff them by eye.

### 4. No `--label bug`

Matches `cargo-audit.yml` and `deploy.yml`'s notifier, whose comments say
alerting must never depend on label configuration. Also removes an empty
`LABEL_ARGS[@]`-under-`set -u` hazard.

### 5. SMTP_PORT — one source of truth

`secrets.SMTP_PORT` is authoritative; the canary's fallback moves **465 → 587**
and emits a `::warning` when the secret is empty.

If that secret is ever deleted, `deploy.yml` (`${SMTP_PORT:-587}`), all four
`docker-compose.*.yml`, and the backend (`config/mod.rs`, already 587) land on
**587/STARTTLS** — while the canary would have probed **465/implicit-TLS**.
That is a canary reporting green against a door the app never opens.

Also fixed two docs that were plainly wrong about code that already defaults to
587: `backend-rust/README.md` ("default: 465") and `backend-rust/.env.example`.
`config/mod.rs` untouched (already correct); `scripts/evergreen/` untouched.

### 6. `simulate_crash` dispatch input

Boolean, default false: *"Make the probe step die before it reports (exercises
the catch-all alert path)"*. A **genuine abort** — it dereferences a
deliberately unset variable while `set -u` is on, which kills the shell
outright — placed *before* anything is written to `$GITHUB_OUTPUT`. Same
discipline as `simulate_failure`, which provokes a real `553` with a real
`.invalid` domain rather than faking an exit code. Emits a `::warning` first.
`simulate_crash` wins over `simulate_failure` if both are set (documented).

### 7. Docs

`docs/email-canary-runbook.md` gains: the three alarms and what each means,
that recovery closes all three, how to exercise `simulate_crash`, the
SMTP_PORT source-of-truth line, and an explicit **KNOWN GAP** section — a
job-level `timeout-minutes` or a lost runner cannot be caught by any in-job
step, so that case shows only as a red run in the Actions list. Documented
rather than fixed with a monitor-the-monitor job, by the owner's call, with the
compensating habit written down (no green run in ~12h → open the Actions tab).

`docs/secrets-runbook.md` states that `secrets.SMTP_PORT` is authoritative and
that a repo **variable** named `SMTP_PORT` is read by nothing.

## Verification

Local (no heavy builds — this laptop is disk-starved, CI is the gate):

- `python3 -c "import yaml; yaml.safe_load(...)"` → OK
- `actionlint .github/workflows/email-canary.yml` → clean (it caught
  `cancelled()` in an `env:`, which is only legal in an `if:`; replaced with
  `job.status`)
- `bash -n` on every extracted `run:` block → all parse
- `shellcheck` → nothing new
- `grep` → no `--search` and no `--label` outside explanatory comments
- Stubbed-`gh` unit checks (temp dirs, no network) proving:
  `simulate_crash` exits non-zero on an *unbound variable* with `$GITHUB_OUTPUT`
  left **empty**; it beats `simulate_failure`; empty `SMTP_PORT` warns and
  probes `smtp://…:587`; `SMTP_PORT=465` still selects `smtps://`; the jq filter
  picks the exact title over a longer near-miss; the create path passes no
  `--label`; recovery closes all three issues; and the catch-all body leads with
  UNKNOWN, renders the outcome table, and contains no relay text (with the
  conditional outage line appearing only when `result=failed`).

The scaffolding was removed before committing.

**Not dispatched.** Per the plan, the orchestrator runs the dispatch
verification sequence after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU
