### PR TITLE
fix(ops): alert backup failures through GitHub issues, and signal recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,8 +188,13 @@ evergreen (`scripts/evergreen/`) dumps, gzips and `age`-encrypts to
 `/srv/backups/loyalty`, so production data never transits a runner. The
 previous GitHub Actions + S3 workflow was removed: it needed cloud storage
 and, because its secrets were environment-scoped while the job declared no
-`environment:`, it reported success nightly while backing up nothing. Setup
-and restore drill: [`docs/restore-runbook.md`](docs/restore-runbook.md).
+`environment:`, it reported success nightly while backing up nothing. Backup
+alerts are **GitHub issues** (`scripts/evergreen/loyalty-backup-notify-github.sh`),
+not email: the only mailbox available is the one the alert would be reporting
+on, so it would suppress its own alarm — and the issue is commented on per
+failure and **closed automatically on recovery**, which is also what clears
+`LAST-FAILURE`. Setup, token rotation and the alert drill:
+[`docs/restore-runbook.md`](docs/restore-runbook.md).
 
 Production deploys live in `deploy.yml` and are **unattended** — the
 `production` environment no longer has a required reviewer, so a green

--- a/docs/restore-runbook.md
+++ b/docs/restore-runbook.md
@@ -19,6 +19,8 @@ Nightly at 01:00 ICT (18:00 UTC) the `loyalty-backup.timer` systemd unit
    `KEEP_MIN` (7) most recent, so a wrong clock cannot empty the directory.
 6. Updates `/srv/backups/loyalty/last-success` — written last, so it only
    advances after a fully verified dump.
+7. If the previous run had failed, sends a **recovery** notification and clears
+   `/srv/backups/loyalty/LAST-FAILURE`. See [Alerting](#alerting).
 
 The dump uses `--no-owner --no-acl` so it can be restored into a DB owned by
 any role.
@@ -49,17 +51,26 @@ It installs `age`, the backup + alert scripts, the systemd units, creates
 the scripts and never overwrites `/etc/loyalty-backup.conf`.
 
 Then set `ALERT_COMMAND` in `/etc/loyalty-backup.conf` so a failure reaches a
-human. Without it, failures land only in the journal and in
-`/srv/backups/loyalty/LAST-FAILURE`.
+human — see [Alerting](#alerting) below. Without it, failures land only in the
+journal and in `/srv/backups/loyalty/LAST-FAILURE`.
 
-| Setting          | What it is                                                 |
-| ---------------- | ---------------------------------------------------------- |
-| `AGE_RECIPIENT`  | Single-line `age1...` **public** key (safe to store here)  |
-| `BACKUP_DIR`     | Where dumps are written (default `/srv/backups/loyalty`)   |
-| `PG_CONTAINER`   | Production Postgres container name                          |
-| `KEEP_DAYS`      | Age-based retention (default 30)                            |
-| `KEEP_MIN`       | Floor on retained dumps regardless of age (default 7)       |
-| `ALERT_COMMAND`  | Command receiving the failure text on stdin                 |
+| Setting              | What it is                                                    |
+| -------------------- | ------------------------------------------------------------- |
+| `AGE_RECIPIENT`      | Single-line `age1...` **public** key (safe to store here)     |
+| `BACKUP_DIR`         | Where dumps are written (default `/srv/backups/loyalty`)      |
+| `PG_CONTAINER`       | Production Postgres container name                             |
+| `KEEP_DAYS`          | Age-based retention (default 30)                               |
+| `KEEP_MIN`           | Floor on retained dumps regardless of age (default 7)          |
+| `ALERT_COMMAND`      | Command receiving the alert text on stdin                      |
+| `GITHUB_REPO`        | `owner/repo` the alert issue is filed on                       |
+| `GITHUB_TOKEN`       | Fine-grained PAT, **Issues: read and write** on that repo only |
+| `GITHUB_ISSUE_TITLE` | Issue title, **no colon** (default is fine)                    |
+| `SMTP_*`             | Only for the optional second (email) channel                   |
+
+> `install.sh` **never re-applies** `loyalty-backup.conf.example` to an existing
+> `/etc/loyalty-backup.conf`. Anything added to the example after the host was
+> provisioned has to be merged in by hand; re-running the installer prints a
+> DRIFT NOTICE when the live conf has no `GITHUB_REPO`.
 
 The age **private** key stays on the operator's machine at
 `~/.age/loyalty-backup.key` and is the only thing that can decrypt a dump.
@@ -99,6 +110,153 @@ ls -lh /srv/backups/loyalty
 
 An untested backup is not a backup — confirm one actually restores using the
 procedure below.
+
+## Alerting
+
+A backup you do not hear about is not monitored. Two things reach a human, and
+one of them must not share fate with the thing being watched.
+
+### Channels
+
+| Channel                                       | Role            | Survives a mail outage |
+| --------------------------------------------- | --------------- | ---------------------- |
+| `loyalty-backup-notify-github.sh` (GitHub issue) | **primary**     | yes                    |
+| `loyalty-backup-notify-email.sh` (SMTP)        | optional second | no                     |
+
+Email is deliberately *not* the primary. The only mailbox available is
+`info@saichon.com` — the same one that carries this app's password resets, and
+the same one whose lapsed subscription caused #352 and made PR #351's first live
+alert test fail with `553 5.7.1 ... Sender address rejected`. An email-only
+alert routed through that mailbox suppresses its own alarm: the backup fails,
+the alert cannot leave the host, and nobody finds out. GitHub does not share
+fate with it, is already where `Production deploy failed` and
+`Email canary - outbound mail is failing` land, and de-duplicates — one issue
+that gains a comment per night rather than one message per night.
+
+Set it up (on evergreen, in `/etc/loyalty-backup.conf`, mode 600):
+
+```sh
+GITHUB_REPO="thehfhotel/loyalty-app"
+GITHUB_TOKEN="github_pat_…"
+ALERT_COMMAND=/usr/local/bin/loyalty-backup-notify-github.sh
+```
+
+To run **both** channels, use the single-quoted two-transport form shown in
+`scripts/evergreen/loyalty-backup.conf.example`. Three details there are load
+bearing: single quotes (the conf is *sourced*, so double quotes expand at source
+time and ship a blank alert), the GitHub transport **last** (a list's exit
+status is its last command, and that status is how the alert script decides
+whether the alert got out), and `|| true` on the email leg so a dead mailbox
+cannot fail a dispatch GitHub already handled.
+
+### What arrives
+
+* **Failure** — an issue titled `Production backup failed on evergreen`, or a
+  comment on the one already open. Body: host, unit, failure time, how old the
+  last good dump is, the marker path, a copy-pasteable triage block, and the raw
+  alert text.
+* **Recovery** — a comment saying backups are working again, and the issue is
+  **closed** (`state_reason: completed`).
+
+`ALERT_COMMAND` learns which is which from the **environment**, never from
+argv — `LOYALTY_ALERT_KIND=failure|recovered`, plus `LOYALTY_ALERT_UNIT` and
+`LOYALTY_ALERT_LAST_SUCCESS_AGE`. A transport that ignores those variables keeps
+working exactly as before, which is why `loyalty-backup-notify-email.sh` needed
+no change: its subject line still says `PRODUCTION BACKUP FAILED` even for a
+recovery, and the first line of the body is what distinguishes the two.
+
+> **The issue body is world-readable.** `thehfhotel/loyalty-app` is a public
+> repository. The transport only ever posts facts this repo already publishes.
+> When you reply in the thread, keep journal excerpts, container environment,
+> connection strings and dump contents on the host.
+
+### `LAST-FAILURE` is now self-clearing
+
+`/srv/backups/loyalty/LAST-FAILURE` used to be written on every failure and
+removed by nothing, so a marker from weeks ago sat next to a fresh
+`last-success` and an operator mid-incident had to compare timestamps to work
+out which was current (#366). It is now the recovery latch:
+
+| Event                                              | Marker      |
+| -------------------------------------------------- | ----------- |
+| Backup fails                                       | written     |
+| Backup succeeds, recovery alert dispatched OK      | **removed** |
+| Backup succeeds, recovery dispatch **failed**      | kept, so the next successful run retries |
+| Backup succeeds, no `ALERT_COMMAND` configured     | removed     |
+
+So: **if `LAST-FAILURE` exists, backups are failing right now** (or the recovery
+notice has not got out yet — the journal says which). It is no longer a
+historical artefact.
+
+Two guards keep this from making things worse than the silence it replaces.
+`backup-loyalty-db.sh` runs under `set -euo pipefail` and calls the alert script
+*after* a verified backup, so the call is wrapped in `|| log "WARNING: …"` and
+`loyalty-backup-alert.sh` ends with an unconditional `exit 0`. Without either,
+a broken alert transport would fail `loyalty-backup.service`, fire its
+`OnFailure=`, and file a FAILURE issue for a run that succeeded. Both comments
+say so in the source; do not tidy them away.
+
+### The token: mint, approve, rotate
+
+The PAT is the one live secret on evergreen and it lives only in
+`/etc/loyalty-backup.conf`.
+
+1. GitHub → Settings → Developer settings → **Personal access tokens → Fine-grained tokens** → *Generate new token*.
+2. **Resource owner: `thehfhotel`** (the organisation, not your personal account) — the issue has to be filed on the org's repo.
+3. Repository access: **Only select repositories → `thehfhotel/loyalty-app`**.
+4. Repository permissions: **Issues → Read and write**. Nothing else. (`Metadata → Read` is added automatically and is mandatory.) It cannot deploy, cannot push, and cannot touch any other repo.
+5. Expiration: 90 days or less. Put the rotation date in the calendar — see the drill below for what an expired token looks like.
+6. **Because `thehfhotel` is an organisation, the token may land in the org's *Pending requests*** (Settings → Third-party Access → Personal access tokens). Until an owner approves it, every call 403s and the transport logs `BACKUP ALERTS ARE NOT REACHING GITHUB`. Approve it before assuming the script is broken.
+7. Install it:
+
+   ```sh
+   sudo sed -i 's|^GITHUB_TOKEN=.*|GITHUB_TOKEN="github_pat_…"|' /etc/loyalty-backup.conf
+   sudo chmod 600 /etc/loyalty-backup.conf
+   sudo systemctl start loyalty-backup.service    # proves the whole path
+   ```
+
+Rotation is the same steps with a new token; there is no other copy to update.
+The token is never passed on a command line (it goes into a mode-600 curl config
+inside a private temp dir) and is never exported, so it appears in neither
+`/proc/*/cmdline` nor `/proc/*/environ`. If it ever leaks, revoke it in GitHub
+first — that is instant — and only then mint a replacement.
+
+### Alert-path drill
+
+An alert channel nobody has ever seen fire is a hypothesis. Exercise the whole
+loop end to end; it takes about two minutes and touches no production data.
+
+```sh
+# On evergreen, as root.
+
+# 1. FAILURE. Fire the alert unit by hand — same path OnFailure= uses.
+sudo systemctl start loyalty-backup-failure@loyalty-backup.service
+journalctl -u 'loyalty-backup-failure@*' -n 40 --no-pager
+ls -l /srv/backups/loyalty/LAST-FAILURE          # marker written
+cat /srv/backups/loyalty/.github-alert-issue     # issue number remembered (mode 600)
+#    -> expect a new "Production backup failed on evergreen" issue on GitHub
+
+# 2. DE-DUPE. Do it again; it must COMMENT, not open a second issue.
+sudo systemctl start loyalty-backup-failure@loyalty-backup.service
+
+# 3. RECOVERY. A real backup run clears it and closes the issue.
+sudo systemctl start loyalty-backup.service
+journalctl -u loyalty-backup.service -n 40 --no-pager
+ls -l /srv/backups/loyalty/LAST-FAILURE          # expect: No such file or directory
+#    -> expect a "Backups are working again" comment and the issue CLOSED
+```
+
+Close the loop by hand afterwards only if something went wrong. What to look for
+when it does:
+
+| Symptom in the journal                             | Cause                                                                   |
+| --------------------------------------------------- | ----------------------------------------------------------------------- |
+| `BACKUP ALERTS ARE NOT REACHING GITHUB` + `401`     | Token wrong, revoked or expired. Mint a new one.                        |
+| Same banner + `403`                                 | Org approval still pending, wrong permission, or a secondary rate limit. |
+| `GITHUB_REPO is not set`                            | Config drift — the conf predates this transport. Re-run `install.sh` for the DRIFT NOTICE. |
+| `gave up after 3 attempts (last HTTP 000)`          | No egress / DNS. Same fix as any other outbound problem on that host.   |
+| A duplicate issue every night                       | The title acquired a colon. GitHub search reads `word:` as a qualifier, so the de-dupe search silently matches nothing. |
+| Marker still present after a successful run         | The recovery dispatch failed. Deliberate — the next successful run retries. |
 
 ## Restoring from backup
 

--- a/docs/secrets-runbook.md
+++ b/docs/secrets-runbook.md
@@ -28,12 +28,32 @@ The following GitHub Actions secrets are expected to be configured under
 
 > Translation services are currently disabled. Azure translator secrets are not required unless that feature is re-enabled.
 
-### Backup secrets — none required any more
+### Backup secrets — none in GitHub, but evergreen holds a live PAT
 
-Postgres backups **no longer run in GitHub Actions**, so there are no backup
-secrets to wire here. They run from a systemd timer on evergreen and are
-configured in `/etc/loyalty-backup.conf` on that host; the only value that
-matters is `AGE_RECIPIENT`, an age *public* key (safe in plaintext).
+Postgres backups **no longer run in GitHub Actions**, so there is still nothing
+to wire into `gh secret set`. They run from a systemd timer on evergreen and are
+configured in `/etc/loyalty-backup.conf` on that host.
+
+That file is no longer harmless, and the heading this section used to carry
+("none required any more") is now false. It holds **two real credentials**:
+
+| Value          | What it is                                                            |
+| -------------- | --------------------------------------------------------------------- |
+| `AGE_RECIPIENT`| age **public** key — safe in plaintext, it can only encrypt            |
+| `GITHUB_TOKEN` | **fine-grained PAT**, `Issues: read and write` on `thehfhotel/loyalty-app` only — the backup alert transport (#366) |
+| `SMTP_PASS`    | mailbox password, only if the optional email channel is enabled        |
+
+Rules for that file: root-owned, **mode 600**, never copied off the host, never
+committed. `scripts/evergreen/install.sh` sets `umask 077` so it is never even
+briefly world-readable, but a conf edited by hand can be widened again —
+`chmod 600 /etc/loyalty-backup.conf` after any edit.
+
+The PAT is scoped so a compromise of evergreen yields the ability to file issues
+on one public repository and nothing else: no contents, no actions, no other
+repo. `thehfhotel` is an organisation, so a fine-grained token may sit in the
+org's *Pending requests* until an owner approves it. Mint/approve/rotate
+procedure and what an expired token looks like in the journal:
+[`restore-runbook.md` → Alerting](./restore-runbook.md#alerting).
 
 The old design uploaded to S3-compatible storage and needed
 `BACKUP_S3_*` + `BACKUP_AGE_RECIPIENT` as repository secrets. It was removed

--- a/scripts/evergreen/backup-loyalty-db.sh
+++ b/scripts/evergreen/backup-loyalty-db.sh
@@ -104,3 +104,50 @@ printf '%s %s %s\n' "$TIMESTAMP" "$NAME" "$SIZE" > "${BACKUP_DIR}/last-success"
 
 REMAINING="$(find "$BACKUP_DIR" -maxdepth 1 -name 'loyalty_pg_*.sql.gz.age' | wc -l | tr -d ' ')"
 log "Backup complete — ${REMAINING} dump(s) retained in ${BACKUP_DIR}"
+
+# ---------------------------------------------------------------------------
+# Recovery signal.
+#
+# The presence of LAST-FAILURE is the whole "were we previously broken?" test —
+# no new state. Before #366 nothing ever removed it, so a marker from weeks ago
+# sat next to a fresh last-success and an operator mid-incident had to compare
+# timestamps to work out which was current. Worse, a failure alert with no
+# closing signal trains people to ignore the channel.
+#
+# The dispatch (and the marker policy: clear on success, KEEP on a failed
+# dispatch so tomorrow retries, clear when no ALERT_COMMAND is configured at
+# all) lives in loyalty-backup-alert.sh, so both directions go out through
+# exactly one code path.
+# ---------------------------------------------------------------------------
+if [ -f "${BACKUP_DIR}/LAST-FAILURE" ]; then
+  ALERT_SCRIPT="${LOYALTY_ALERT_SCRIPT:-}"
+  if [ -z "$ALERT_SCRIPT" ]; then
+    # install.sh puts both scripts in /usr/local/bin; prefer a sibling so a
+    # checkout runs against its own copy.
+    SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [ -x "${SELF_DIR}/loyalty-backup-alert.sh" ]; then
+      ALERT_SCRIPT="${SELF_DIR}/loyalty-backup-alert.sh"
+    else
+      ALERT_SCRIPT=/usr/local/bin/loyalty-backup-alert.sh
+    fi
+  fi
+
+  if [ -x "$ALERT_SCRIPT" ]; then
+    log "Previous run had failed — sending the recovery notification"
+    # #########################################################################
+    # ##  THE `|| log` GUARD IS LOAD-BEARING. DO NOT REMOVE IT.              ##
+    # ##                                                                     ##
+    # ##  This script runs under `set -euo pipefail`, and this line executes ##
+    # ##  AFTER a fully verified backup. An unguarded non-zero exit here     ##
+    # ##  would fail loyalty-backup.service, fire its OnFailure=, and file a ##
+    # ##  FAILURE alert for a run that SUCCEEDED — strictly worse than the   ##
+    # ##  silence this feature exists to fix. loyalty-backup-alert.sh also   ##
+    # ##  ends with an unconditional `exit 0` for the same reason; both      ##
+    # ##  belong, because either one can be lost in a refactor.              ##
+    # #########################################################################
+    LOYALTY_ALERT_KIND=recovered "$ALERT_SCRIPT" loyalty-backup.service \
+      || log "WARNING: recovery notification failed; ${BACKUP_DIR}/LAST-FAILURE kept for the next run to retry"
+  else
+    log "WARNING: ${ALERT_SCRIPT} is missing — cannot send the recovery notification; ${BACKUP_DIR}/LAST-FAILURE left in place"
+  fi
+fi

--- a/scripts/evergreen/install.sh
+++ b/scripts/evergreen/install.sh
@@ -12,6 +12,12 @@
 
 set -euo pipefail
 
+# /etc/loyalty-backup.conf now holds a GitHub PAT as well as SMTP credentials,
+# and fetch() below creates a file before it chmods it — with the default umask
+# that is a brief window in which the conf is world-readable. Setting the umask
+# here closes the window instead of relying on the chmod winning a race.
+umask 077
+
 REPO_RAW="https://raw.githubusercontent.com/thehfhotel/loyalty-app/main/scripts/evergreen"
 SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONF=/etc/loyalty-backup.conf
@@ -37,12 +43,28 @@ if ! command -v age >/dev/null; then
 else
   echo "  age present ($(age --version 2>/dev/null || echo unknown))"
 fi
+# jq is OPTIONAL: the GitHub alert transport prefers it for building request
+# JSON but ships a pure-bash escaper for hosts without it. Never fatal — an
+# alerting path that refuses to install because of an optional package is worse
+# than one that installs with a fallback.
+if ! command -v jq >/dev/null; then
+  echo "  installing jq (optional — used to build alert JSON)"
+  apt-get update -qq && apt-get install -y -qq jq \
+    || echo "  jq install failed — the GitHub transport will use its built-in escaper"
+else
+  echo "  jq present ($(jq --version 2>/dev/null || echo unknown))"
+fi
 command -v docker >/dev/null || { echo "docker is required but not installed" >&2; exit 1; }
+# Hard requirement, not best-effort: every alert transport shipped here is
+# curl-based (no MTA and no `gh` on evergreen), and this script itself falls
+# back to curl when run without a checkout.
+command -v curl >/dev/null || { echo "curl is required but not installed" >&2; exit 1; }
 
 echo "==> Scripts"
 fetch backup-loyalty-db.sh          /usr/local/bin/backup-loyalty-db.sh          755
 fetch loyalty-backup-alert.sh       /usr/local/bin/loyalty-backup-alert.sh       755
 fetch loyalty-backup-notify-email.sh /usr/local/bin/loyalty-backup-notify-email.sh 755
+fetch loyalty-backup-notify-github.sh /usr/local/bin/loyalty-backup-notify-github.sh 755
 
 echo "==> systemd units"
 fetch loyalty-backup.service          /etc/systemd/system/loyalty-backup.service          644
@@ -57,6 +79,27 @@ echo "  $BACKUP_DIR (mode 700)"
 echo "==> Config"
 if [ -f "$CONF" ]; then
   echo "  $CONF already exists — left untouched"
+  # …which means loyalty-backup.conf.example is NEVER re-applied, so every
+  # setting added after the host was provisioned is invisible unless someone
+  # says so here. Silent config drift is how you end up with an upgraded alert
+  # path that still has nowhere to send anything.
+  if ! grep -q '^[[:space:]]*GITHUB_REPO=' "$CONF"; then
+    cat <<EOF
+
+  !! DRIFT NOTICE — $CONF predates the GitHub alert transport.
+     It has no GITHUB_REPO, so loyalty-backup-notify-github.sh cannot run and
+     backup alerts are whatever ALERT_COMMAND was before (email only, or
+     nothing at all). This installer never rewrites an existing conf.
+
+     Add, from scripts/evergreen/loyalty-backup.conf.example:
+       GITHUB_REPO="thehfhotel/loyalty-app"
+       GITHUB_TOKEN="github_pat_…"    # fine-grained, Issues: read and write
+       ALERT_COMMAND=/usr/local/bin/loyalty-backup-notify-github.sh
+
+     Then: chmod 600 $CONF && systemctl start loyalty-backup.service
+
+EOF
+  fi
 else
   fetch loyalty-backup.conf.example "$CONF" 600
   echo "  wrote $CONF (mode 600) — review AGE_RECIPIENT and set ALERT_COMMAND"

--- a/scripts/evergreen/loyalty-backup-alert.sh
+++ b/scripts/evergreen/loyalty-backup-alert.sh
@@ -1,18 +1,52 @@
 #!/usr/bin/env bash
 #
-# Fired by systemd (OnFailure=) when the nightly backup unit fails.
+# The one place a backup alert is dispatched from — in BOTH directions.
 #
-# A failed backup that only lands in the journal is the same class of problem
-# as the old GitHub workflow reporting green while backing nothing up: nobody
-# finds out. This writes a durable marker AND, if configured, sends a real
-# alert.
+#   FAILURE    fired by systemd (OnFailure= on loyalty-backup.service). Writes
+#              the durable LAST-FAILURE marker and sends the alert.
+#   RECOVERED  fired by backup-loyalty-db.sh after a verified successful dump,
+#              but only if LAST-FAILURE exists. Sends the "working again"
+#              message and clears the marker.
+#
+# A failed backup that only lands in the journal is the same class of problem as
+# the old GitHub workflow reporting green while backing nothing up: nobody finds
+# out. And a failure alert with no matching recovery is only half a signal —
+# this repo's alerting convention is to pair the two so alarms stay trusted, and
+# #366 recorded that LAST-FAILURE was written but never cleared.
 #
 # Configure ALERT_COMMAND in /etc/loyalty-backup.conf to route it somewhere a
 # human actually reads. The message arrives on stdin.
-#   e.g. ALERT_COMMAND='mail -s "loyalty backup FAILED" ops@example.com'
+#   e.g. ALERT_COMMAND=/usr/local/bin/loyalty-backup-notify-github.sh
+#        ALERT_COMMAND='mail -s "loyalty backup" ops@example.com'
 #        ALERT_COMMAND='curl -sS -X POST -d @- https://hooks.example/…'
+#
+# Which direction this is, is passed to the transport in the ENVIRONMENT, never
+# in argv:
+#
+#   LOYALTY_ALERT_KIND              failure | recovered
+#   LOYALTY_ALERT_UNIT              the systemd unit the alert is about
+#   LOYALTY_ALERT_LAST_SUCCESS_AGE  how old the last good dump is, human form
+#
+# ALERT_COMMAND is a free-form shell string run through `eval`, so appending an
+# argument (`eval "$ALERT_COMMAND" recovered`) would tack the word onto that
+# string's LAST command. Both configurations this repo documents would break:
+# `mail -s … ops@example.com recovered` gains a second recipient, and
+# `curl … https://hooks.example/backup recovered` gains a second URL. Sniffing
+# the message text instead would be worse still — the wording is not an API.
+# Transports that ignore these variables keep working unchanged, which is why
+# loyalty-backup-notify-email.sh needed no edit for any of this.
 
 set -euo pipefail
+
+# The caller's intent, captured BEFORE the config file is sourced: a stray
+# LOYALTY_ALERT_KIND assignment in /etc/loyalty-backup.conf must not be able to
+# turn a failure into a recovery. Anything unrecognised becomes `failure` —
+# always fail toward alerting.
+ALERT_KIND="${LOYALTY_ALERT_KIND:-failure}"
+case "$ALERT_KIND" in
+  failure|recovered) ;;
+  *) ALERT_KIND=failure ;;
+esac
 
 FAILED_UNIT="${1:-loyalty-backup.service}"
 CONFIG_FILE="${LOYALTY_BACKUP_CONFIG:-/etc/loyalty-backup.conf}"
@@ -21,16 +55,65 @@ CONFIG_FILE="${LOYALTY_BACKUP_CONFIG:-/etc/loyalty-backup.conf}"
 
 : "${BACKUP_DIR:=/srv/backups/loyalty}"
 
+MARKER="${BACKUP_DIR}/LAST-FAILURE"
 WHEN="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 LAST_OK="$(cat "${BACKUP_DIR}/last-success" 2>/dev/null || echo 'never')"
 
-MESSAGE="$(cat <<EOF
+# Age of the last good dump, from the marker file's mtime rather than by parsing
+# its timestamp: `date -d` cannot read the compact 20260726T180001Z form
+# portably, and mtime is written by the same successful run.
+last_success_age() {
+  local f="${BACKUP_DIR}/last-success" mtime now age
+  [ -f "$f" ] || { printf 'never — no successful backup has ever been recorded'; return 0; }
+  mtime="$(stat -c %Y "$f" 2>/dev/null || stat -f %m "$f" 2>/dev/null || true)"
+  case "${mtime:-x}" in
+    ''|*[!0-9]*) printf 'unknown — could not stat %s' "$f"; return 0 ;;
+  esac
+  now="$(date -u +%s)"
+  age=$(( now - mtime ))
+  if [ "$age" -lt 0 ]; then
+    printf 'unknown — %s is in the future (clock skew)' "$f"
+    return 0
+  fi
+  printf '%dd %dh %dm ago' "$(( age / 86400 ))" "$(( age % 86400 / 3600 ))" "$(( age % 3600 / 60 ))"
+}
+LAST_SUCCESS_AGE="$(last_success_age)"
+
+if [ "$ALERT_KIND" = 'recovered' ]; then
+  FAILING_SINCE='unknown'
+  if [ -f "$MARKER" ]; then
+    FAILING_SINCE="$(
+      { stat -c %y "$MARKER" 2>/dev/null || stat -f %Sm "$MARKER" 2>/dev/null; } || true
+    )"
+    [ -n "$FAILING_SINCE" ] || FAILING_SINCE='unknown'
+  fi
+  MESSAGE="$(cat <<EOF
+LOYALTY PRODUCTION BACKUP RECOVERED
+
+Unit:          ${FAILED_UNIT}
+Host:          $(hostname)
+Recovered at:  ${WHEN}
+Last good:     ${LAST_OK}
+Backup age:    ${LAST_SUCCESS_AGE}
+Failing since: ${FAILING_SINCE}
+
+A backup ran, passed its size and age-header checks, and was written to
+${BACKUP_DIR}. The failure marker below is being cleared.
+
+Marker: ${MARKER}
+
+Restore procedure: docs/restore-runbook.md
+EOF
+  )"
+else
+  MESSAGE="$(cat <<EOF
 LOYALTY PRODUCTION BACKUP FAILED
 
-Unit:       ${FAILED_UNIT}
-Host:       $(hostname)
-Failed at:  ${WHEN}
-Last good:  ${LAST_OK}
+Unit:        ${FAILED_UNIT}
+Host:        $(hostname)
+Failed at:   ${WHEN}
+Last good:   ${LAST_OK}
+Backup age:  ${LAST_SUCCESS_AGE}
 
 There is no new backup for tonight. Until this is fixed the newest restorable
 dump is the one listed above.
@@ -41,21 +124,67 @@ Diagnose with:
 
 Restore procedure: docs/restore-runbook.md
 EOF
-)"
+  )"
+fi
 
 mkdir -p "$BACKUP_DIR"
-printf '%s\n' "$MESSAGE" > "${BACKUP_DIR}/LAST-FAILURE"
+
+# The marker is written for a failure and cleared for a recovery — but only
+# after the recovery has actually been delivered (below), so a transport outage
+# cannot silently drop the "we are fine again" signal AND erase the evidence.
+if [ "$ALERT_KIND" = 'failure' ]; then
+  printf '%s\n' "$MESSAGE" > "$MARKER"
+fi
 
 # Always land it in the journal, tagged so it is greppable.
 printf '%s\n' "$MESSAGE" | systemd-cat -t loyalty-backup -p err || printf '%s\n' "$MESSAGE" >&2
 
 if [ -n "${ALERT_COMMAND:-}" ]; then
+  # Exported for the transport. A transport that ignores them behaves exactly as
+  # it did before these existed.
+  export LOYALTY_ALERT_KIND="$ALERT_KIND"
+  export LOYALTY_ALERT_UNIT="$FAILED_UNIT"
+  export LOYALTY_ALERT_LAST_SUCCESS_AGE="$LAST_SUCCESS_AGE"
+
   # Never let a broken alert channel mask the original failure.
   if printf '%s\n' "$MESSAGE" | eval "$ALERT_COMMAND"; then
-    echo "Alert dispatched via ALERT_COMMAND"
+    echo "Alert dispatched via ALERT_COMMAND (kind=${ALERT_KIND})"
+    if [ "$ALERT_KIND" = 'recovered' ]; then
+      rm -f "$MARKER"
+      echo "Cleared ${MARKER}"
+    fi
   else
-    echo "WARNING: ALERT_COMMAND failed; the failure is still recorded in ${BACKUP_DIR}/LAST-FAILURE" >&2
+    if [ "$ALERT_KIND" = 'recovered' ]; then
+      # KEEP the marker. It is the only record that we still owe someone a
+      # recovery message, and it is what makes tomorrow's successful run try
+      # again instead of leaving an alert issue open forever.
+      echo "WARNING: ALERT_COMMAND failed for the recovery notice; ${MARKER} kept so the next successful run retries" >&2
+    else
+      echo "WARNING: ALERT_COMMAND failed; the failure is still recorded in ${MARKER}" >&2
+    fi
   fi
 else
-  echo "No ALERT_COMMAND configured — failure recorded to ${BACKUP_DIR}/LAST-FAILURE and the journal only." >&2
+  echo "No ALERT_COMMAND configured — ${ALERT_KIND} recorded to the journal only." >&2
+  if [ "$ALERT_KIND" = 'recovered' ]; then
+    # Nothing to deliver and nothing to retry: keeping the marker would leave a
+    # stale LAST-FAILURE sitting next to a fresh last-success forever, which is
+    # the exact confusion #366 opens with.
+    rm -f "$MARKER"
+    echo "Cleared ${MARKER}" >&2
+  fi
 fi
+
+# ###########################################################################
+# ##  UNCONDITIONAL exit 0 — LOAD-BEARING, DO NOT "TIDY" THIS AWAY.         ##
+# ##                                                                        ##
+# ##  backup-loyalty-db.sh calls this script on the RECOVERY path, and it   ##
+# ##  runs under `set -euo pipefail` AFTER a fully verified backup. A       ##
+# ##  non-zero exit here would fail loyalty-backup.service, fire its        ##
+# ##  OnFailure=, and file a FAILURE alert for a run that succeeded —       ##
+# ##  strictly worse than the silence #366 is fixing. The caller guards the ##
+# ##  invocation with `|| log WARNING` as well; both belong here.           ##
+# ##                                                                        ##
+# ##  Nothing downstream reads this status: whether the alert got out is    ##
+# ##  reported through the journal and through the LAST-FAILURE marker.     ##
+# ###########################################################################
+exit 0

--- a/scripts/evergreen/loyalty-backup-failure@.service
+++ b/scripts/evergreen/loyalty-backup-failure@.service
@@ -6,3 +6,20 @@ Documentation=https://github.com/thehfhotel/loyalty-app/blob/main/docs/restore-r
 Type=oneshot
 # %i is the failed unit name, passed through by OnFailure=.
 ExecStart=/usr/local/bin/loyalty-backup-alert.sh %i
+
+# The default TimeoutStartSec (90s) is not enough now that the alert may go out
+# over the network: the GitHub transport retries transient errors with a 0/3/9s
+# backoff and allows --connect-timeout 10 --max-time 25 per call, and a
+# two-channel ALERT_COMMAND runs an SMTP send before it. Being SIGTERMed
+# mid-retry would kill the alert at exactly the moment it matters.
+TimeoutStartSec=300
+
+# The transport writes a mode-600 curl config holding the PAT into a mktemp
+# directory; a private /tmp keeps it out of every other process's view.
+#
+# NOTE: do NOT add ProtectSystem=strict here without a matching
+# ReadWritePaths=/srv/backups/loyalty. loyalty-backup.service can afford it
+# because it declares that path; this unit's whole job is to write
+# /srv/backups/loyalty/LAST-FAILURE, and under a read-only /srv it would fail
+# to record the failure it was started to record.
+PrivateTmp=true

--- a/scripts/evergreen/loyalty-backup-notify-github.sh
+++ b/scripts/evergreen/loyalty-backup-notify-github.sh
@@ -1,0 +1,534 @@
+#!/usr/bin/env bash
+#
+# GitHub-issue transport for loyalty backup alerts. Set it as ALERT_COMMAND in
+# /etc/loyalty-backup.conf; the alert text arrives on stdin.
+#
+#   ALERT_COMMAND=/usr/local/bin/loyalty-backup-notify-github.sh
+#
+# WHY THIS EXISTS (#366). The only transport this repo shipped before sent mail
+# through info@saichon.com — the same mailbox whose lapsed subscription caused
+# #352, and the same mailbox the app's password resets ride on. A mail outage
+# therefore suppressed its own alarm: the backup failed, LAST-FAILURE was
+# written, the journal recorded it, and nothing left the host. GitHub is already
+# where "Production deploy failed" and "outbound mail is failing" land, it does
+# not share fate with the mailbox, and it de-duplicates instead of piling up one
+# message per night.
+#
+# Two directions, selected by LOYALTY_ALERT_KIND (exported by
+# loyalty-backup-alert.sh, never taken from argv — ALERT_COMMAND is a free-form
+# shell string and an appended word would land on its LAST command):
+#
+#   failure    create the issue, or comment on the one already open
+#   recovered  comment on the open issue and CLOSE it
+#
+# Anything else (including unset) is treated as `failure`: failing toward
+# alerting is the only safe default.
+#
+# ############################################################################
+# ##  THIS REPOSITORY IS PUBLIC. EVERY ISSUE BODY AND COMMENT WRITTEN HERE   ##
+# ##  IS WORLD-READABLE, FOREVER, INCLUDING BY SEARCH ENGINES.               ##
+# ##                                                                         ##
+# ##  The body below is deliberately limited to facts that are ALREADY       ##
+# ##  public in this repository: the host name, the unit name, timestamps,   ##
+# ##  the paths that scripts/evergreen/ already documents, and the alert     ##
+# ##  text this project generates itself. NEVER extend it with journal       ##
+# ##  excerpts, `docker inspect` / container environment, connection         ##
+# ##  strings, database names, user counts, dump contents, or the age key.   ##
+# ##  If you need any of that to debug, read it on the host — the issue      ##
+# ##  tells the operator exactly which commands to run.                      ##
+# ############################################################################
+#
+# Transport is curl against the REST API: evergreen has no MTA and no `gh`, and
+# this keeps the dependency list at curl (jq is optional, see below).
+
+set -euo pipefail
+# Belt and braces, and it must come before the config file is read: if this ever
+# runs from a shell with xtrace inherited (`bash -x`, or SHELLOPTS=xtrace in the
+# environment) every expansion is echoed to the journal — including the PAT.
+set +x
+# Everything this script creates (temp dir, curl config, issue-state file) holds
+# or touches the token, so default to owner-only from the first byte rather than
+# creating world-readable and chmod-ing afterwards.
+umask 077
+
+# The caller's intent, captured BEFORE the config file is sourced so a stray
+# assignment in /etc/loyalty-backup.conf cannot override it.
+ALERT_KIND="${LOYALTY_ALERT_KIND:-failure}"
+case "$ALERT_KIND" in
+  failure|recovered) ;;
+  *) ALERT_KIND=failure ;;
+esac
+
+ALERT_UNIT="${LOYALTY_ALERT_UNIT:-loyalty-backup.service}"
+ALERT_LAST_SUCCESS_AGE="${LOYALTY_ALERT_LAST_SUCCESS_AGE:-unknown}"
+
+CONFIG_FILE="${LOYALTY_BACKUP_CONFIG:-/etc/loyalty-backup.conf}"
+# shellcheck source=/dev/null
+[ -r "$CONFIG_FILE" ] && . "$CONFIG_FILE"
+
+: "${BACKUP_DIR:=/srv/backups/loyalty}"
+: "${GITHUB_API_BASE:=https://api.github.com}"
+# NO COLON IN THIS TITLE. The search fallback below goes through GitHub's search
+# API, where `word:` is read as a qualifier — a colon makes the query silently
+# match nothing, which files a brand new duplicate issue on every single run.
+: "${GITHUB_ISSUE_TITLE:=Production backup failed on evergreen}"
+: "${GITHUB_REPO:?GITHUB_REPO is not set in ${CONFIG_FILE} (expected owner/repo)}"
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is not set in ${CONFIG_FILE} (fine-grained PAT with Issues: read and write)}"
+
+GITHUB_API_BASE="${GITHUB_API_BASE%/}"
+STATE_FILE="${BACKUP_DIR}/.github-alert-issue"
+HOST="$(hostname 2>/dev/null || echo 'unknown-host')"
+WHEN="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+log()  { printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$*"; }
+warn() { log "WARNING: $*" >&2; }
+die()  { log "ERROR: $*" >&2; exit 1; }
+
+# A credential problem is not a transient problem, and it is the one failure
+# mode that makes this whole transport useless without changing anything the
+# operator can see. Say so at maximum volume, in the journal, with words worth
+# grepping for.
+loud() {
+  printf '%s\n' "$@" >&2
+  if command -v systemd-cat >/dev/null 2>&1; then
+    printf '%s\n' "$@" | systemd-cat -t loyalty-backup -p err || true
+  fi
+}
+
+case "$GITHUB_REPO" in
+  */*/*|/*|*/) die "GITHUB_REPO='${GITHUB_REPO}' is not owner/repo" ;;
+  */*)         ;;
+  *)           die "GITHUB_REPO='${GITHUB_REPO}' is not owner/repo" ;;
+esac
+
+case "$GITHUB_ISSUE_TITLE" in
+  *:*) warn "GITHUB_ISSUE_TITLE contains a colon; GitHub search reads 'word:' as a qualifier, so the de-dupe fallback will not match it" ;;
+esac
+
+RAW_ALERT="$(cat || true)"
+[ -n "$RAW_ALERT" ] || RAW_ALERT='(no alert text received on stdin)'
+
+# -----------------------------------------------------------------------------
+# Workspace. The PAT is written into a curl config file inside a private temp
+# directory and NEVER passed as an argument: /proc/<pid>/cmdline is readable by
+# any process of the same user, which is exactly the defect email-canary.yml
+# calls out in loyalty-backup-notify-email.sh's `--user` flag.
+# -----------------------------------------------------------------------------
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+CURL_CFG="${WORKDIR}/curlrc"
+RESP="${WORKDIR}/response.json"
+CURL_ERR="${WORKDIR}/curl.err"
+PAYLOAD="${WORKDIR}/payload.json"
+
+# curl's config syntax takes a double-quoted value, so backslash and quote are
+# escaped here. printf is a shell BUILTIN — the token never becomes an argument
+# to an external process, and never reaches any log.
+esc_token="${GITHUB_TOKEN//\\/\\\\}"
+esc_token="${esc_token//\"/\\\"}"
+printf 'header = "Authorization: Bearer %s"\n' "$esc_token" > "$CURL_CFG"
+chmod 600 "$CURL_CFG"
+# Drop the token from this shell entirely. It is deliberately never exported:
+# an exported value would be inherited by curl and visible in
+# /proc/<pid>/environ for the life of every request.
+unset esc_token GITHUB_TOKEN
+
+HAVE_JQ=0
+command -v jq >/dev/null 2>&1 && HAVE_JQ=1
+
+# -----------------------------------------------------------------------------
+# JSON — building (jq preferred) and parsing (never jq).
+#
+# jq is used ONLY to build request bodies. That is the dangerous half: the body
+# carries arbitrary multi-line operator-supplied text, and one unescaped quote
+# turns a 201 into a 422 at 3am. The pure-bash escaper below is a real fallback,
+# not a stub — evergreen may not have jq, and an alert that depends on an
+# optional package is not an alert.
+# -----------------------------------------------------------------------------
+json_escape() {  # -> a complete JSON string literal, quotes included
+  local s="$1"
+  # Byte-wise: with LC_ALL=C the ranges below are byte ranges and any UTF-8
+  # sequence passes through untouched instead of tripping over the locale.
+  local LC_ALL=C
+  s="${s//\\/\\\\}"
+  s="${s//\"/\\\"}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  s="${s//$'\n'/\\n}"
+  # Any remaining C0 control byte is illegal raw inside a JSON string.
+  case "$s" in
+    *[$'\001'-$'\010'$'\013'$'\014'$'\016'-$'\037']*)
+      local out='' i ch
+      for (( i = 0; i < ${#s}; i++ )); do
+        ch="${s:i:1}"
+        case "$ch" in
+          [$'\001'-$'\010'$'\013'$'\014'$'\016'-$'\037']) printf -v ch '\\u%04x' "'$ch" ;;
+        esac
+        out="${out}${ch}"
+      done
+      s="$out"
+      ;;
+  esac
+  printf '"%s"' "$s"
+}
+
+json_object() {  # json_object KEY VALUE [KEY VALUE ...] -> stdout (all strings)
+  if [ "$HAVE_JQ" -eq 1 ]; then
+    jq -n --args '
+      $ARGS.positional as $a
+      | reduce range(0; ($a | length); 2) as $i ({}; . + { ($a[$i]): $a[$i + 1] })
+    ' "$@"
+    return
+  fi
+  local out='{' first=1
+  while [ "$#" -ge 2 ]; do
+    if [ "$first" -eq 0 ]; then out="${out},"; fi
+    first=0
+    out="${out}$(json_escape "$1"):$(json_escape "$2")"
+    shift 2
+  done
+  printf '%s}\n' "$out"
+}
+
+# Responses are parsed with grep, which is safe ONLY because every request below
+# asks for exactly ONE object: per_page=1 for the search, a single issue
+# everywhere else. In a single issue object GitHub emits `number` and `state`
+# before any nested object that could repeat those keys, so "first match wins"
+# is correct.
+#
+# *** RAISING per_page BREAKS THIS AND YOU MUST SWITCH TO jq. *** With two items
+# in the array, item 1's `milestone.number` precedes item 2's own `number`, and
+# the first match would be the wrong issue. If more than one result is ever
+# needed, make jq REQUIRED and parse `.items[0].number`.
+#
+# `sed -n 1p` rather than `head -n1`: head closes the pipe early, grep dies with
+# SIGPIPE, and `set -o pipefail` would turn that into a script-killing failure.
+json_first_number() {  # json_first_number KEY FILE
+  grep -oE "\"$1\"[[:space:]]*:[[:space:]]*[0-9]+" "$2" 2>/dev/null \
+    | sed -n '1p' | grep -oE '[0-9]+$' || true
+}
+
+json_first_string() {  # json_first_string KEY FILE
+  grep -oE "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$2" 2>/dev/null \
+    | sed -n '1p' | sed -E 's/^.*:[[:space:]]*"//; s/"$//' || true
+}
+
+# -----------------------------------------------------------------------------
+# One API call, with retries for the failures that are worth retrying.
+#
+# Extra curl arguments (the search query string) come in through API_EXTRA so
+# the retry/classification logic exists exactly once. Sets API_STATUS; returns 0
+# when a definitive HTTP status was obtained (the caller decides what 404 means),
+# 1 when every attempt was a transport error / 5xx / 429. A rejected credential
+# exits the script outright — see below.
+# -----------------------------------------------------------------------------
+API_EXTRA=()
+API_STATUS=''
+
+api() {  # api METHOD URL [PAYLOAD_FILE]
+  local method="$1" url="$2" payload="${3:-}"
+  local attempt=0 delay status rc
+  local -a args
+
+  for delay in 0 3 9; do
+    attempt=$(( attempt + 1 ))
+    if [ "$delay" -gt 0 ]; then
+      log "retrying ${method} in ${delay}s (attempt ${attempt}/3)"
+      sleep "$delay"
+    fi
+
+    args=(
+      --silent --show-error
+      --config "$CURL_CFG"
+      --header 'Accept: application/vnd.github+json'
+      --header 'X-GitHub-Api-Version: 2022-11-28'
+      --user-agent 'loyalty-backup-notify-github'
+      # Per call, not per script: a wedged TLS handshake must not hold the
+      # backup unit's failure handler open until systemd kills it.
+      --connect-timeout 10 --max-time 25
+      --request "$method"
+      --output "$RESP"
+      --write-out '%{http_code}'
+    )
+    # NEVER --verbose here: a verbose trace prints the request headers, and the
+    # Authorization header IS the token.
+    [ "${#API_EXTRA[@]}" -eq 0 ] || args+=("${API_EXTRA[@]}")
+    if [ -n "$payload" ]; then
+      args+=(--header 'Content-Type: application/json' --data-binary "@${payload}")
+    fi
+    args+=("$url")
+
+    : > "$RESP"
+    : > "$CURL_ERR"
+    rc=0
+    status="$(curl "${args[@]}" 2>"$CURL_ERR")" || rc=$?
+    [ -n "$status" ] || status='000'
+
+    case "$status" in
+      401|403)
+        loud \
+          "################################################################" \
+          "## BACKUP ALERTS ARE NOT REACHING GITHUB                      ##" \
+          "################################################################" \
+          "The GitHub API rejected the credential with HTTP ${status}." \
+          "Until GITHUB_TOKEN in ${CONFIG_FILE} is fixed, every backup failure" \
+          "on ${HOST} is invisible outside this host: the only remaining record" \
+          "is ${BACKUP_DIR}/LAST-FAILURE and the local journal, and nobody" \
+          "watches those (that is the entire reason this transport exists)." \
+          "Fix: mint a fine-grained PAT for ${GITHUB_REPO} with Issues: read and" \
+          "write, put it in ${CONFIG_FILE} (mode 600), and re-run" \
+          "'systemctl start loyalty-backup.service'. See docs/restore-runbook.md." \
+          "Not retrying: a rejected credential does not start working on attempt 2." \
+          "(HTTP 403 can also be a secondary rate limit; the response body above" \
+          "says which, and a rate limit clears on its own.)"
+        sed -n '1,5p' "$RESP" >&2 || true
+        exit 1
+        ;;
+      000|429|5??)
+        warn "${method} ${url} -> HTTP ${status} (curl exit ${rc})"
+        sed -n '1,3p' "$CURL_ERR" >&2 || true
+        if [ "$attempt" -ge 3 ]; then break; fi
+        continue
+        ;;
+      *)
+        API_STATUS="$status"
+        return 0
+        ;;
+    esac
+  done
+
+  API_STATUS="$status"
+  warn "${method} ${url} gave up after ${attempt} attempts (last HTTP ${status})"
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# Issue de-dupe. Local state first, search only as a fallback.
+#
+# The state file is the primary index because a GET of a known issue number hits
+# GitHub's primary database and is always current, whereas the search index lags
+# by seconds to minutes — long enough for two consecutive nightly failures to
+# each conclude "nothing open" and file a duplicate. Search still earns its keep
+# for the cases the state file cannot cover: BACKUP_DIR rebuilt, the host
+# reinstalled, or the issue opened by hand.
+# -----------------------------------------------------------------------------
+read_state_issue() {
+  local n
+  [ -r "$STATE_FILE" ] || return 0
+  n="$(tr -cd '0-9' < "$STATE_FILE" 2>/dev/null || true)"
+  printf '%s' "$n"
+}
+
+write_state_issue() {
+  mkdir -p "$BACKUP_DIR" 2>/dev/null || true
+  if printf '%s\n' "$1" > "$STATE_FILE" 2>/dev/null; then
+    chmod 600 "$STATE_FILE" 2>/dev/null || true
+  else
+    warn "could not write ${STATE_FILE}; de-dupe will fall back to the search API"
+  fi
+}
+
+ISSUE=''
+UNCERTAIN=0
+
+CACHED="$(read_state_issue)"
+if [ -n "$CACHED" ]; then
+  API_EXTRA=()
+  if api GET "${GITHUB_API_BASE}/repos/${GITHUB_REPO}/issues/${CACHED}"; then
+    case "$API_STATUS" in
+      200)
+        STATE="$(json_first_string state "$RESP")"
+        case "$STATE" in
+          open)
+            ISSUE="$CACHED"
+            log "issue #${CACHED} from ${STATE_FILE} is still open"
+            ;;
+          closed)
+            log "issue #${CACHED} from ${STATE_FILE} is closed; forgetting it"
+            rm -f "$STATE_FILE"
+            ;;
+          *)
+            warn "could not read the state of issue #${CACHED} from the response"
+            UNCERTAIN=1
+            ;;
+        esac
+        ;;
+      404|410)
+        log "issue #${CACHED} from ${STATE_FILE} no longer exists; forgetting it"
+        rm -f "$STATE_FILE"
+        ;;
+      *)
+        warn "unexpected HTTP ${API_STATUS} looking up issue #${CACHED}"
+        UNCERTAIN=1
+        ;;
+    esac
+  else
+    UNCERTAIN=1
+  fi
+fi
+
+if [ -z "$ISSUE" ]; then
+  # per_page=1 — see the parser comment above before touching this.
+  API_EXTRA=(
+    --get
+    --data-urlencode "q=repo:${GITHUB_REPO} is:issue is:open in:title \"${GITHUB_ISSUE_TITLE}\""
+    --data-urlencode 'per_page=1'
+  )
+  if api GET "${GITHUB_API_BASE}/search/issues" && [ "$API_STATUS" = '200' ]; then
+    FOUND="$(json_first_number number "$RESP")"
+    if [ -n "$FOUND" ]; then
+      ISSUE="$FOUND"
+      log "search found open issue #${ISSUE}"
+      write_state_issue "$ISSUE"
+    fi
+  else
+    warn "issue search failed (HTTP ${API_STATUS:-none})"
+    UNCERTAIN=1
+  fi
+  API_EXTRA=()
+fi
+
+# -----------------------------------------------------------------------------
+# Bodies. printf rather than a heredoc so the markdown fences stay literal
+# backticks with no escaping games, and so nothing in the text can be taken as
+# shell.
+# -----------------------------------------------------------------------------
+LAST_SUCCESS_LINE="$(cat "${BACKUP_DIR}/last-success" 2>/dev/null || true)"
+[ -n "$LAST_SUCCESS_LINE" ] || LAST_SUCCESS_LINE='(none recorded)'
+
+# SC2016 is disabled across these builders on purpose: the single quotes are
+# what keep markdown's backticks and $-signs literal, and every value that
+# should expand is passed as a printf argument instead.
+# shellcheck disable=SC2016
+emit_facts() {  # $1 = label for the timestamp row
+  printf '| | |\n'
+  printf '| --- | --- |\n'
+  printf '| Host | `%s` |\n' "$HOST"
+  printf '| Unit | `%s` |\n' "$ALERT_UNIT"
+  printf '| %s (UTC) | `%s` |\n' "$1" "$WHEN"
+  printf '| Last successful backup | `%s` |\n' "$ALERT_LAST_SUCCESS_AGE"
+  printf '| last-success | `%s` |\n' "$LAST_SUCCESS_LINE"
+  printf '| Failure marker | `%s/LAST-FAILURE` |\n' "$BACKUP_DIR"
+}
+
+# shellcheck disable=SC2016
+emit_raw_alert() {
+  printf '<details><summary>Raw alert text</summary>\n\n'
+  # FOUR backticks: the alert text is not guaranteed to be free of three, and a
+  # three-backtick fence would be terminated early by the payload it is fencing.
+  printf '````\n%s\n````\n\n' "$RAW_ALERT"
+  printf '</details>\n'
+}
+
+# shellcheck disable=SC2016
+emit_public_warning() {
+  printf -- '---\n\n'
+  printf 'Filed automatically by `scripts/evergreen/loyalty-backup-notify-github.sh` on `%s`. It comments here on every further failure and **closes this issue by itself** after the next successful backup.\n\n' "$HOST"
+  printf '**This repository is PUBLIC and everything in this thread is world-readable.** Keep journal excerpts, container environment, connection strings and dump contents on the host — the commands above are there so you never need to paste any of it here.\n'
+}
+
+# shellcheck disable=SC2016
+build_failure_body() {
+  if [ -n "$ISSUE" ]; then
+    printf '**The nightly production backup failed again.** Still no new dump.\n\n'
+  else
+    printf '**The nightly production backup FAILED.** There is no new dump for tonight; the newest restorable dump is the one below.\n\n'
+  fi
+  emit_facts 'Failed at'
+  printf '\n### Triage, on the host\n\n'
+  printf '```sh\n'
+  printf 'journalctl -u %s -n 100 --no-pager\n' "$ALERT_UNIT"
+  printf 'systemctl status %s\n' "$ALERT_UNIT"
+  printf 'ls -lh %s\n' "$BACKUP_DIR"
+  printf 'sudo systemctl start loyalty-backup.service   # retry the backup now\n'
+  printf '```\n\n'
+  printf 'Restore procedure: `docs/restore-runbook.md`.\n\n'
+  emit_raw_alert
+  printf '\n'
+  emit_public_warning
+}
+
+# shellcheck disable=SC2016
+build_recovery_body() {
+  printf '**Backups are working again.** A run completed and verified a new dump, so this alert is resolved and the issue is being closed automatically.\n\n'
+  emit_facts 'Recovered at'
+  printf '\n'
+  printf 'The failure marker `%s/LAST-FAILURE` has been cleared. If backups fail again a fresh issue is filed (or this one is reopened by hand and commented on).\n\n' "$BACKUP_DIR"
+  emit_raw_alert
+  printf '\n'
+  emit_public_warning
+}
+
+post_comment() {  # post_comment ISSUE BODY
+  json_object body "$2" > "$PAYLOAD"
+  API_EXTRA=()
+  if api POST "${GITHUB_API_BASE}/repos/${GITHUB_REPO}/issues/${1}/comments" "$PAYLOAD" \
+     && [ "$API_STATUS" = '201' ]; then
+    return 0
+  fi
+  warn "commenting on issue #${1} failed (HTTP ${API_STATUS:-none})"
+  sed -n '1,5p' "$RESP" >&2 || true
+  return 1
+}
+
+# -----------------------------------------------------------------------------
+# Dispatch.
+# -----------------------------------------------------------------------------
+case "$ALERT_KIND" in
+  failure)
+    BODY="$(build_failure_body)"
+    if [ -n "$ISSUE" ]; then
+      post_comment "$ISSUE" "$BODY" || die "could not report the backup failure to GitHub"
+      log "commented on issue #${ISSUE} (${GITHUB_REPO})"
+      write_state_issue "$ISSUE"
+      exit 0
+    fi
+
+    # No open issue found — and if the lookup itself was inconclusive we create
+    # anyway. A duplicate issue costs one click; a 3am alert that was never
+    # filed because a search API hiccuped costs a database.
+    if [ "$UNCERTAIN" -eq 1 ]; then
+      warn "could not confirm whether an issue is already open; creating one rather than risking a lost alert"
+    fi
+    json_object title "$GITHUB_ISSUE_TITLE" body "$BODY" > "$PAYLOAD"
+    API_EXTRA=()
+    if api POST "${GITHUB_API_BASE}/repos/${GITHUB_REPO}/issues" "$PAYLOAD" \
+       && [ "$API_STATUS" = '201' ]; then
+      NEW="$(json_first_number number "$RESP")"
+      [ -n "$NEW" ] || NEW='?'
+      log "filed issue #${NEW} on ${GITHUB_REPO}"
+      [ "$NEW" = '?' ] || write_state_issue "$NEW"
+      exit 0
+    fi
+    sed -n '1,5p' "$RESP" >&2 || true
+    die "could not file the backup failure issue (HTTP ${API_STATUS:-none})"
+    ;;
+
+  recovered)
+    if [ -z "$ISSUE" ]; then
+      if [ "$UNCERTAIN" -eq 1 ]; then
+        # Exiting non-zero makes loyalty-backup-alert.sh KEEP LAST-FAILURE, so
+        # tomorrow's successful run tries again. An issue left open forever
+        # because one lookup failed is exactly the stale-signal problem #366 is
+        # about.
+        die "could not determine whether an alert issue is open; leaving the failure marker in place so the next run retries"
+      fi
+      log "no open '${GITHUB_ISSUE_TITLE}' issue to close — nothing to do"
+      exit 0
+    fi
+
+    BODY="$(build_recovery_body)"
+    post_comment "$ISSUE" "$BODY" || die "could not comment the recovery on issue #${ISSUE}"
+
+    json_object state closed state_reason completed > "$PAYLOAD"
+    API_EXTRA=()
+    if api PATCH "${GITHUB_API_BASE}/repos/${GITHUB_REPO}/issues/${ISSUE}" "$PAYLOAD" \
+       && [ "$API_STATUS" = '200' ]; then
+      log "commented and closed issue #${ISSUE} (${GITHUB_REPO})"
+      rm -f "$STATE_FILE"
+      exit 0
+    fi
+    sed -n '1,5p' "$RESP" >&2 || true
+    die "commented on issue #${ISSUE} but could not close it (HTTP ${API_STATUS:-none})"
+    ;;
+esac

--- a/scripts/evergreen/loyalty-backup.conf.example
+++ b/scripts/evergreen/loyalty-backup.conf.example
@@ -2,6 +2,18 @@
 #
 # Copy to /etc/loyalty-backup.conf on evergreen and fill in AGE_RECIPIENT.
 # Everything else has a working default.
+#
+# ############################################################################
+# ##  install.sh NEVER RE-APPLIES THIS FILE TO AN EXISTING CONF.            ##
+# ##                                                                        ##
+# ##  It copies the example only when /etc/loyalty-backup.conf is absent,   ##
+# ##  so that upgrades cannot clobber your AGE_RECIPIENT, your SMTP block   ##
+# ##  or your token. The cost is that ANY setting added here after the host ##
+# ##  was provisioned has to be merged into the live file BY HAND. When a   ##
+# ##  new option appears below, edit the real conf on evergreen — re-running ##
+# ##  install.sh will not do it for you. (It does print a DRIFT NOTICE when ##
+# ##  the live conf has no GITHUB_REPO, which is the one that matters now.) ##
+# ############################################################################
 
 # REQUIRED. The age PUBLIC key backups are encrypted to. Safe to store here in
 # plaintext — it can only encrypt. The matching PRIVATE key lives solely on the
@@ -22,20 +34,95 @@ AGE_RECIPIENT="age18sdlft5g3rnwlyhshykht3s9gmydylallnvmkmrr4ms3g08pfvmss5qm0k"
 #KEEP_DAYS=30
 #KEEP_MIN=7
 
-# OPTIONAL but strongly recommended: how a failure reaches a human. The alert
-# text arrives on stdin. Without this, failures are only visible in the journal
-# and in $BACKUP_DIR/LAST-FAILURE.
+# ---------------------------------------------------------------------------
+# ALERTING — how a failure (and a recovery) reaches a human.
 #
-# The bundled email transport needs no MTA (evergreen has none) — it sends via
-# curl over SMTPS. Fill in the SMTP block below and point ALERT_COMMAND at it:
+# The alert text arrives on stdin. Without ALERT_COMMAND, failures are visible
+# only in the journal and in $BACKUP_DIR/LAST-FAILURE, and nobody watches those.
 #
-#   ALERT_COMMAND=/usr/local/bin/loyalty-backup-notify-email.sh
+# RECOMMENDED PRIMARY: the GitHub-issue transport.
+#
+#   ALERT_COMMAND=/usr/local/bin/loyalty-backup-notify-github.sh
+#
+# Why not email as the primary? Shared fate. The only mailbox available is
+# info@saichon.com, which also carries this app's password resets — and when its
+# subscription lapsed (#352) every send was refused. An email-only alert channel
+# routed through the mailbox that is most likely to be broken suppresses its own
+# alarm: the backup fails, the alert cannot leave the host, and the failure is
+# discovered whenever someone next looks. GitHub does not share fate with the
+# mailbox, is already where "Production deploy failed" and "outbound mail is
+# failing" land, and de-duplicates: one issue that gets a comment per night and
+# CLOSES ITSELF on recovery, rather than one message per night forever.
+#
+# OPTIONAL SECOND CHANNEL: email as well, not instead. Two independent channels
+# beat one, as long as the primary does not depend on the thing being watched.
+#
+#   ALERT_COMMAND='M="$(cat)"; printf "%s\n" "$M" | /usr/local/bin/loyalty-backup-notify-email.sh >/dev/null 2>&1 || true; printf "%s\n" "$M" | /usr/local/bin/loyalty-backup-notify-github.sh'
+#
+# Three things about that line are deliberate, and each is a real bug if changed:
+#
+#   * SINGLE QUOTES. This file is SOURCED, so a double-quoted value would expand
+#     $M and $(cat) right here, at source time, when there is no alert text at
+#     all — and ship a blank alert every night.
+#   * THE PRIMARY TRANSPORT IS LAST. loyalty-backup-alert.sh decides whether the
+#     alert got out from the exit status of the whole string, and a list's (or a
+#     pipeline's) status is its LAST command. Put email last and a bounced mail
+#     reads as "alert failed" even though GitHub has the issue.
+#   * THE EMAIL LEG ENDS IN `|| true`. A dead mailbox must not be able to fail
+#     the dispatch that GitHub already handled.
 #
 # Any other command works too; the alert text arrives on stdin:
 #
 #   ALERT_COMMAND='curl -sS -X POST --data-binary @- https://hooks.example/backup'
 #
+# Which direction the alert is (failure vs recovery) is passed in the
+# ENVIRONMENT — LOYALTY_ALERT_KIND=failure|recovered, plus LOYALTY_ALERT_UNIT
+# and LOYALTY_ALERT_LAST_SUCCESS_AGE. It is NOT appended to this string, because
+# that would land on the string's last command (a second mail recipient, a
+# second curl URL). A transport that ignores those variables keeps working
+# exactly as before — loyalty-backup-notify-email.sh does, which is why its
+# subject line still says FAILED even for a recovery; its first body line is
+# the one that distinguishes them.
+#
 #ALERT_COMMAND=''
+
+# --- GitHub, used only by loyalty-backup-notify-github.sh ---
+#
+# GITHUB_REPO   owner/repo the issue is filed on.
+# GITHUB_TOKEN  a FINE-GRAINED personal access token, scoped to that ONE repo,
+#               with Repository permissions -> Issues: Read and write. Nothing
+#               else: no contents, no actions, no metadata beyond the mandatory
+#               read. It cannot deploy, cannot read code you have not already
+#               published, and cannot touch any other repository.
+#
+#               thehfhotel is an ORGANISATION, so a fine-grained token may land
+#               in "Pending requests" until an owner approves it — the transport
+#               will 403 until then. docs/restore-runbook.md has the mint,
+#               approve and rotate procedure.
+#
+#               KEEP THIS FILE MODE 600, ROOT-OWNED. It is the only place the
+#               token lives. install.sh sets `umask 077` so it is never created
+#               world-readable, but a conf edited by hand can still be widened:
+#                   chmod 600 /etc/loyalty-backup.conf
+#               The token is never passed on a command line (it goes into a
+#               mode-600 curl config in a private temp dir) and is never
+#               exported, so it does not appear in /proc/*/cmdline or environ.
+#
+#GITHUB_REPO="thehfhotel/loyalty-app"
+#GITHUB_TOKEN=""
+#
+# Title of the issue. NO COLON, EVER. The de-dupe fallback goes through GitHub's
+# search API, where `word:` is a qualifier — a colon makes the search silently
+# match nothing and files a fresh duplicate issue on every single run.
+#GITHUB_ISSUE_TITLE="Production backup failed on evergreen"
+#
+# Only for GitHub Enterprise or a test double. Default: https://api.github.com
+#GITHUB_API_BASE="https://api.github.com"
+#
+# NOTE: issue bodies and comments on a PUBLIC repository are world-readable.
+# The transport deliberately posts only facts this repo already publishes —
+# host, unit, timestamps, paths and its own alert text. Do not extend it with
+# journal excerpts, container environment or connection strings.
 
 # --- SMTP, used only by loyalty-backup-notify-email.sh ---
 #


### PR DESCRIPTION
Closes #366.

## The problem

The only alert transport this repo shipped mails through `info@saichon.com` —
the same mailbox whose lapse caused #352, and the one PR #351's commit message
records refusing its very first live alert with `553 5.7.1 ... Sender address
rejected`. An email-only channel routed through the mailbox most likely to be
broken **suppresses its own alarm**. And nothing ever cleared `LAST-FAILURE`, so
a marker from weeks ago sat next to a fresh `last-success` and a failure alert
was terminal — no signal ever closed the loop, which is the opposite of this
repo's stated alerting convention.

## What this does

**New primary transport** — `scripts/evergreen/loyalty-backup-notify-github.sh`.
Create-or-comment on failure, comment-and-close on recovery, over the REST API
with `curl` (evergreen has no MTA and no `gh`). Title `Production backup failed
on evergreen`, deliberately **colon-free**: `gh`/GitHub search reads `word:` as a
qualifier, so a colon silently matches nothing and files a duplicate every night.

The body is what someone actually needs at 3am: host, unit, failure time,
**last-success age**, marker path, a copy-pasteable triage block (`journalctl` /
`systemctl status` / `ls -lh` / `systemctl start` to retry), and the raw alert
text inside a `<details>` fenced with **four** backticks — the text is not
guaranteed free of three. A banner comment in the source states loudly that this
repo is PUBLIC and issue bodies are world-readable, so the body is limited to
facts the repo already publishes; the issue itself repeats that to whoever
replies in the thread.

**Failure vs recovery travels in the environment, never argv.**
`LOYALTY_ALERT_KIND=failure|recovered`, plus `LOYALTY_ALERT_UNIT` and
`LOYALTY_ALERT_LAST_SUCCESS_AGE`, exported before `eval "$ALERT_COMMAND"`.
`ALERT_COMMAND` is a free-form shell string, so `eval "$CMD" recovered` would
append the word to that string's *last* command and break both configurations
the repo documents (a second mail recipient; a second curl URL). The kind is
captured **before** the conf is sourced so a stray assignment cannot override the
caller, and anything unrecognised becomes `failure` — fail toward alerting.
Transports that ignore the variables are unaffected: `loyalty-backup-notify-email.sh`
is untouched and verified byte-identical with the variables set and unset.

**Recovery path** in `backup-loyalty-db.sh`: if `LAST-FAILURE` exists after a
verified dump, dispatch through the same alert script. Marker policy lives in one
place — cleared on successful dispatch, **kept** when dispatch fails so tomorrow
retries, cleared when no `ALERT_COMMAND` is configured at all.

> ⚠️ The invocation is guarded with `|| log "WARNING: …"` and
> `loyalty-backup-alert.sh` ends with an unconditional `exit 0`. `backup-loyalty-db.sh`
> runs under `set -euo pipefail` and this executes **after** a verified backup —
> an unguarded non-zero would fail the unit, fire `OnFailure=`, and file a FAILURE
> issue for a run that succeeded, which is strictly worse than today. Both
> comments say exactly this; please don't tidy them away in review.

**De-dupe via local state, not search.** `${BACKUP_DIR}/.github-alert-issue`
(mode 600) holds the open issue number, confirmed with `GET /issues/{n}` — the
primary DB, no index lag. Search is the fallback only (BACKUP_DIR rebuilt, filed
by hand), and if the *search* errors on a failure we **create anyway**: a
duplicate issue is far cheaper than a lost 3am alert.

**jq is optional.** Used only to *build* request JSON — the dangerous half,
arbitrary multi-line text — with a pure-bash escaper fallback. Responses are
parsed with `per_page=1` + first-match `grep`, with a comment warning that
raising `per_page` **requires** switching to jq (an earlier item's
`milestone.number` would precede the next item's `number`).

**PAT hygiene.** Never in argv (mode-600 curl config inside a `mktemp -d` with a
trap), `set +x` immediately after `set -euo pipefail`, never `curl -v`, never
exported. A 401/403 emits a distinct loud journal banner naming that **BACKUP
ALERTS ARE NOT REACHING GITHUB** and exits without retrying; only `000`/`5xx`/`429`
retry, `--connect-timeout 10 --max-time 25` per call.

**Also:** `install.sh` fetches the new script, sets `umask 077` (its `fetch()`
creates then chmods, and the conf now holds a PAT), hard-checks `curl`,
best-effort installs `jq`, and prints a **DRIFT NOTICE** when an existing conf
has no `GITHUB_REPO` — the example is never re-applied.
`loyalty-backup-failure@.service` gains `TimeoutStartSec=300` (the default 90s
can kill the transport mid-retry) and `PrivateTmp=true`; deliberately **no**
`ProtectSystem=strict`, which would break the `LAST-FAILURE` write.
`loyalty-backup.conf.example` recommends the GitHub transport with the
shared-fate rationale, demotes email to an optional second channel, and shows the
two-channel form **single-quoted** (the conf is *sourced*) with the primary
**last** (a list's status is its last command).

## Verification — all real, nothing faked

`shellcheck -x scripts/evergreen/*.sh` clean. 100 assertions across three
harnesses, every one a real run of the real scripts:

- **LAST-FAILURE lifecycle** in a temp dir with `LOYALTY_BACKUP_CONFIG` at a
  scratch conf: created on failure, cleared on recovery, **retained** when the
  dispatch fails, cleared when no `ALERT_COMMAND` — and **exit 0 in every case**.
  A conf that tries to set `LOYALTY_ALERT_KIND` cannot override the caller; a
  bogus kind falls back to `failure`.
- **Env pass-through** across the `eval` boundary with
  `ALERT_COMMAND='env | grep ^LOYALTY_ALERT_'`, plus a check that `$#` is 0 in
  the transport (nothing appended to argv).
- **Email transport unchanged**: real runs against a closed port, stderr and exit
  status byte-identical with `LOYALTY_ALERT_*` set and unset, and `git diff`
  proves the file is untouched.
- **Full protocol** against a local HTTP stand-in for the API: create → comment
  (no duplicate, no search when the state file is valid) → comment + close
  (`{"state":"closed","state_reason":"completed"}`); stale state file → search
  fallback → create; broken search on failure → creates anyway; broken search on
  recovery → non-zero so the marker is kept. State file asserted mode 600, and
  the token asserted present in the request header but absent from all output.
- **JSON escaper** on a payload with quotes, backslashes, tabs, newlines, UTF-8
  (é, ท), C0 control bytes, three *and* four backticks, and `$(whoami)`/backtick
  injection bait — parsed by **both** `jq` and `python3 -m json.tool`, run twice:
  once normally, once with **jq genuinely removed from PATH** (asserted). Both
  payloads are semantically identical.
- **Negative paths with real errors**: unresolvable `GITHUB_API_BASE` (3 retries
  then give up, non-zero, token absent) and a **real 401 from the live
  api.github.com** with an invalid token (loud banner, zero retries, token
  absent from output).
- **Live round trip.** Created a throwaway private repo under my own account,
  ran failure → failure → recovery against `api.github.com` for real, verified
  independently with `gh api`: issue #1 `state=closed reason=completed
  comments=2`, markdown and the four-backtick `<details>` rendering correctly.
  Repo deleted afterwards; confirmed gone.
- `install.sh`'s conf branch extracted and run both ways (drift notice fires
  without `GITHUB_REPO`, stays quiet with it, and a *commented-out*
  `GITHUB_REPO` still counts as drift); `umask 077` verified to yield mode 600.
- `conf.example` verified to parse and source cleanly, and the documented
  two-channel `ALERT_COMMAND` executed for real: both channels receive the text,
  an email failure does **not** poison the dispatch status, a GitHub failure
  **does**, and recovery flows through both.

Not run locally, per the disk-starved-laptop build policy: nothing in this PR
touches Rust, the frontend or `.github/workflows/`.

## Follow-up for the operator (not code)

Nothing here ships a token. After merge, on evergreen: mint the fine-grained PAT
(`Issues: read and write` on this repo only — note `thehfhotel` is an **org**, so
it may sit in *Pending requests* until approved), add `GITHUB_REPO` /
`GITHUB_TOKEN` / `ALERT_COMMAND` to `/etc/loyalty-backup.conf`, re-run
`install.sh`, then run the alert-path drill in `docs/restore-runbook.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU
