### PR TITLE
fix(ops): repair the four defects the live backup/restore drill exposed

### DIFF
--- a/docs/public-launch-readiness.md
+++ b/docs/public-launch-readiness.md
@@ -23,9 +23,8 @@ Legend:
   which required cloud storage and had never actually produced a backup
   (its environment-scoped secrets read empty, so it skipped nightly while
   reporting success). Restore drill in
-  [`docs/restore-runbook.md`](restore-runbook.md). **TODO before public
-  launch**: run `scripts/evergreen/install.sh` on evergreen and *actually
-  run the restore drill once.*
+  [`docs/restore-runbook.md`](restore-runbook.md). Installed and drilled on
+  evergreen 2026-07-28 — see the row below.
 - [x] **Failure-alert path** (CRIT-2) — `cargo-audit`, `Verify Staging`,
   and `deploy.yml` now file GitHub issues on red instead of relying on
   someone refreshing the Actions tab.
@@ -82,13 +81,39 @@ Legend:
 
 ## Still open before public launch
 
-- [ ] **Backup installed on evergreen** — run
-  `sudo ./scripts/evergreen/install.sh`, set `ALERT_COMMAND` in
-  `/etc/loyalty-backup.conf`, then verify with
-  `systemctl start loyalty-backup.service` and confirm a dump decrypts with
-  the private key. Until this runs, **there is no production backup at all**.
-  Note the backups sit on the same host as the database, so this does not yet
-  protect against loss of evergreen itself.
+- [x] **Backup installed on evergreen** — **done 2026-07-28.** `install.sh` has
+  been run on evergreen: the timer is active (next run 01:00 ICT), 5 encrypted
+  dumps are present and `last-success` is fresh;
+  `loyalty-backup-notify-github.sh` is installed and set as `ALERT_COMMAND`; a
+  full alert drill filed issue #375 on a genuine failure, de-duplicated a repeat
+  run to a comment, proved a broken notifier cannot fail an otherwise-good
+  backup (`Result=success`, marker retained), then commented, **closed #375**
+  and cleared the markers on a clean run; and a restore drill decrypted
+  `loyalty_pg_20260727T204006Z.sql.gz.age` with the age key, loaded it into a
+  throwaway `loyalty_db_restore` under `ON_ERROR_STOP=1`, verified 44 tables /
+  10 users / 4 tiers, and dropped the scratch DB. Log:
+  [`docs/restore-runbook.md` § Restore drill log](restore-runbook.md#restore-drill-log).
+
+Nothing else is outstanding in this section. See **Accepted risks** below for
+the one thing deliberately *not* being fixed before launch.
+
+## Accepted risks
+
+Decisions taken with eyes open, not oversights. Each is a conscious trade-off
+the owner has signed off on; revisit them at the ~90-day re-audit.
+
+- **Backups are single-site (accepted 2026-07-28).** The encrypted dumps in
+  `/srv/backups/loyalty` live on evergreen, the same host that runs the
+  production database. There are no offsite or second-machine copies. This
+  covers the failure modes that actually happen — a bad migration, an
+  accidental `DELETE`, a corrupted table, a restore drill — but **losing
+  evergreen loses the database and every backup of it together**. The owner has
+  weighed that against the cost and key-management surface of offsite storage
+  and chosen to launch this way. Watch criteria for revisiting: the host moving
+  off its current hardware, the first real data-loss incident, or any regulatory
+  or customer commitment on recovery. The mitigation, if and when it is taken,
+  is a pull-based copy of `/srv/backups/loyalty` to a second machine — the dumps
+  are already `age`-encrypted at rest, so the second site never needs the key.
 
 ## After the first 30 days
 

--- a/docs/restore-runbook.md
+++ b/docs/restore-runbook.md
@@ -105,7 +105,7 @@ A harmless warning appears in the journal on every run:
 # On evergreen — run now rather than waiting for 18:00 UTC
 sudo systemctl start loyalty-backup.service
 journalctl -u loyalty-backup.service -n 40 --no-pager
-ls -lh /srv/backups/loyalty
+sudo ls -lh /srv/backups/loyalty    # 700, root-owned — without sudo this "does not exist"
 ```
 
 An untested backup is not a backup — confirm one actually restores using the
@@ -232,8 +232,8 @@ loop end to end; it takes about two minutes and touches no production data.
 # 1. FAILURE. Fire the alert unit by hand — same path OnFailure= uses.
 sudo systemctl start loyalty-backup-failure@loyalty-backup.service
 journalctl -u 'loyalty-backup-failure@*' -n 40 --no-pager
-ls -l /srv/backups/loyalty/LAST-FAILURE          # marker written
-cat /srv/backups/loyalty/.github-alert-issue     # issue number remembered (mode 600)
+sudo ls -l /srv/backups/loyalty/LAST-FAILURE     # marker written (mode 600)
+sudo cat /srv/backups/loyalty/.github-alert-issue # issue number remembered (mode 600)
 #    -> expect a new "Production backup failed on evergreen" issue on GitHub
 
 # 2. DE-DUPE. Do it again; it must COMMENT, not open a second issue.
@@ -242,7 +242,7 @@ sudo systemctl start loyalty-backup-failure@loyalty-backup.service
 # 3. RECOVERY. A real backup run clears it and closes the issue.
 sudo systemctl start loyalty-backup.service
 journalctl -u loyalty-backup.service -n 40 --no-pager
-ls -l /srv/backups/loyalty/LAST-FAILURE          # expect: No such file or directory
+sudo ls -l /srv/backups/loyalty/LAST-FAILURE     # expect: No such file or directory
 #    -> expect a "Backups are working again" comment and the issue CLOSED
 ```
 
@@ -263,18 +263,28 @@ when it does:
 ### 1. Pick the dump
 
 ```bash
-# On evergreen — newest last
-ls -lh /srv/backups/loyalty/
-cat /srv/backups/loyalty/last-success   # timestamp, filename, size of the last good run
+# On evergreen — newest last. sudo is required for both: see the note below.
+sudo ls -lh /srv/backups/loyalty/
+sudo cat /srv/backups/loyalty/last-success   # timestamp, filename, size of the last good run
 ```
 
 Copy it to the machine holding the private key (dumps cannot be decrypted on
-evergreen — it only has the public key):
+evergreen — it only has the public key). Stream it through `sudo cat`; this is
+the form verified in the 2026-07-28 drill:
 
 ```bash
-scp evergreen:/srv/backups/loyalty/loyalty_pg_20260513T180001Z.sql.gz.age \
-  /tmp/restore.sql.gz.age
+ssh evergreen 'sudo cat /srv/backups/loyalty/loyalty_pg_20260727T204006Z.sql.gz.age' \
+  > /tmp/restore.sql.gz.age
 ```
+
+> **Do not use `scp` here.** `/srv/backups/loyalty` is mode 700 and root-owned
+> (`install.sh` creates it that way), and `scp` runs as your unprivileged login,
+> not as root — so it cannot even `stat` inside the directory and fails with
+> **`No such file or directory`**, not "Permission denied". The dump is right
+> there; the error is misleading. Hitting this cost real time on 2026-07-28.
+
+(`evergreen` above is your `~/.ssh/config` alias for the cloudflared host — the
+same target as the longer `ssh -o ProxyCommand=…` invocations further down.)
 
 ### 2. Decrypt and decompress locally
 
@@ -369,11 +379,11 @@ was last exercised.
 
 | Date       | Operator | Backup restored                          | Notes                |
 | ---------- | -------- | ---------------------------------------- | -------------------- |
-| _pending_  | _name_   | _e.g. loyalty_pg_20260513T180001Z._      | First drill required |
+| 2026-07-28 | Winut    | `loyalty_pg_20260727T204006Z.sql.gz.age` | Decrypted with the age key on the operator's machine; loaded into a throwaway `loyalty_db_restore` with `ON_ERROR_STOP=1`; verified 44 tables / 10 users / 4 tiers; scratch DB dropped. Also exposed the `scp` trap fixed in step 1 above. |
 
-> **Pre-launch action**: perform one full end-to-end restore drill into
-> a throwaway database before flipping the public switch. Record the
-> result in this table.
+> The pre-launch drill requirement is **satisfied** by the row above. Re-run the
+> drill after any change to the dump, encryption or restore path, and at least
+> once per token-rotation cycle, so the procedure never goes stale.
 
 ## Troubleshooting
 

--- a/scripts/evergreen/install.sh
+++ b/scripts/evergreen/install.sh
@@ -19,7 +19,18 @@ set -euo pipefail
 umask 077
 
 REPO_RAW="https://raw.githubusercontent.com/thehfhotel/loyalty-app/main/scripts/evergreen"
-SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# `${BASH_SOURCE[0]:-}`, not `${BASH_SOURCE[0]}`: piped to bash — which is the
+# documented `curl … | sudo bash` install — there is no source file, so
+# BASH_SOURCE is unset and under `set -u` the bare form made
+# `BASH_SOURCE[0]: unbound variable` the installer's very first line of output.
+# How bad that is depends on the bash: on evergreen it was survivable noise (the
+# run continued and fetch() fell through to the curl branch, which is the right
+# behaviour for a piped install), but on bash 5.3 the failed command
+# substitution trips `set -e` and the installer exits before it even checks for
+# root. Either way it is unacceptable on a root-run installer. With a real
+# source file this still resolves the checkout directory, so
+# `sudo ./scripts/evergreen/install.sh` keeps using the local copies.
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-}")" && pwd)"
 CONF=/etc/loyalty-backup.conf
 BACKUP_DIR=/srv/backups/loyalty
 
@@ -117,12 +128,14 @@ Installed.
 Verify with a real run right now (does not wait for 18:00 UTC):
     systemctl start loyalty-backup.service
     journalctl -u loyalty-backup.service -n 40 --no-pager
-    ls -lh ${BACKUP_DIR}
+    sudo ls -lh ${BACKUP_DIR}     # 700, root-owned — without sudo it "does not exist"
 
 Then confirm the dump actually restores — an untested backup is not a backup.
-On YOUR machine (which holds the private key):
-    scp evergreen:${BACKUP_DIR}/loyalty_pg_*.sql.gz.age /tmp/
-    age --decrypt --identity ~/.age/loyalty-backup.key /tmp/loyalty_pg_*.sql.gz.age \\
+On YOUR machine (which holds the private key). Note the 'sudo cat' — ${BACKUP_DIR}
+is mode 700 and root-owned, so scp runs as your unprivileged login, cannot stat
+inside it, and fails with a misleading "No such file or directory":
+    ssh evergreen 'sudo cat ${BACKUP_DIR}/<dump>.sql.gz.age' > /tmp/restore.sql.gz.age
+    age --decrypt --identity ~/.age/loyalty-backup.key /tmp/restore.sql.gz.age \\
       | gunzip | head -20
 
 Set ALERT_COMMAND in ${CONF} so failures reach a human, then re-run this

--- a/scripts/evergreen/loyalty-backup-alert.sh
+++ b/scripts/evergreen/loyalty-backup-alert.sh
@@ -134,6 +134,7 @@ mkdir -p "$BACKUP_DIR"
 # cannot silently drop the "we are fine again" signal AND erase the evidence.
 if [ "$ALERT_KIND" = 'failure' ]; then
   printf '%s\n' "$MESSAGE" > "$MARKER"
+  chmod 600 "$MARKER"   # match the dumps and .github-alert-issue; 644 was untidy
 fi
 
 # Always land it in the journal, tagged so it is greppable.


### PR DESCRIPTION
Found by **running the real procedure on the production host**, not by reading it. A live drill on evergreen exercised backups, the new GitHub alert transport, recovery, and a full end-to-end restore. Four things were wrong. Two of them were documentation that **actively misled**: one described a command that cannot work, the other stated that no backups existed when five encrypted dumps were sitting on disk.

## 1 — `docs/restore-runbook.md`: the copy step is impossible (HIGH)

The runbook told the operator to:

```
scp evergreen:/srv/backups/loyalty/loyalty_pg_….sql.gz.age /tmp/restore.sql.gz.age
```

`/srv/backups/loyalty` is mode 700 and root-owned — `install.sh` creates it that way and the runbook itself documents it. `scp` runs as your unprivileged login, so it cannot even `stat` inside the directory and fails with:

```
No such file or directory
```

not `Permission denied`. The failure mode looks like a **missing dump**, so the next step is hunting for a backup that is right there. Observed live this session.

Replaced with the form actually verified working, plus a one-line note on *why* and on what the misleading error looks like:

```
ssh evergreen 'sudo cat /srv/backups/loyalty/<dump>.sql.gz.age' > /tmp/restore.sql.gz.age
```

Swept the rest of the file for the same flaw: `ls`/`cat` against that directory in *Verify it works*, the alert drill, and *Pick the dump* now carry `sudo`. `scripts/evergreen/install.sh` printed the same bad `scp` suggestion in its closing message — fixed there too.

## 2 — `docs/public-launch-readiness.md`: stated the opposite of reality (HIGH)

The backup row was still open, wording included *"Until this runs, there is no production backup at all"*, with a TODO to run `install.sh` and the restore drill. All of that is done and verified on evergreen:

- `install.sh` run; timer active (next run 01:00 ICT); 5 encrypted dumps present; `last-success` fresh.
- GitHub alert transport installed and set as `ALERT_COMMAND`.
- Full alert drill: genuine failure → issue #375 filed → repeat run **de-duplicated to a comment** → a deliberately broken notifier proved a failed alert cannot fail a good backup (`Result=success`, marker retained) → a clean run commented, **closed #375**, and cleared the markers.
- Restore drill end to end: dump decrypted with the age key on the operator's machine, loaded into a throwaway `loyalty_db_restore` with `ON_ERROR_STOP=1`, verified **44 tables / 10 users / 4 tiers**, scratch DB dropped.

Row ticked with a dated evidence note. Nothing else was ticked.

Also records the **accepted risk** the owner decided this session, phrased as the deliberate decision it is rather than an oversight: backups live on the same host as the database, there are no offsite copies, and losing evergreen loses both. Includes the watch criteria for revisiting it and the mitigation if it is ever taken.

## 3 — `docs/restore-runbook.md`: drill log was `_pending_`

Filled in with this session's drill (2026-07-28, `loyalty_pg_20260727T204006Z.sql.gz.age`, restored into `loyalty_db_restore` under `ON_ERROR_STOP=1`, 44 tables / 10 users / 4 tiers, scratch DB dropped). Column shape unchanged. The adjacent *"Pre-launch action: perform one full end-to-end restore drill"* blockquote is now satisfied, so it is replaced with guidance on when to re-run the drill.

## 4 — `scripts/evergreen/install.sh`: unbound variable on the documented install (MEDIUM)

Run the documented way (`curl -fsSL … | sudo bash`) the installer's **first line of output** was:

```
bash: line 22: BASH_SOURCE[0]: unbound variable
```

Under `set -u` there is no source file when the script is piped. Fixed with `${BASH_SOURCE[0]:-}`. No other restructuring.

Worth noting how bad this actually was: on evergreen it was survivable noise (the run continued and fell through to the `curl` branch, which *is* correct for a piped install), but reproducing it locally on bash 5.3.9 shows the failed command substitution trips `set -e` and the installer **exits at line 22, before it even checks for root**:

```
$ git show origin/main:scripts/evergreen/install.sh | bash
bash: line 22: BASH_SOURCE[0]: unbound variable
bash: line 22: cd: null directory
(exit 1 — never reaches the root check)
```

**Both paths verified after the fix:**

| Case | Command | Result |
| --- | --- | --- |
| (a) piped via stdin, `set -u` active | `cat install.sh \| bash` | No unbound-variable output. Reaches the root guard normally (`Run as root (sudo).`). Trace shows `SRC_DIR` resolving to the cwd, where none of the script names exist, so `fetch()` falls through to the `curl` branch — correct for a piped install. |
| (b) from a real checkout | `bash -x /…/scripts/evergreen/install.sh` | `+ SRC_DIR=/…/scripts/evergreen` — the script's **own** directory, not the cwd (which was the repo root), so the local-copy branch still works. |

## Also (small, factual)

`loyalty-backup-alert.sh` wrote `LAST-FAILURE` at mode 644 while `.github-alert-issue` is 600. Both already sit inside a 700 directory, so **neither was ever exposed** — this is tidiness, not a security fix. It was a one-line change (`chmod 600 "$MARKER"`, matching how `backup-loyalty-db.sh` and the GitHub transport already handle their own files), so it is included.

## Verification

- `shellcheck -x scripts/evergreen/*.sh` — clean, exit 0.
- `bash -n` — clean on every script.
- Installer directory detection exercised both ways (table above).
- Installer epilogue rendered and inspected (`${BACKUP_DIR}` expansion, literal `<dump>`, line continuation intact).
- Every markdown link in both edited docs resolved to an existing file; the new `#restore-drill-log` anchor matches a real heading.

No application code touched — docs and the evergreen ops scripts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU
