### PR TITLE
fix(ci): run the real gate on release-please branches before merge

### DIFF
--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -2,11 +2,45 @@ name: CI Build & Deploy
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      # RELEASE-PLEASE BRANCHES GET THE REAL SUITE, PRE-MERGE.
+      #
+      # release-please opens its release PR with GITHUB_TOKEN, and GitHub does
+      # not raise `pull_request` workflow runs for bot-token events. Every
+      # release PR (#350, #358, #362, #367, #372) therefore merged with ZERO
+      # check runs on its head commit — and merging a release PR is exactly
+      # what triggers the UNATTENDED production deploy. Running the genuine
+      # pipeline on the branch attaches real checks to the head commit before
+      # anyone merges it.
+      #
+      # Glob rationale: see the matching comment in ci-test.yml.
+      #
+      # DEPLOY SAFETY — a run on this branch must build and test, and mutate
+      # NOTHING. Every mutating job below is gated on
+      # `github.ref == 'refs/heads/main' && github.event_name == 'push'`:
+      # promote-latest, wait-for-frontend-checks, deploy-staging,
+      # verify-staging, notify-verify-staging-failure. The one unguarded job
+      # that writes anywhere is build-and-push (GHCR); it already pushes a
+      # commit-SHA image on every pull_request, and its mutable `:<branch>`
+      # tag is now scoped to the default branch so a release branch cannot
+      # leave a junk tag behind. deploy.yml cannot cascade from here: its
+      # `workflow_run` trigger is filtered to `branches: [main]`, which matches
+      # workflow_run.head_branch, and its check-prerequisites additionally
+      # requires this run's `Verify Staging` job to have concluded `success`
+      # (it is skipped off main) and the SHA to still be the tip of main.
+      - 'release-please--**'
     # Workflow- or docs-only changes don't alter the built backend/frontend
     # images, so skip the build -> staging -> production pipeline for them and
     # avoid a needless prod redeploy + approval. paths-ignore only skips a push
     # when EVERY changed file matches, so any code change still deploys.
+    #
+    # Confirmed against release commit 3bffb1d7 ("chore(main): release 4.5.1"),
+    # which touches .release-please-manifest.json, CHANGELOG.md,
+    # backend-rust/Cargo.toml, frontend/package.json, package.json and
+    # package-lock.json. Only CHANGELOG.md matches `**.md`; the five others
+    # match nothing here, so a release push is never skipped and the checks
+    # always attach.
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -474,9 +508,21 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/backend
+          # The immutable commit-SHA tag is what every automated path consumes
+          # (deploy-staging, deploy.yml, regression-api, start-app-stack), and
+          # it is produced on every event.
+          #
+          # The mutable branch tag is scoped to the DEFAULT branch. `push` now
+          # also fires on `release-please--**`, and without this guard each
+          # release PR would mint a permanent
+          # `backend:release-please--branches--main--components--loyalty-app`
+          # tag in GHCR — a mutable tag nothing consumes, silently re-pointed
+          # at a different commit on every release. `main` is unaffected:
+          # is_default_branch is true there, so the `:main` tag is still
+          # published exactly as before.
           tags: |
             type=sha,format=long,prefix=
-            type=ref,event=branch
+            type=ref,event=branch,enable={{is_default_branch}}
 
       - name: Build and push backend
         id: build-backend
@@ -588,9 +634,11 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ env.IMAGE_REPO }}/frontend
+          # Same scoping as the backend metadata above: immutable SHA tag
+          # always, mutable branch tag only on the default branch.
           tags: |
             type=sha,format=long,prefix=
-            type=ref,event=branch
+            type=ref,event=branch,enable={{is_default_branch}}
 
       - name: Build and push frontend
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,9 +2,37 @@ name: CI Tests
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      # RELEASE-PLEASE BRANCHES GET THE REAL SUITE, PRE-MERGE.
+      #
+      # release-please opens its release PR using GITHUB_TOKEN, and GitHub does
+      # not raise `pull_request` workflow runs for bot-token events
+      # (anti-recursion). Result: PRs #350/#358/#362/#367/#372 all reached
+      # `main` with ZERO check runs on their head commit — and merging a
+      # release PR is precisely what triggers the UNATTENDED production
+      # deploy. The one PR class that ships to prod was the one class nobody
+      # verified first. (It is also the entire "26 of 30" shortfall behind
+      # OpenSSF Scorecard alerts #92 SAST and #925 CI-Tests.)
+      #
+      # The fix is to run the GENUINE gate on the branch itself, so real
+      # checks attach to the head commit before merge. Deliberately NOT a PAT,
+      # a GitHub App token, or a token-only workflow whose sole product is a
+      # green check — that would be metric-gaming, not verification.
+      #
+      # Glob, not the literal branch name: release-please builds the branch as
+      # `release-please--branches--<target>--components--<component>`, and the
+      # `<target>`/`<component>` halves move whenever
+      # release-please-config.json changes (adding a package, renaming the
+      # component, or targeting a maintenance branch). Only the
+      # `release-please--` prefix is fixed by the action's branch-name builder,
+      # so anchoring there is what survives a config edit. `**` also spans `/`,
+      # covering a future `separator` change.
+      - 'release-please--**'
     # See ci-build-e2e.yml: skip workflow/docs-only pushes so a CI-config or
     # documentation change doesn't spin up the deploy-gating test pipeline.
+    # A release commit always touches .release-please-manifest.json and the
+    # three version files, so it can never be skipped by this list.
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,19 @@ failure and **closed automatically on recovery**, which is also what clears
 `LAST-FAILURE`. Setup, token rotation and the alert drill:
 [`docs/restore-runbook.md`](docs/restore-runbook.md).
 
+**Release-please branches run the full suite before merge.** `ci-test.yml`
+and `ci-build-e2e.yml` also trigger on `push` to `release-please--**`.
+release-please opens its PR with `GITHUB_TOKEN`, and GitHub raises no
+`pull_request` workflow run for bot-token events — so release PRs used to
+merge with *zero* checks on their head commit, and merging one is exactly
+what fires the unattended production deploy. The deploy-triggering PR class
+must not be the unverified one. Only the build/test half runs there: every
+mutating job (`promote-latest`, `deploy-staging`, `verify-staging`, the
+notifiers) is gated on `github.ref == 'refs/heads/main'`, and `deploy.yml`'s
+`workflow_run` trigger is filtered to `branches: [main]`, so a release-branch
+run cannot reach staging or production. Cost: one extra full pipeline each
+time release-please updates the release branch.
+
 Production deploys live in `deploy.yml` and are **unattended** — the
 `production` environment no longer has a required reviewer, so a green
 build ships to production with no human in the loop. What stands in for

--- a/docs/workflow-review-2026-07.md
+++ b/docs/workflow-review-2026-07.md
@@ -56,6 +56,7 @@
 | 49 | low | correctness | `codeql.yml:28` | `cancel-in-progress: true` on a shared main/schedule concurrency group evicts main-branch and weekly analyses |
 | 50 | low | maintainability | `backup-production.yml:187` | Run summary prints a literal `${BACKUP_S3_BUCKET}` and silently reports empty fields on failure |
 | 51 | low | redundancy | `ci-test.yml:112` | Four overlapping dependency-CVE mechanisms with three different cadences and only one that pages anyone |
+| 52 | high | correctness | `ci-test.yml:4`, `ci-build-e2e.yml:4` | Release-please PRs carry zero check runs, so the only PR class that triggers a production deploy is the one class nothing verifies |
 
 ## HIGH severity
 
@@ -514,3 +515,58 @@ Line 187 writes `- Destination: \`s3://\${BACKUP_S3_BUCKET}/daily/\``, but the `
 The same class of finding is produced by: `npm audit --audit-level=moderate` with `continue-on-error: true` on the deploy-gating lint job (ci-test.yml:112-115); Trivy's filesystem scan over Cargo.lock/package-lock.json (trivy.yml:127, workflow_run + weekly Saturday only); Trivy's two image scans (per-merge); and `cargo audit` daily (cargo-audit.yml:19). Of the four, only cargo-audit files an issue on failure (cargo-audit.yml:53); the Trivy results land silently in SARIF and the npm audit is `continue-on-error`, meaning it costs runner time on the critical deploy path and can never change an outcome. Dependabot (weekly Monday, `open-pull-requests-limit: 1` per ecosystem) is a fifth path with its own cadence. The result is high scan cost and low signal: a moderate frontend CVE produces a green check, a silent SARIF entry, and possibly a queued Dependabot PR behind the limit-1 cap.
 
 **Fix:** Delete the `npm audit` step from ci-test.yml:112-115 (it duplicates Trivy's filesystem scan and the pre-push hook's `npm run security:audit`), and give trivy.yml's scan-filesystem the same notify-on-failure issue-filing job cargo-audit.yml:53 already implements so source-dependency CVEs have one owner and one alert channel.
+
+## Addendum — found after the original review
+
+### 52. Release-please PRs carry zero check runs, so the only PR class that triggers a production deploy is the one class nothing verifies
+
+**`ci-test.yml:4`, `ci-build-e2e.yml:4`** · correctness · high
+
+Both gating workflows triggered on `push: branches: [main]` and
+`pull_request: branches: [main]`. The release PR targets `main`, so on paper
+the `pull_request` trigger covers it. It does not: release-please opens and
+force-updates the PR using `GITHUB_TOKEN`, and GitHub deliberately raises no
+workflow run for events created by that token (anti-recursion). The head
+commit of every release PR therefore has **no check runs at all** — confirmed
+for #350, #358, #362, #367 and #372, all authored by `app/github-actions` on
+branch `release-please--branches--main--components--loyalty-app`, with runs
+observed sitting in `action_required` and never starting.
+
+Consequence: merging a release PR is precisely what puts a new version on
+`main`, which fires CI Build & Deploy → staging → the now-**unattended**
+production deploy (see finding 12 and the `deploy.yml` rewrite). The single PR
+class that ships to production is the single PR class that arrives unverified.
+It is also the entire shortfall behind OpenSSF Scorecard alerts #92 (SAST,
+medium) and #925 (CI-Tests, low), both stuck at "26 of 30".
+
+**Fix (applied):** add `release-please--**` to the `push: branches:` list of
+`ci-test.yml` and `ci-build-e2e.yml`, so the *genuine* suite runs on the
+release branch and real checks attach to the head commit before merge.
+Explicitly **not** a PAT or GitHub App token, and explicitly not a workflow
+whose only product is a green check — that inflates the Scorecard number
+without verifying anything.
+
+Deploy safety, the whole risk of the change: every mutating job in
+`ci-build-e2e.yml` was already gated on
+`github.ref == 'refs/heads/main' && github.event_name == 'push'` —
+`promote-latest`, `wait-for-frontend-checks`, `deploy-staging`,
+`verify-staging`, `notify-verify-staging-failure` — so no new guard was
+needed for any of them. The one unguarded writer is `build-and-push`, which
+already pushes a commit-SHA image on every `pull_request`; its mutable
+`type=ref,event=branch` tag was scoped to `enable={{is_default_branch}}` so a
+release branch cannot mint a permanent junk tag in GHCR. `deploy.yml` cannot
+cascade: its `workflow_run` trigger is filtered `branches: [main]` (matched
+against `workflow_run.head_branch`), and `check-prerequisites` independently
+requires the triggering run's `Verify Staging` job to have concluded
+`success` — it is skipped off `main` — plus the SHA to still be the tip of
+`main`. `trivy.yml`'s image scans and `e2e.yml` are likewise
+`workflow_run … branches: [main]`, so neither fires on a release branch.
+
+Residual risk, stated honestly: GitHub's anti-recursion rule suppresses
+workflow runs for *all* `GITHUB_TOKEN`-triggered events, and release-please
+pushes the release branch with that same token. If `push` is suppressed the
+same way `pull_request` is, checks still will not attach and this fix is
+inert (harmless, but inert). It can only be settled empirically at the next
+release. What to look for: check runs present on the release PR's head
+commit, and **no** `Deploy to Staging` / `Verify Staging` / `Promote latest
+tag` / notifier job having run.


### PR DESCRIPTION
## The problem

Every release-please PR merges with **zero check runs on its head commit** — confirmed for #350, #358, #362, #367 and #372, all authored by `app/github-actions` on branch `release-please--branches--main--components--loyalty-app`.

Cause: release-please opens and force-updates the PR using `GITHUB_TOKEN`, and GitHub deliberately raises no workflow run for events created by that token (anti-recursion). The `pull_request: branches: [main]` trigger on both gating workflows therefore never fires for it; runs were observed sitting in `action_required` and never starting.

The consequence that actually matters is not the metric. **Merging a release PR is exactly what puts a new version on `main`, which fires CI Build & Deploy → staging → the now-unattended production deploy.** The one PR class that ships to production is the one class nothing verifies first.

It is also the entire "26 of 30" shortfall behind OpenSSF Scorecard alerts **#92 (SAST, medium)** and **#925 (CI-Tests, low)**.

## The fix

Add `release-please--**` to the `push: branches:` list of the two genuine gates — `ci-test.yml` and `ci-build-e2e.yml` — so the **real** suite runs on the release branch and real checks attach to the head commit before anyone merges it.

Explicitly **not** a PAT or GitHub App token. Explicitly **not** a workflow whose only product is a green check — that inflates the Scorecard number without verifying anything, and was rejected up front.

### Why a glob and not the literal branch name

release-please builds the branch as `release-please--branches--<target>--components--<component>`. The `<target>`/`<component>` tail moves whenever `release-please-config.json` changes — adding a package, renaming the component, or targeting a maintenance branch. Only the `release-please--` prefix is fixed by the action's branch-name builder, so anchoring there is what survives a config edit. `**` also spans `/`, which covers a future `separator` change.

### paths-ignore does not swallow the run

`ci-build-e2e.yml` ignores `**.md`, `docs/**`, `.github/workflows/**`, and `paths-ignore` only skips a push when **every** changed file matches. Checked against a real release commit:

```
$ git show 3bffb1d7 --name-only     # chore(main): release 4.5.1 (#372)
.release-please-manifest.json
CHANGELOG.md
backend-rust/Cargo.toml
frontend/package.json
package-lock.json
package.json
```

Only `CHANGELOG.md` matches `**.md`. The other five match nothing in the list, so the push always runs. This is structural, not incidental: a release PR exists only because the version changed, and the version lives in `.release-please-manifest.json` plus the three version files — none of which can ever match these patterns. A build that never runs cannot attach a check, and this one always runs.

---

## Deploy safety — the whole risk of this change

A run on a release branch must build and test and **mutate nothing**. Full audit of every job in `ci-build-e2e.yml`:

| Job | Mutates? | Guard | Relied on / added |
|---|---|---|---|
| `lint-backend` | no | — | n/a (read-only: fmt + clippy) |
| `test-backend-unit` | no | — | n/a (read-only) |
| `test-backend-integration` | no | — | n/a (runner-local postgres/redis service containers) |
| `build-backend-release` | no | — | n/a (uploads an Actions artifact only) |
| `build-and-push` | **yes — GHCR** | none (by design) | **added** tag scoping, see below |
| `promote-latest` | **yes — moves `:latest`** | `github.ref == 'refs/heads/main' && github.event_name == 'push'` | **relied on** (pre-existing) |
| `regression-api` | no | — | n/a (pulls the run's own SHA images, starts them on the runner, tears them down) |
| `wait-for-frontend-checks` | no | `github.ref == 'refs/heads/main' && github.event_name == 'push'` | **relied on** (pre-existing) |
| `deploy-staging` | **yes — SSH deploy** | `github.ref == 'refs/heads/main' && github.event_name == 'push'` | **relied on** (pre-existing) |
| `verify-staging` | no (but marks the GH deployment) | `github.ref == 'refs/heads/main' && github.event_name == 'push'` | **relied on** (pre-existing) |
| `notify-verify-staging-failure` | **yes — files/comments an issue** | `always() && needs.verify-staging.result == 'failure' && github.ref == 'refs/heads/main' && github.event_name == 'push'` | **relied on** (pre-existing) |

**Every mutating job was already ref-scoped.** I added no `if:` guards, because none were missing — the deploy-gate hardening in #337/#339 had already put `github.ref == 'refs/heads/main' && github.event_name == 'push'` on all five. There is also a second, independent barrier: `deploy-staging` and `promote-latest` both `needs: wait-for-frontend-checks`, which is itself main-only, and a skipped `needs` job skips its dependents regardless of their own `if:`.

### The one guard I did add: `build-and-push`

`build-and-push` has no ref guard and holds `packages: write`. That is pre-existing and intentional — it already pushes a commit-SHA image on **every `pull_request`**, because `regression-api` (the deploy gate) tests the actual pushed image. Adding a release-branch push does not change that shape: one more immutable `<sha>` tag, indistinguishable in kind from the one every PR already produces, and consumed only by the same run's `regression-api`.

What *would* have been new is the mutable branch tag. `type=ref,event=branch` on a release-branch push would mint a permanent `backend:release-please--branches--main--components--loyalty-app` tag (and the frontend twin) — mutable, nothing consumes it, silently re-pointed at a different commit on every release. Scoped it:

```yaml
tags: |
  type=sha,format=long,prefix=
  type=ref,event=branch,enable={{is_default_branch}}
```

`main` is unaffected — `is_default_branch` is true there, so `:main` is still published exactly as before. Nothing in the repo consumes a branch tag anyway (`docker-compose.ghcr.yml` uses `${IMAGE_TAG:-latest}`; both deploy paths pass the SHA), so no registry litter, no ambiguity with `main`.

### deploy.yml cannot be reached — three independent barriers

I checked this specifically because it is the failure mode that would make this change dangerous rather than merely noisy. It cannot happen:

1. **Trigger filter.** `deploy.yml` is `workflow_run: workflows: ["CI Build & Deploy"], types: [completed], branches: [main]`. The `branches:` filter on a `workflow_run` trigger matches `workflow_run.head_branch`, which for a release-branch run is `release-please--branches--main--components--loyalty-app`. No match → **the workflow is never even created.**
2. **Staging assertion.** Even if it were triggered, `check-prerequisites` reads the triggering run's jobs and requires `Verify Staging` to have concluded `success`. On a release branch that job is *skipped*, so the query returns absent → `exit 1`. It fails loudly; it does not skip-and-report-green.
3. **Staleness guard.** It then requires the SHA to still be the tip of `main`. A release-branch head commit is not on `main` at all.

Same story for the other `workflow_run` consumers: `trivy.yml`'s two image scans and `e2e.yml` are both `workflow_run … branches: [main]`, so neither fires on a release branch. No spurious image scans, no browser E2E, and — importantly — **no notifier can file a spurious issue**, since `e2e.yml`'s `notify-on-failure` and `deploy.yml`'s `notify-on-failure` both live in workflows that are never triggered.

Net: a release-branch run executes lint-backend, both backend test jobs, build-backend-release, build-and-push, regression-api, and both frontend jobs. Everything downstream of the gate is skipped, and a skipped job does not change the run's conclusion, so the run concludes `success` and the checks attach green.

---

## Cost and noise

One extra full pipeline **each time release-please refreshes the release branch** — which is on every push to `main` that changes the pending changelog, not merely once per release. That is the honest number; it roughly doubles pipeline runs on an active day.

Two things bound it:

- The workflow concurrency group is `ci-build-${{ github.ref }}` with `cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}` — **true** on a release branch. release-please force-pushes the same ref, so each refresh cancels the superseded run instead of queueing it. Same for `ci-test.yml` (`ci-test-${{ github.ref }}`, `cancel-in-progress: true`). Only the final head commit — the one that actually gets merged — carries a completed run, which is exactly the commit that needs one.
- Nothing on the production critical path is touched, so a red or slow release-branch run delays nothing except the release PR itself.

Minor, worth knowing: release-branch runs write their own Actions cache scopes (`Swatinem/rust-cache`, the frontend `node_modules` cache). Branch-scoped caches are invisible to `main`, so `main`'s cache hit rate is unaffected; the only cost is a little more pressure on the repo's 10 GB cache budget.

---

## What is verified, and what is not

**Verified locally:**
- `actionlint` on both files: 12 findings, all pre-existing `shellcheck` info/style notes inside `promote-latest`'s unmodified script. Byte-identical count against the `origin/main` baseline — **zero new findings**.
- `python3 -c "yaml.safe_load(...)"` on both files: parse clean, `push.branches == ['main', 'release-please--**']` in each.
- Job-guard dump from the parsed YAML, which is the audit table above.

**Verified in CI:** this PR itself is the normal-PR regression test — it exercises the `pull_request` path on both workflows with the modified trigger blocks. Check list observed on this PR is in a comment below.

**Cannot be verified until the next release, and I will not pretend otherwise:** whether checks actually attach to a release-please branch. There is a real chance this is inert. GitHub's anti-recursion rule suppresses workflow runs for *all* `GITHUB_TOKEN`-triggered events, and release-please-action pushes the release branch with that same token — if `push` is suppressed the way `pull_request` demonstrably is, no run will be created and this change achieves nothing (harmlessly, but nothing). The observed `action_required` runs suggest events *are* reaching the workflow layer for this branch, which is why this is worth trying, but it is inference, not proof.

**What to look for at the next release:**
1. On the release PR's head commit — **check runs present**: `Lint Frontend`, `Frontend Unit Tests`, `Lint Backend (Rust)`, `Test Backend Unit (Rust)`, `Test Backend Integration (Rust)`, `Build Backend Release`, `Build & Push to GHCR`, `Regression & Smoke (API)`.
2. On the same run — **these jobs must show `skipped`, never `success`**: `Deploy to Staging`, `Verify Staging`, `Promote latest tag`, `Wait for Frontend Checks`, `Notify on Verify Staging failure`.
3. **No `Deploy` workflow run** whose `head_branch` is the release branch, and no new `Production deploy failed` / `Verify Staging failed on main` issue filed.
4. GHCR shows a new `<sha>` tag for the release-branch commit and **no** `release-please--*` tag.
5. If (1) is empty — no checks attached — the anti-recursion theory is confirmed for `push` as well, and this approach is a dead end. Report that back rather than escalating to a PAT/App token, which the owner has already ruled out.

## Docs

- `CLAUDE.md` CI/CD section: one paragraph on why release branches now get the full suite, and that only the build/test half runs there.
- `docs/workflow-review-2026-07.md`: finding **#52** (high, correctness) added to the table and written up in a new "Addendum — found after the original review" section, including the residual-risk paragraph above.

## Files changed

- `.github/workflows/ci-test.yml`
- `.github/workflows/ci-build-e2e.yml`
- `CLAUDE.md`
- `docs/workflow-review-2026-07.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU
