### PR TITLE
fix(ci): revert the inert release-please push trigger, correct the docs

### DIFF
--- a/.github/workflows/ci-build-e2e.yml
+++ b/.github/workflows/ci-build-e2e.yml
@@ -2,45 +2,11 @@ name: CI Build & Deploy
 
 on:
   push:
-    branches:
-      - main
-      # RELEASE-PLEASE BRANCHES GET THE REAL SUITE, PRE-MERGE.
-      #
-      # release-please opens its release PR with GITHUB_TOKEN, and GitHub does
-      # not raise `pull_request` workflow runs for bot-token events. Every
-      # release PR (#350, #358, #362, #367, #372) therefore merged with ZERO
-      # check runs on its head commit — and merging a release PR is exactly
-      # what triggers the UNATTENDED production deploy. Running the genuine
-      # pipeline on the branch attaches real checks to the head commit before
-      # anyone merges it.
-      #
-      # Glob rationale: see the matching comment in ci-test.yml.
-      #
-      # DEPLOY SAFETY — a run on this branch must build and test, and mutate
-      # NOTHING. Every mutating job below is gated on
-      # `github.ref == 'refs/heads/main' && github.event_name == 'push'`:
-      # promote-latest, wait-for-frontend-checks, deploy-staging,
-      # verify-staging, notify-verify-staging-failure. The one unguarded job
-      # that writes anywhere is build-and-push (GHCR); it already pushes a
-      # commit-SHA image on every pull_request, and its mutable `:<branch>`
-      # tag is now scoped to the default branch so a release branch cannot
-      # leave a junk tag behind. deploy.yml cannot cascade from here: its
-      # `workflow_run` trigger is filtered to `branches: [main]`, which matches
-      # workflow_run.head_branch, and its check-prerequisites additionally
-      # requires this run's `Verify Staging` job to have concluded `success`
-      # (it is skipped off main) and the SHA to still be the tip of main.
-      - 'release-please--**'
+    branches: [main]
     # Workflow- or docs-only changes don't alter the built backend/frontend
     # images, so skip the build -> staging -> production pipeline for them and
     # avoid a needless prod redeploy + approval. paths-ignore only skips a push
     # when EVERY changed file matches, so any code change still deploys.
-    #
-    # Confirmed against release commit 3bffb1d7 ("chore(main): release 4.5.1"),
-    # which touches .release-please-manifest.json, CHANGELOG.md,
-    # backend-rust/Cargo.toml, frontend/package.json, package.json and
-    # package-lock.json. Only CHANGELOG.md matches `**.md`; the five others
-    # match nothing here, so a release push is never skipped and the checks
-    # always attach.
     paths-ignore:
       - '**.md'
       - 'docs/**'
@@ -512,14 +478,12 @@ jobs:
           # (deploy-staging, deploy.yml, regression-api, start-app-stack), and
           # it is produced on every event.
           #
-          # The mutable branch tag is scoped to the DEFAULT branch. `push` now
-          # also fires on `release-please--**`, and without this guard each
-          # release PR would mint a permanent
-          # `backend:release-please--branches--main--components--loyalty-app`
-          # tag in GHCR — a mutable tag nothing consumes, silently re-pointed
-          # at a different commit on every release. `main` is unaffected:
-          # is_default_branch is true there, so the `:main` tag is still
-          # published exactly as before.
+          # The mutable branch tag is scoped to the DEFAULT branch. Nothing
+          # consumes a `:<branch>` tag off main, so any other branch that ever
+          # reaches this job would only leave a permanent GHCR tag behind,
+          # silently re-pointed at a different commit each time it built. `main`
+          # is unaffected: is_default_branch is true there, so the `:main` tag
+          # is still published exactly as before.
           tags: |
             type=sha,format=long,prefix=
             type=ref,event=branch,enable={{is_default_branch}}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -2,37 +2,9 @@ name: CI Tests
 
 on:
   push:
-    branches:
-      - main
-      # RELEASE-PLEASE BRANCHES GET THE REAL SUITE, PRE-MERGE.
-      #
-      # release-please opens its release PR using GITHUB_TOKEN, and GitHub does
-      # not raise `pull_request` workflow runs for bot-token events
-      # (anti-recursion). Result: PRs #350/#358/#362/#367/#372 all reached
-      # `main` with ZERO check runs on their head commit — and merging a
-      # release PR is precisely what triggers the UNATTENDED production
-      # deploy. The one PR class that ships to prod was the one class nobody
-      # verified first. (It is also the entire "26 of 30" shortfall behind
-      # OpenSSF Scorecard alerts #92 SAST and #925 CI-Tests.)
-      #
-      # The fix is to run the GENUINE gate on the branch itself, so real
-      # checks attach to the head commit before merge. Deliberately NOT a PAT,
-      # a GitHub App token, or a token-only workflow whose sole product is a
-      # green check — that would be metric-gaming, not verification.
-      #
-      # Glob, not the literal branch name: release-please builds the branch as
-      # `release-please--branches--<target>--components--<component>`, and the
-      # `<target>`/`<component>` halves move whenever
-      # release-please-config.json changes (adding a package, renaming the
-      # component, or targeting a maintenance branch). Only the
-      # `release-please--` prefix is fixed by the action's branch-name builder,
-      # so anchoring there is what survives a config edit. `**` also spans `/`,
-      # covering a future `separator` change.
-      - 'release-please--**'
+    branches: [main]
     # See ci-build-e2e.yml: skip workflow/docs-only pushes so a CI-config or
     # documentation change doesn't spin up the deploy-gating test pipeline.
-    # A release commit always touches .release-please-manifest.json and the
-    # three version files, so it can never be skipped by this list.
     paths-ignore:
       - '**.md'
       - 'docs/**'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,18 +196,29 @@ failure and **closed automatically on recovery**, which is also what clears
 `LAST-FAILURE`. Setup, token rotation and the alert drill:
 [`docs/restore-runbook.md`](docs/restore-runbook.md).
 
-**Release-please branches run the full suite before merge.** `ci-test.yml`
-and `ci-build-e2e.yml` also trigger on `push` to `release-please--**`.
-release-please opens its PR with `GITHUB_TOKEN`, and GitHub raises no
-`pull_request` workflow run for bot-token events — so release PRs used to
-merge with *zero* checks on their head commit, and merging one is exactly
-what fires the unattended production deploy. The deploy-triggering PR class
-must not be the unverified one. Only the build/test half runs there: every
-mutating job (`promote-latest`, `deploy-staging`, `verify-staging`, the
-notifiers) is gated on `github.ref == 'refs/heads/main'`, and `deploy.yml`'s
-`workflow_run` trigger is filtered to `branches: [main]`, so a release-branch
-run cannot reach staging or production. Cost: one extra full pipeline each
-time release-please updates the release branch.
+**Release-please PRs currently merge without checks — this is a known,
+unfixed gap.** `release-please.yml` authors its release PR as
+`github-actions[bot]` using `GITHUB_TOKEN`, and GitHub treats
+`GITHUB_TOKEN`-driven events specially in two different ways:
+
+- **`push`** — no workflow run is created *at all* (the long-standing
+  anti-recursion rule). Adding `release-please--**` to a workflow's `push:
+  branches:` list therefore does nothing; that was tried in #377 and reverted
+  once release PR #378 confirmed zero `push` runs on the release branch.
+- **`pull_request`** — since 2026-06-11 a run *is* created, but parked in an
+  approval-required state (`action_required`). It never starts unless a
+  maintainer approves it in the Actions UI.
+
+Net position today: a release PR's head commit carries **no completed
+checks** unless someone manually approves its parked runs, and merging that
+PR is exactly what fires the unattended production deploy. This shortfall is
+what OpenSSF Scorecard alerts #92 (SAST) and #925 (CI-Tests) measure.
+
+Planned fix (**not yet implemented**): have `release-please.yml` mint a
+GitHub App installation token and pass it to the action, so the release PR is
+authored by an App identity rather than `GITHUB_TOKEN` and its CI runs are
+created and started like any other PR's. Until that lands, treat a release PR
+as unverified: check the checks before merging one.
 
 Production deploys live in `deploy.yml` and are **unattended** — the
 `production` environment no longer has a required reviewer, so a green

--- a/docs/workflow-review-2026-07.md
+++ b/docs/workflow-review-2026-07.md
@@ -56,7 +56,7 @@
 | 49 | low | correctness | `codeql.yml:28` | `cancel-in-progress: true` on a shared main/schedule concurrency group evicts main-branch and weekly analyses |
 | 50 | low | maintainability | `backup-production.yml:187` | Run summary prints a literal `${BACKUP_S3_BUCKET}` and silently reports empty fields on failure |
 | 51 | low | redundancy | `ci-test.yml:112` | Four overlapping dependency-CVE mechanisms with three different cadences and only one that pages anyone |
-| 52 | high | correctness | `ci-test.yml:4`, `ci-build-e2e.yml:4` | Release-please PRs carry zero check runs, so the only PR class that triggers a production deploy is the one class nothing verifies |
+| 52 | high | correctness | `release-please.yml:57` | Release-please PRs carry no completed check runs, so the only PR class that triggers a production deploy is the one class nothing verifies — **still open**, #377's `push:`-trigger fix was inert and has been reverted |
 
 ## HIGH severity
 
@@ -518,19 +518,20 @@ The same class of finding is produced by: `npm audit --audit-level=moderate` wit
 
 ## Addendum — found after the original review
 
-### 52. Release-please PRs carry zero check runs, so the only PR class that triggers a production deploy is the one class nothing verifies
+### 52. Release-please PRs carry no completed check runs, so the only PR class that triggers a production deploy is the one class nothing verifies
 
-**`ci-test.yml:4`, `ci-build-e2e.yml:4`** · correctness · high
+**`release-please.yml:57`** · correctness · high · **STILL OPEN**
 
-Both gating workflows triggered on `push: branches: [main]` and
+Both gating workflows trigger on `push: branches: [main]` and
 `pull_request: branches: [main]`. The release PR targets `main`, so on paper
-the `pull_request` trigger covers it. It does not: release-please opens and
-force-updates the PR using `GITHUB_TOKEN`, and GitHub deliberately raises no
-workflow run for events created by that token (anti-recursion). The head
-commit of every release PR therefore has **no check runs at all** — confirmed
-for #350, #358, #362, #367 and #372, all authored by `app/github-actions` on
-branch `release-please--branches--main--components--loyalty-app`, with runs
-observed sitting in `action_required` and never starting.
+the `pull_request` trigger covers it. In practice it does not produce checks:
+release-please opens and force-updates the PR using `GITHUB_TOKEN`, and
+GitHub does not let a `GITHUB_TOKEN`-driven event start a workflow run. The
+head commit of every release PR therefore reaches `main` with **no completed
+check runs** — observed for #350, #358, #362, #367, #372 and #378, all
+authored by `app/github-actions` on branch
+`release-please--branches--main--components--loyalty-app`, with runs sitting
+in `action_required` and never starting on their own.
 
 Consequence: merging a release PR is precisely what puts a new version on
 `main`, which fires CI Build & Deploy → staging → the now-**unattended**
@@ -539,34 +540,60 @@ class that ships to production is the single PR class that arrives unverified.
 It is also the entire shortfall behind OpenSSF Scorecard alerts #92 (SAST,
 medium) and #925 (CI-Tests, low), both stuck at "26 of 30".
 
-**Fix (applied):** add `release-please--**` to the `push: branches:` list of
-`ci-test.yml` and `ci-build-e2e.yml`, so the *genuine* suite runs on the
-release branch and real checks attach to the head commit before merge.
-Explicitly **not** a PAT or GitHub App token, and explicitly not a workflow
-whose only product is a green check — that inflates the Scorecard number
-without verifying anything.
+**Attempted fix (#377) — REVERTED, it did not work.** #377 added
+`release-please--**` to the `push: branches:` list of `ci-test.yml` and
+`ci-build-e2e.yml`, on the theory that the `push` trigger would fire where
+`pull_request` did not. The residual risk it flagged for itself is exactly
+what happened.
 
-Deploy safety, the whole risk of the change: every mutating job in
-`ci-build-e2e.yml` was already gated on
-`github.ref == 'refs/heads/main' && github.event_name == 'push'` —
-`promote-latest`, `wait-for-frontend-checks`, `deploy-staging`,
-`verify-staging`, `notify-verify-staging-failure` — so no new guard was
-needed for any of them. The one unguarded writer is `build-and-push`, which
-already pushes a commit-SHA image on every `pull_request`; its mutable
-`type=ref,event=branch` tag was scoped to `enable={{is_default_branch}}` so a
-release branch cannot mint a permanent junk tag in GHCR. `deploy.yml` cannot
-cascade: its `workflow_run` trigger is filtered `branches: [main]` (matched
-against `workflow_run.head_branch`), and `check-prerequisites` independently
-requires the triggering run's `Verify Staging` job to have concluded
-`success` — it is skipped off `main` — plus the SHA to still be the tip of
-`main`. `trivy.yml`'s image scans and `e2e.yml` are likewise
-`workflow_run … branches: [main]`, so neither fires on a release branch.
+Empirical result, measured on release PR #378 (`chore(main): release 4.5.2`,
+head `264f49dd`). The test was valid: `264f49dd`'s parent is `dbe23ea5` —
+#377's own merge commit — so the release branch was cut *from* #377, and
+`.github/workflows/ci-test.yml` **at `264f49dd` itself** carries the
+`release-please--**` entry. (This matters because a push to a non-default
+branch is evaluated against the workflow file on *that* branch, not the one
+on `main`.) release-please pushed that commit to the branch at
+`2026-07-27T21:53:43Z`. What the push produced:
 
-Residual risk, stated honestly: GitHub's anti-recursion rule suppresses
-workflow runs for *all* `GITHUB_TOKEN`-triggered events, and release-please
-pushes the release branch with that same token. If `push` is suppressed the
-same way `pull_request` is, checks still will not attach and this fix is
-inert (harmless, but inert). It can only be settled empirically at the next
-release. What to look for: check runs present on the release PR's head
-commit, and **no** `Deploy to Staging` / `Verify Staging` / `Promote latest
-tag` / notifier job having run.
+| | |
+| --- | --- |
+| Workflow runs on branch `release-please--branches--main--components--loyalty-app` | 44 |
+| …with `event == "pull_request"` | 44 |
+| …with `event == "push"` | **0** |
+
+The trigger was in place, on the right branch, on the right commit, and
+created nothing. #377 was inert and has been reverted (the `push: branches:`
+list is back to `[main]` in both workflows).
+
+**The two `GITHUB_TOKEN` behaviours are different, and that is the whole
+lesson.** GitHub's anti-recursion rule is not one rule:
+
+- **`push` from `GITHUB_TOKEN` → no workflow run is created at all.** There
+  is nothing to approve and nothing to see. This is why #377 was inert.
+- **`pull_request` from `GITHUB_TOKEN` → a run *is* created**, but parked in
+  an approval-required state (`status: completed`, `conclusion:
+  action_required`) and never started. This behaviour arrived 2026-06-11; it
+  is why the earlier release PRs show parked runs rather than no runs.
+
+#378's own five `pull_request` runs demonstrate the parked path end to end:
+all five were `created_at 2026-07-27T21:53:47Z` and sat unstarted until
+`run_started_at 22:00:36Z` as `run_attempt: 2` with `triggering_actor:
+jwinut` — i.e. they only ran because a human clicked approve in the Actions
+UI. Absent that click, the head commit merges with no completed checks.
+
+**Kept from #377:** the `enable={{is_default_branch}}` scoping on both
+`type=ref,event=branch` tags in `build-and-push`'s `docker/metadata-action`
+steps. It is correct independently of the trigger — nothing consumes a
+mutable `:<branch>` GHCR tag off `main`, every automated consumer
+(`deploy-staging`, `deploy.yml`, `regression-api`, `start-app-stack`) reads
+the immutable commit-SHA tag, and `pull_request` events already reach this
+job. `main` is unaffected: `is_default_branch` is true there, so `:main` is
+published exactly as before.
+
+**Real fix (not yet implemented):** have `release-please.yml` mint a GitHub
+App installation token and pass it to `googleapis/release-please-action` via
+`token:`. An App identity is not `GITHUB_TOKEN`, so its `pull_request` events
+create runs that start normally, and the release PR gets checks like any
+other PR. Until that lands the honest statement of the position is: **release
+PRs carry no completed checks unless a maintainer manually approves their
+parked runs**, and that is what Scorecard #92 / #925 are measuring.


### PR DESCRIPTION
## This reverts a change that did not work

PR #377 (`dbe23ea5`) added `release-please--**` to the `push: branches:` list of
`ci-test.yml` and `ci-build-e2e.yml`, on the theory that the `push` trigger would
fire where `pull_request` did not, so release PRs would finally carry real checks
before merge. #377 flagged this as its own residual risk. The risk landed: **the
trigger is inert.** This PR removes it and — more importantly — corrects the docs
that were left asserting CI coverage this repo does not have.

## The evidence

Release PR #378 (`chore(main): release 4.5.2`, head `264f49dd`) was the first
release cut *after* #377 merged. The test was clean:

- `264f49dd`'s parent is `dbe23ea5` — #377's own merge commit — so the release
  branch was cut from #377, and `.github/workflows/ci-test.yml` **at `264f49dd`
  itself** contains the `release-please--**` entry. This matters: a push to a
  non-default branch is evaluated against the workflow file on *that branch*,
  not the one on `main`. So the trigger was genuinely in force.
- release-please pushed `264f49dd` to the branch at `2026-07-27T21:53:43Z`.

What that push produced, on branch
`release-please--branches--main--components--loyalty-app`:

| | |
| --- | --- |
| Total workflow runs | 44 |
| …with `event == "pull_request"` | 44 |
| …with `event == "push"` | **0** |

Right trigger, right branch, right commit — zero runs.

## Two different `GITHUB_TOKEN` behaviours (this is what #377 conflated)

GitHub's anti-recursion rule is not one rule, and the difference is exactly why
#377 looked plausible and still failed:

- **`push` from `GITHUB_TOKEN` → no workflow run is created at all.** Nothing is
  queued, nothing is parked, nothing appears in the Actions tab. Adding branches
  to a `push:` trigger cannot help, because the event never becomes a run.
- **`pull_request` from `GITHUB_TOKEN` → a run *is* created**, but parked in an
  approval-required state (`status: completed`, `conclusion: action_required`)
  and never started. This behaviour arrived 2026-06-11, which is why release PRs
  show *parked* runs rather than *no* runs.

#378 demonstrates the parked path end to end: its five `pull_request` runs were
all `created_at 2026-07-27T21:53:47Z`, sat unstarted, and only began at
`run_started_at 22:00:36Z` as `run_attempt: 2` with `triggering_actor: jwinut` —
i.e. a human clicked approve in the Actions UI. Absent that click the head commit
merges with no completed checks.

## What this PR actually fixes

The workflow revert is the small half. The real defect is that `CLAUDE.md` and
`docs/workflow-review-2026-07.md` were left claiming release branches get the
full suite pre-merge. That claim is false, and a false claim about a gate is
worse than a known gap. Both documents now state the current true position:

> A release PR's head commit carries no completed checks unless a maintainer
> manually approves its parked runs — and merging that PR is exactly what fires
> the unattended production deploy. This is what OpenSSF Scorecard alerts #92
> (SAST) and #925 (CI-Tests) measure.

Finding 52 in the review doc is re-marked **STILL OPEN** and re-pointed from
`ci-test.yml:4` / `ci-build-e2e.yml:4` to `release-please.yml:57`, which is where
a fix would actually go.

## The real fix is a follow-up — it is NOT in this PR

Have `release-please.yml` mint a **GitHub App installation token** and pass it to
`googleapis/release-please-action` via `token:`. An App identity is not
`GITHUB_TOKEN`, so its `pull_request` events create runs that start normally and
the release PR gets checks like any other PR. **This PR does not implement that**,
and both documents say so explicitly rather than describing it as done.

## Kept from #377

The `enable={{is_default_branch}}` scoping on both `type=ref,event=branch`
`docker/metadata-action` tags in `build-and-push` is **retained unchanged**. It is
correct independently of the trigger: nothing consumes a mutable `:<branch>` GHCR
tag off `main`, every automated consumer (`deploy-staging`, `deploy.yml`,
`regression-api`, `start-app-stack`) reads the immutable commit-SHA tag, and
`pull_request` events already reach that job. `main` is unaffected —
`is_default_branch` is true there, so `:main` publishes exactly as before.

Net shape of the diff against pre-#377:

- `ci-test.yml` — **byte-identical** to its pre-#377 state.
- `ci-build-e2e.yml` — differs from pre-#377 **only** by the two
  `enable={{is_default_branch}}` additions and their comments.

The one comment I did rewrite is the metadata-action rationale, which justified
the scoping by "push now also fires on `release-please--**`". That premise is
gone, so the comment now states the branch-tag reasoning on its own terms.

## Verification

- **actionlint** on both workflows: **12 findings before, 12 after, identical
  set** (line numbers normalized) — all pre-existing shellcheck `info`/`style`
  in `ci-build-e2e.yml`. No new findings.
- **`yaml.safe_load`** parses both files.
- **`push.branches == ['main']`** asserted in each.
- `type=ref,event=branch,enable={{is_default_branch}}` present **2×**; zero
  unscoped `type=ref,event=branch` remain.
- `grep -rn 'release-please--\*\*' .github/` → no matches.
- Repo-wide grep for `release-please` / "release branch" / "release PR" across
  `docs/`, `CLAUDE.md`, `.github/` → no other stale coverage claims.
  `CHANGELOG.md` is left alone: it is a release-please-generated record of what
  was committed at the time, not a live assertion.

No local build was run (disk-constrained laptop); CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU
