### PR TITLE
fix(ci): author release PRs with the hf-release-bot App so CI runs on them

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,6 +27,58 @@ name: Release Please
 # version instead re-syncs from Cargo.toml on the next cargo invocation, and
 # nothing in CI builds with `--locked`, so a temporarily stale entry there is
 # cosmetic. Committed in sync here.
+#
+# =============================================================================
+# WHY THIS JOB AUTHENTICATES AS A GITHUB APP AND NOT AS GITHUB_TOKEN
+#
+# Release PRs used to arrive with ZERO check runs on their head commit, and
+# merging a release PR is exactly what fires the UNATTENDED production deploy.
+# The one PR class that ships to production was the one class nothing verified.
+# That is the whole of OpenSSF Scorecard alerts #92 (SAST) and #925 (CI-Tests).
+#
+# Two separate GitHub behaviours produced it, both keyed on the *token that
+# authored the event*, and neither has an opt-out setting:
+#
+#   1. `pull_request` runs for PRs authored by `github-actions[bot]` are PARKED
+#      in an approval-required state (`action_required`) — a rule GitHub
+#      introduced 2026-06-11. They never start unless a human clicks approve.
+#   2. `push` events made with GITHUB_TOKEN raise NO workflow run at all
+#      (the long-standing anti-recursion rule).
+#
+# Adding `release-please--**` to the `push:` triggers of ci-test.yml /
+# ci-build-e2e.yml was an earlier attempt at this (#377) and was inert for
+# reason (2): the branch push carries the same GITHUB_TOKEN, so no run is
+# created. Release PR #378 confirmed it — 44 runs on the release branch, all
+# 44 `pull_request`, ZERO `push` — and #379 reverted the trigger. Do not
+# re-add it; the author identity, not the trigger list, is what was wrong.
+#
+# GitHub's documented fix is to author the PR with a **GitHub App installation
+# token**. Events created by an App installation are ordinary events: they
+# raise `pull_request` runs that start immediately, and they raise `push` runs.
+# So the release PR now gets checks on its head commit like any other PR.
+#
+# The App is `hf-release-bot` (app_id in `vars.RELEASE_BOT_APP_ID`, private key
+# in `secrets.RELEASE_BOT_PRIVATE_KEY`), installed on the `thehfhotel` org with
+# repository_selection=selected — this repository only — and holding exactly
+# three permissions: contents=write, pull_requests=write, metadata=read. It has
+# NO `actions` permission, so it cannot approve, cancel or re-run workflows,
+# and NO `administration`, so it cannot touch settings or branch protection.
+#
+# FAIL LOUDLY, NEVER FALL BACK. If the token cannot be minted — key rotated,
+# secret deleted, App uninstalled — this job MUST go red. There is deliberately
+# no `|| github.token` anywhere below: a fallback would silently restore the
+# parked-runs problem while the workflow reported green, which is precisely the
+# failure mode this change exists to remove. The guard step below therefore
+# checks both settings are non-empty BEFORE minting (an empty
+# `vars.RELEASE_BOT_APP_ID` otherwise surfaces as an opaque 401 from the API),
+# and a second step asserts a non-empty token actually came back.
+#
+# Operational dependency, stated plainly: this workflow now depends on an App
+# that a human can delete or whose key a human can rotate. If it breaks, the
+# symptom is "Release Please" failing on `main` with one of the two guard
+# errors and no release PR appearing. The fix is to re-add the credential —
+# see docs/secrets-runbook.md → "Release-bot App".
+# =============================================================================
 
 on:
   push:
@@ -48,13 +100,88 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      # Create/update the release PR branch, and tag + publish on merge.
+      # NOTE — these two are now REDUNDANT and are deliberately left unchanged
+      # rather than silently narrowed in the same PR that switches the auth.
+      #
+      # They scope GITHUB_TOKEN, and after this change nothing in this job uses
+      # GITHUB_TOKEN: release-please receives the App installation token via its
+      # `token:` input (below) and makes every API call with it, and
+      # create-github-app-token authenticates with the private key, not with
+      # GITHUB_TOKEN. Narrowing both to `contents: read` is the correct
+      # follow-up, but it should land only once a real release has been
+      # observed running end-to-end on the App token — so that if something
+      # does go wrong, the failure is the loud guard below and not a confusing
+      # 403 from a permission that was tightened at the same time.
+      #
+      # This is NOT a widening: it is the exact permission set the job already
+      # had before the App token existed.
       contents: write
       pull-requests: write
 
     steps:
+      # -----------------------------------------------------------------------
+      # A missing credential must be a red run with a readable message, never a
+      # quiet fallback to GITHUB_TOKEN. `vars.*` and `secrets.*` that do not
+      # exist expand to EMPTY STRINGS with no error, so nothing below would
+      # notice on its own: create-github-app-token would just report a 401 that
+      # reads like an App/permissions problem rather than "the secret is gone".
+      # -----------------------------------------------------------------------
+      - name: Guard — hf-release-bot App credentials must be visible to this job
+        env:
+          RELEASE_BOT_APP_ID: ${{ vars.RELEASE_BOT_APP_ID }}
+          RELEASE_BOT_PRIVATE_KEY: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          missing=""
+          [ -n "${RELEASE_BOT_APP_ID:-}" ] || missing="${missing} vars.RELEASE_BOT_APP_ID (Settings -> Secrets and variables -> Actions -> Variables)"
+          [ -n "${RELEASE_BOT_PRIVATE_KEY:-}" ] || missing="${missing} secrets.RELEASE_BOT_PRIVATE_KEY (Settings -> Secrets and variables -> Actions -> Secrets)"
+
+          if [ -n "$missing" ]; then
+            echo "::error title=Release Please cannot authenticate::Empty release-bot setting(s):${missing}. These belong to the 'hf-release-bot' GitHub App, which must stay installed on thehfhotel/loyalty-app with contents=write, pull_requests=write, metadata=read. This job DOES NOT fall back to GITHUB_TOKEN on purpose: a release PR authored by github-actions[bot] gets its pull_request runs PARKED in action_required and gets no push runs at all, so it would merge to main with zero checks and fire the unattended production deploy unverified. Restore the credential (docs/secrets-runbook.md -> 'Release-bot App') and re-run; do not work around this by removing the token: input."
+            exit 1
+          fi
+          echo "vars.RELEASE_BOT_APP_ID and secrets.RELEASE_BOT_PRIVATE_KEY are both non-empty."
+
+      - name: Mint hf-release-bot installation token
+        id: app-token
+        # `app-id` is soft-deprecated upstream in favour of `client-id`; both
+        # are accepted at v3.2.0 and app-id only emits a deprecation notice.
+        # Switch to client-id when the App's client ID is recorded as a repo
+        # variable — that is a rename, not a behaviour change.
+        #
+        # `owner`/`repositories` are intentionally omitted: the action then
+        # scopes the token to THIS repository, which is the narrowest option
+        # and matches the App's repository_selection=selected installation.
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
+      # Belt and braces. The mint step above fails on an API error by itself,
+      # so this mainly defends the invariant against a future edit that adds a
+      # `continue-on-error:` or an `|| github.token` fallback: an empty token
+      # reaching release-please would make it fall back to the ambient
+      # GITHUB_TOKEN and quietly re-create the parked-runs bug, green.
+      - name: Assert an installation token was actually minted
+        env:
+          # Via env, never inlined as ${{ }} into the script body — repo rule:
+          # no expression interpolation inside `run:`.
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          APP_INSTALLATION_ID: ${{ steps.app-token.outputs.installation-id }}
+        run: |
+          set -euo pipefail
+          if [ -z "${APP_TOKEN:-}" ]; then
+            echo "::error title=Release Please got an empty App token::actions/create-github-app-token produced no token, so release-please would silently fall back to GITHUB_TOKEN and open a release PR that CI refuses to run (parked in action_required). Check the 'hf-release-bot' App is still installed on thehfhotel/loyalty-app and that secrets.RELEASE_BOT_PRIVATE_KEY matches a key that has not been deleted in the App settings. See docs/secrets-runbook.md -> 'Release-bot App'."
+            exit 1
+          fi
+          echo "Installation token minted for app-slug '${APP_SLUG}' (installation ${APP_INSTALLATION_ID})."
+
       - name: Run release-please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
+          # The App token, NOT github.token (which is this input's default).
+          # This is the single line that makes release PRs runnable by CI.
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,29 +196,47 @@ failure and **closed automatically on recovery**, which is also what clears
 `LAST-FAILURE`. Setup, token rotation and the alert drill:
 [`docs/restore-runbook.md`](docs/restore-runbook.md).
 
-**Release-please PRs currently merge without checks — this is a known,
-unfixed gap.** `release-please.yml` authors its release PR as
-`github-actions[bot]` using `GITHUB_TOKEN`, and GitHub treats
-`GITHUB_TOKEN`-driven events specially in two different ways:
+**Release PRs are authored by a GitHub App, so CI runs on them like any
+other PR.** `release-please.yml` mints an installation token for the
+**`hf-release-bot`** App (`vars.RELEASE_BOT_APP_ID` +
+`secrets.RELEASE_BOT_PRIVATE_KEY`, via `actions/create-github-app-token`)
+and passes it to the release-please action instead of `GITHUB_TOKEN`. The
+release PR is therefore authored by `hf-release-bot[bot]`, its
+`pull_request` runs are created *and start on their own*, and its head
+commit carries real checks before anyone merges it.
+
+Why that was needed: GitHub treats `GITHUB_TOKEN`-driven events specially
+in two different ways, neither with an opt-out setting —
 
 - **`push`** — no workflow run is created *at all* (the long-standing
   anti-recursion rule). Adding `release-please--**` to a workflow's `push:
   branches:` list therefore does nothing; that was tried in #377 and reverted
-  once release PR #378 confirmed zero `push` runs on the release branch.
+  in #379 once release PR #378 confirmed zero `push` runs on the release
+  branch.
 - **`pull_request`** — since 2026-06-11 a run *is* created, but parked in an
   approval-required state (`action_required`). It never starts unless a
   maintainer approves it in the Actions UI.
 
-Net position today: a release PR's head commit carries **no completed
-checks** unless someone manually approves its parked runs, and merging that
-PR is exactly what fires the unattended production deploy. This shortfall is
-what OpenSSF Scorecard alerts #92 (SAST) and #925 (CI-Tests) measure.
+So a release PR's head commit used to carry **no completed checks** unless
+someone manually approved its parked runs — and merging that PR is exactly
+what fires the unattended production deploy, making the one PR class that
+ships to production the one class nothing verified. That shortfall is what
+OpenSSF Scorecard alerts **#92** (SAST) and **#925** (CI-Tests) measure.
+Both score a rolling 30-PR window, so **they do not close on merge**: they
+recover as App-authored release PRs with real checks age into that window.
 
-Planned fix (**not yet implemented**): have `release-please.yml` mint a
-GitHub App installation token and pass it to the action, so the release PR is
-authored by an App identity rather than `GITHUB_TOKEN` and its CI runs are
-created and started like any other PR's. Until that lands, treat a release PR
-as unverified: check the checks before merging one.
+**No silent fallback.** The job asserts `vars.RELEASE_BOT_APP_ID` and
+`secrets.RELEASE_BOT_PRIVATE_KEY` are non-empty before minting, and that a
+non-empty token came back. If the App is uninstalled, the key rotated, or
+the secret deleted, the run **fails loudly** with a message naming both
+settings and no release PR appears — it never falls back to `GITHUB_TOKEN`,
+because a green run that re-parks the checks is the exact failure this
+removes. Recovery: re-add the credential per
+[`docs/secrets-runbook.md`](docs/secrets-runbook.md) → *Release-bot App*.
+The App is installed on this repository only, with exactly
+`contents=write`, `pull_requests=write`, `metadata=read` — notably **no
+`actions`**, so the release bot can cause workflow runs but never approve,
+cancel or re-run one.
 
 Production deploys live in `deploy.yml` and are **unattended** — the
 `production` environment no longer has a required reviewer, so a green

--- a/docs/secrets-runbook.md
+++ b/docs/secrets-runbook.md
@@ -90,6 +90,91 @@ same trap that made the old backup workflow report green while backing up
 nothing. The canary's first step fails loudly on empty values for exactly this
 reason. See [`email-canary-runbook.md`](./email-canary-runbook.md).
 
+### Release-bot App — how release PRs get CI
+
+`.github/workflows/release-please.yml` does **not** authenticate as
+`GITHUB_TOKEN`. It mints a GitHub App installation token and hands that to the
+release-please action, so the release PR is authored by `hf-release-bot[bot]`
+and CI runs on it like any other PR. With `GITHUB_TOKEN`, GitHub parks the
+`pull_request` runs of `github-actions[bot]` PRs in `action_required` and
+raises no run at all for its pushes — release PRs then merged with zero checks
+on their head commit, which is what OpenSSF Scorecard alerts #92 and #925 were
+measuring. Full reasoning:
+[`workflow-review-2026-07.md` §53](./workflow-review-2026-07.md).
+
+| Setting | Kind | Value / contents |
+| --- | --- | --- |
+| `RELEASE_BOT_APP_ID` | repository **variable** (not secret — an App ID is public information) | numeric App ID of `hf-release-bot` |
+| `RELEASE_BOT_PRIVATE_KEY` | repository **secret** | the App's PEM private key, `-----BEGIN RSA PRIVATE KEY-----` … pasted whole, including the header/footer lines and trailing newline |
+
+**The App.** `hf-release-bot`, owned by the `thehfhotel` organisation and
+installed with `repository_selection=selected` — **`thehfhotel/loyalty-app`
+only**, not org-wide. Its permissions are exactly three:
+
+| Permission | Level | Why |
+| --- | --- | --- |
+| `contents` | write | push the `release-please--**` branch, create the `vX.Y.Z` tag and the GitHub release |
+| `pull_requests` | write | open, update and label the release PR |
+| `metadata` | read | mandatory for every App; grants nothing on its own |
+
+Deliberately **absent**: `actions` (so the bot cannot approve, cancel or re-run
+any workflow — it can only cause runs, never bless them), `administration` (no
+settings, no branch protection), `checks`, `issues`, `workflows`. The
+installation token the workflow mints is additionally scoped to this single
+repository (the action defaults to the current repo when `owner`/`repositories`
+are omitted) and is revoked when the job ends.
+
+Because the App holds `contents: write` on this repo, its private key is a
+**production-grade credential**: anyone holding it can push to `main` (subject
+to branch protection) and publish releases. Treat it like the deploy SSH key.
+
+**If it breaks, the workflow goes red — it never falls back.** A deleted
+secret, a rotated-away key or an uninstalled App all produce a failing
+`Release Please` run on `main` with an error naming both settings, and **no
+release PR appears**. That is intentional: a silent fallback to `GITHUB_TOKEN`
+would re-park the checks while reporting green. Recovery is to restore the
+credential below and re-run the workflow (`gh workflow run release-please.yml`)
+— nothing else is needed, release-please is idempotent and simply re-opens or
+re-updates the PR.
+
+#### Rotating `RELEASE_BOT_PRIVATE_KEY`
+
+Zero-downtime, because an App may hold several private keys at once and all of
+them are valid until deleted. Generate first, swap second, delete last.
+
+1. **Generate a new key.** GitHub → organisation `thehfhotel` → Settings →
+   Developer settings → GitHub Apps → `hf-release-bot` → *Private keys* →
+   **Generate a private key**. A `.pem` downloads.
+2. **Replace the secret** with the file, header/footer and all:
+
+   ```bash
+   gh secret set RELEASE_BOT_PRIVATE_KEY < ~/Downloads/hf-release-bot.*.private-key.pem
+   ```
+
+3. **Prove it works before deleting anything:**
+
+   ```bash
+   gh workflow run release-please.yml
+   gh run list --workflow=release-please.yml --limit 1
+   ```
+
+   A green run whose log contains `Installation token minted for app-slug
+   'hf-release-bot'` is the confirmation.
+4. **Delete the old key** in the same *Private keys* panel. Skipping this step
+   is the actual risk — an un-deleted old key stays valid forever.
+5. **Shred the download.** `rm -P ~/Downloads/hf-release-bot.*.pem`. Never
+   commit it, never paste it into an issue or a chat.
+
+`RELEASE_BOT_APP_ID` only changes if the App itself is recreated; read the new
+value off the App's settings page and `gh variable set RELEASE_BOT_APP_ID
+--body <id>`. If the App is ever reinstalled, keep
+`repository_selection=selected` and the same three permissions — adding
+`actions` would let the release bot approve its own workflow runs, which
+defeats the point.
+
+Suggested cadence: **annually**, and **immediately** if the `.pem` was ever
+downloaded to a shared machine, committed, or pasted anywhere.
+
 ### Inspecting and updating secrets
 
 ```bash
@@ -207,6 +292,8 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 - JWT-family secrets: **every 90 days**
 - OAuth credentials: when the provider requires, or **annually**
 - API keys: **every 180 days**
+- `RELEASE_BOT_PRIVATE_KEY` (GitHub App): **annually** — different procedure,
+  see [Release-bot App](#release-bot-app--how-release-prs-get-ci)
 - After any security incident: **immediately**
 
 ### Impact on active sessions

--- a/docs/workflow-review-2026-07.md
+++ b/docs/workflow-review-2026-07.md
@@ -590,10 +590,100 @@ the immutable commit-SHA tag, and `pull_request` events already reach this
 job. `main` is unaffected: `is_default_branch` is true there, so `:main` is
 published exactly as before.
 
-**Real fix (not yet implemented):** have `release-please.yml` mint a GitHub
-App installation token and pass it to `googleapis/release-please-action` via
-`token:`. An App identity is not `GITHUB_TOKEN`, so its `pull_request` events
-create runs that start normally, and the release PR gets checks like any
-other PR. Until that lands the honest statement of the position is: **release
-PRs carry no completed checks unless a maintainer manually approves their
-parked runs**, and that is what Scorecard #92 / #925 are measuring.
+**Real fix:** have `release-please.yml` mint a GitHub App installation token
+and pass it to `googleapis/release-please-action` via `token:`. An App
+identity is not `GITHUB_TOKEN`, so its `pull_request` events create runs that
+start normally, and the release PR gets checks like any other PR. That is
+finding 53 below, and it is now implemented.
+
+### 53. Release PRs are now authored by a GitHub App, so their CI runs start on their own
+
+**`release-please.yml:57`** · correctness · high
+
+Finding 52 established the position and #379 corrected the docs to state it
+honestly: a release PR's head commit carries **no completed checks** unless a
+maintainer hand-approves its parked runs, and merging that PR is exactly what
+fires the unattended production deploy. #379 also named the real fix and was
+explicit that it was *not yet implemented*. This is that fix.
+
+`release-please.yml` now mints a **GitHub App installation token** with
+`actions/create-github-app-token` (pinned
+`bcd2ba49218906704ab6c1aa796996da409d3eb1`, v3.2.0) and passes it to
+`googleapis/release-please-action` through its `token:` input, replacing the
+input's implicit `${{ github.token }}` default. Events created by an App
+installation are ordinary events — they are not subject to either
+`GITHUB_TOKEN` rule — so the release PR is authored by `hf-release-bot[bot]`
+and its `pull_request` runs are created *and start on their own*.
+
+Note this is not in tension with finding 52's "explicitly **not** a PAT or
+GitHub App token". That sentence rejected a *token-only workflow whose only
+product is a green check* — metric-gaming. Nothing about the suite changes
+here; only the author identity does, which is the single thing that stops
+GitHub parking it.
+
+**The App.** `hf-release-bot`, installed on the `thehfhotel` org with
+`repository_selection=selected` — `thehfhotel/loyalty-app` only — holding
+exactly `contents=write` (push the release branch, tag, publish the release),
+`pull_requests=write` (open/update/label the PR) and `metadata=read`
+(mandatory, grants nothing). Deliberately **no `actions`** permission, so the
+release bot can *cause* workflow runs but can never approve, cancel or re-run
+one; and no `administration`, so it cannot touch settings or branch
+protection. The minted token is additionally scoped to this single repository
+and is revoked when the job ends. Credentials are `vars.RELEASE_BOT_APP_ID`
+and `secrets.RELEASE_BOT_PRIVATE_KEY`; inventory and rotation live in
+[`secrets-runbook.md` → Release-bot App](./secrets-runbook.md#release-bot-app--how-release-prs-get-ci).
+
+**Fails loudly, never falls back.** This is the load-bearing property. A guard
+step asserts both settings are non-empty *before* minting — absent ones expand
+to empty strings with no error, and an empty app-id otherwise surfaces as an
+opaque 401 that reads like an App problem rather than "the secret is gone" —
+and a second step asserts a non-empty token came back. There is no
+`|| github.token` anywhere in the file. A fallback would restore the
+parked-runs bug *while the workflow reported green*, which is precisely the
+failure mode this change exists to remove. The guard's error text mirrors the
+SMTP guard in `email-canary.yml`.
+
+**Permissions left alone, on purpose.** The job's `contents: write` /
+`pull-requests: write` scope `GITHUB_TOKEN`, which nothing in the job now uses
+— release-please makes every API call with the App token, and
+`create-github-app-token` authenticates with the private key. They are
+therefore *redundant, not wrong*, and this is not a widening: it is the exact
+set the job already had. Narrowing both to `contents: read` is the correct
+follow-up, but it belongs in a separate PR after a real release has been
+observed on the App token, so a tightened permission cannot mask the guard
+with a confusing 403.
+
+**Scorecard, stated accurately.** #92 (SAST, medium) and #925 (CI-Tests, low)
+sat at "26 of 30" precisely because the most recent release PRs had no checks.
+Both score a rolling window of the last 30 PRs, so **they do not close when
+this merges** — they recover as App-authored release PRs with real checks age
+into that window. Expect the ratio to climb over the next several releases.
+
+**Not provable until the next release.** Nothing offline can prove the token
+mints, that the PR is authored by `hf-release-bot[bot]`, or that its checks
+start unattended. What was verified before merge: `actionlint` clean on the
+file, `yaml.safe_load` parses it, `gh api
+repos/actions/create-github-app-token/git/ref/tags/v3.2.0` resolves to exactly
+the pinned SHA, and no `GITHUB_TOKEN`/`github.token` remains wired into any
+step input. It is settled empirically the first time `Release Please` runs on
+`main` afterwards. What to look for:
+
+1. The `Release Please` run on `main` is green and its log shows
+   *"Installation token minted for app-slug 'hf-release-bot'"*.
+2. The release PR's author is `hf-release-bot[bot]`, not `github-actions[bot]`.
+3. `gh pr checks <n>` on that PR lists **running/completed** checks with
+   `run_attempt: 1` and no `triggering_actor` who is a human — nothing sitting
+   in `action_required`.
+4. **No** `Deploy to Staging` / `Verify Staging` / `Promote latest tag` /
+   notifier job ran off `main` (they are all gated on
+   `github.ref == 'refs/heads/main'`; `deploy.yml`'s `workflow_run` is
+   filtered to `branches: [main]`).
+
+**Failure signature and rollback.** If the App is uninstalled or the key
+rotated away, `Release Please` fails on `main` at the guard step with an error
+naming both settings, and **no release PR appears** — that combination is the
+tell. Fix by restoring the credential per the secrets runbook. To back the
+change out entirely, revert this commit: `release-please.yml` returns to a
+single `Run release-please` step with no `token:` input, which restores the
+pre-existing behaviour (release PRs with parked runs needing manual approval)
+rather than breaking releases.


### PR DESCRIPTION
Rebased onto `main` after **#379** landed (which reverted the inert `release-please--**` push trigger and corrected the docs to state the real position). #379 named this change as the fix and was explicit that it was *not yet implemented*. This implements it.

## The problem

A release PR's head commit carries **no completed checks** unless a maintainer hand-approves its parked runs — and merging a release PR is exactly what fires the **unattended production deploy**. The one PR class that ships to production is the one class nothing verifies. That is what OpenSSF Scorecard alerts **#92** (SAST) and **#925** (CI-Tests) measure.

Two distinct `GITHUB_TOKEN` behaviours, neither with an opt-out setting:

| Event on the release branch / PR | With `GITHUB_TOKEN` |
| --- | --- |
| `pull_request` | run created but **parked** in `action_required` — never starts without a human click (rule introduced 2026-06-11) |
| `push` | **no run created at all** (long-standing anti-recursion rule) |

#377 tried to fix this with a `push:` trigger, which is inert for the second reason; #378 proved it (44 runs on the release branch, all 44 `pull_request`, **0** `push`) and #379 reverted it.

## The fix

Author the PR with a **GitHub App installation token**. Events created by an App installation are ordinary events, subject to neither rule — so the release PR is authored by `hf-release-bot[bot]` and its `pull_request` runs are created *and start on their own*.

`release-please.yml` now mints one with `actions/create-github-app-token` (pinned `bcd2ba49218906704ab6c1aa796996da409d3eb1`, **v3.2.0**, matching the repo's `@<sha> # <version>` convention) and passes it via the release-please action's `token:` input, replacing that input's implicit `${{ github.token }}` default.

The App is **`hf-release-bot`** (`vars.RELEASE_BOT_APP_ID` + `secrets.RELEASE_BOT_PRIVATE_KEY`, both already configured), installed on `thehfhotel` with `repository_selection=selected` — this repo only — holding exactly `contents=write`, `pull_requests=write`, `metadata=read`. **No `actions`** permission, so the bot can *cause* workflow runs but can never approve, cancel or re-run one; **no `administration`**, so it cannot touch settings or branch protection. The minted token is scoped to this single repository and revoked when the job ends.

This is not in tension with §52's "explicitly **not** a PAT or GitHub App token" — that rejected a *token-only workflow whose only product is a green check*. The suite that runs is unchanged; only the author identity is, which is the single thing that stops GitHub parking it.

## Fails loudly, never falls back

The load-bearing property, not a nicety. A silent fallback to `GITHUB_TOKEN` would re-create the parked-runs bug *while reporting green* — the precise failure this exists to remove.

- **Guard step** asserts `vars.RELEASE_BOT_APP_ID` and `secrets.RELEASE_BOT_PRIVATE_KEY` are non-empty **before** minting. Both expand to empty strings with no error if absent, and an empty app-id otherwise surfaces as an opaque 401 that reads like an App problem rather than "the secret is gone". Error text mirrors the SMTP guard in `email-canary.yml`.
- **Assertion step** after minting fails on an empty token — defends the invariant against a future edit adding `continue-on-error:` or a fallback expression.
- There is **no `|| github.token`** anywhere in the file.

## Permissions — flagged, not silently changed

The job's `contents: write` / `pull-requests: write` are **left exactly as they were**. They scope `GITHUB_TOKEN`, and nothing in the job now uses `GITHUB_TOKEN` (release-please makes every API call with the App token; `create-github-app-token` authenticates with the private key). They are **redundant, not wrong** — this is not a widening, it is the exact set the job already had.

Narrowing both to `contents: read` is the correct follow-up, deliberately **not** done here: it should land only once a real release has run end-to-end on the App token, so that if something misbehaves the failure is the loud guard rather than a confusing 403 from a permission tightened in the same PR. Reviewer's call if you'd rather do it now.

## What I could NOT verify

Stated plainly: **nothing offline proves the token actually mints**, that the PR is authored by `hf-release-bot[bot]`, or that its checks start unattended. That is settled the first time `Release Please` runs on `main` after this merges. What to look for:

1. The `Release Please` run on `main` is green and logs `Installation token minted for app-slug 'hf-release-bot'`.
2. The release PR's author is `hf-release-bot[bot]`, not `github-actions[bot]`.
3. `gh pr checks <n>` on that PR lists **running/completed** checks at `run_attempt: 1` with no human `triggering_actor` — nothing in `action_required`.
4. **No** `Deploy to Staging` / `Verify Staging` / `Promote latest tag` / notifier job ran off `main`.

What I *did* verify locally: `actionlint` clean on this file, `python3 yaml.safe_load` clean, `gh api repos/actions/create-github-app-token/git/ref/tags/v3.2.0` resolves to exactly the pinned SHA, no `GITHUB_TOKEN`/`github.token` wired into any step input, and no `${{ }}` interpolation inside any `run:` body.

## Scorecard — accurately stated

**#92 and #925 are not claimed closed by this PR.** Both score a rolling window of the last 30 PRs, so they recover as App-authored release PRs with real checks age into that window — expect the ratio to climb over the next several releases, not to flip green on merge.

## Docs

- `CLAUDE.md` — CI/CD section moved from "known, unfixed gap" to the true new position, including the fail-loudly dependency and the App's exact permissions.
- `docs/workflow-review-2026-07.md` — §52's "Real fix (not yet implemented)" updated; new **§53** with the full rationale, the verification checklist above, and the failure signature.
- `docs/secrets-runbook.md` — new *Release-bot App* section: what it is, exact permissions, this-repo-only installation, and the generate → swap → **verify** → **delete the old key** rotation procedure.

## Rollback

`git revert <this commit>` restores `release-please.yml` to a single `Run release-please` step with no `token:` input. That returns the pre-existing behaviour (release PRs with parked runs needing manual approval) — it does not break releases. **Symptom that you need it:** `Release Please` failing on `main` with a token/guard error and **no release PR appearing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhBUo82ufqG3R3Sm7GhZZU
