### PR TITLE
fix(deploy): restart staging containers unless-stopped

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -11,6 +11,12 @@
 services:
   postgres:
     container_name: loyalty_postgres_dev
+    # Staging (unlike this base override's default of "no") must survive an
+    # evergreen daemon/host restart unattended — see the incident on
+    # 2026-08-27 where all five dev containers stayed down after two host
+    # restarts until someone started them by hand. Production already sets
+    # this in docker-compose.prod.yml; mirror it here for staging only.
+    restart: unless-stopped
     ports:
       # Bind to localhost only — backend reaches postgres via the docker network.
       # Host port mapping exists for ad-hoc DBA access from the host (via SSH tunnel).
@@ -29,12 +35,14 @@ services:
 
   redis:
     container_name: loyalty_redis_dev
+    restart: unless-stopped
     ports:
       # Bind to localhost only — backend reaches redis via the docker network.
       - "127.0.0.1:6380:6379"  # Dev port 6380 (prod uses 6379)
 
   backend:
     container_name: loyalty_backend_dev
+    restart: unless-stopped
     environment:
       RUST_ENV: staging
       NODE_ENV: staging
@@ -78,6 +86,7 @@ services:
 
   frontend:
     container_name: loyalty_frontend_dev
+    restart: unless-stopped
     # NOTE: VITE_API_URL is build-time only (baked into the image during docker build).
     # NODE_ENV is not consumed by the alpine nginx serving the built SPA.
     # Neither belongs in runtime env for the GHCR frontend image.
@@ -88,6 +97,7 @@ services:
 
   nginx:
     container_name: loyalty_nginx_dev
+    restart: unless-stopped
     ports:
       - "5001:80"  # Dev port 5001 (prod uses 4001)
     volumes:


### PR DESCRIPTION
## Summary
- The loyalty staging stack (`docker-compose.staging.yml`, containers `loyalty_*_dev` on evergreen) has no `restart` policy, so it defaults to Docker's `no`.
- After an evergreen daemon/host restart, all five dev containers stay down until someone starts them by hand — happened twice on 2026-08-27.
- Production already runs `unless-stopped` (`docker-compose.prod.yml`). This PR mirrors that in the staging override only — `docker-compose.yml` (base) and `docker-compose.prod.yml` are untouched.

## Scope check
Merged staging compose config (`docker-compose.yml` + `docker-compose.ghcr.yml` + `docker-compose.staging.yml`, the exact set `ci-build-e2e.yml`'s `deploy-staging` job ships) now resolves `restart: unless-stopped` for all 5 services (verified locally via a PyYAML deep-merge script — no Docker runtime on this machine). Production compose files are untouched (`git diff --stat` on them is empty).

## Test plan
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"` on all 4 compose files
- [x] Merged-config restart policy checked programmatically (all 5 staging services → `unless-stopped`)
- [ ] CI: Lint Backend/Frontend, backend unit/integration tests, Build & Push, API regression/smoke, Deploy to Staging, Verify Staging health check
- [ ] After merge: confirm on evergreen — `docker inspect loyalty_postgres_dev loyalty_backend_dev --format '{{.Name}} {{.HostConfig.RestartPolicy.Name}} {{.State.Status}}'` → `unless-stopped running`
- [ ] Confirm production containers' `StartedAt` unchanged

Note: this repo's staging deploy fires on every push to `main` (trunk-based; no separate `develop` branch), and `deploy.yml` then ships to production **unattended** once staging passes. Per `CLAUDE.md` hard rule #3, merge is left for explicit human approval rather than done by the agent.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

https://claude.ai/code/session_01F3YHohMAaq3CbhjvQC5YWr